### PR TITLE
'New Category' link moved and renamed.

### DIFF
--- a/app/views/categories/index.html.haml
+++ b/app/views/categories/index.html.haml
@@ -1,5 +1,8 @@
 %h1 Listing categories
 
+%p
+  = link_to 'Add a Category', new_category_path
+
 %table
   %thead
     %tr
@@ -17,7 +20,3 @@
         %td= link_to 'Show', category
         %td= link_to 'Edit', edit_category_path(category)
         %td= link_to 'Destroy', category, :method => :delete, :data => { :confirm => 'Are you sure?' }
-
-%br
-
-= link_to 'New Category', new_category_path


### PR DESCRIPTION
The link has been moved to the top of the pages and renamed 'Add a Category'.