### PR TITLE
Amend categories action links

### DIFF
--- a/app/assets/stylesheets/formfinder.scss
+++ b/app/assets/stylesheets/formfinder.scss
@@ -1,3 +1,7 @@
 #global-header .header-wrapper {
   .sign-out { padding: 0.4em 1em; }
 }
+
+.button-warning{
+  @include button($red);
+}

--- a/app/views/categories/index.html.haml
+++ b/app/views/categories/index.html.haml
@@ -1,5 +1,8 @@
 %h1 Listing categories
 
+%p
+  = link_to 'Add a Category', new_category_path
+
 %table
   %thead
     %tr
@@ -17,7 +20,3 @@
         %td= link_to 'Show', category
         %td= link_to 'Edit', edit_category_path(category)
         %td= link_to 'Destroy', category, :method => :delete, :data => { :confirm => 'Are you sure?' }
-
-%br
-
-= link_to 'New Category', new_category_path

--- a/app/views/categories/index.html.haml
+++ b/app/views/categories/index.html.haml
@@ -1,7 +1,9 @@
-%h1 Listing categories
+%h1 Categories management
 
 %p
-  = link_to 'Add a Category', new_category_path
+  = link_to 'Create a new category', new_category_path, class: 'button'
+
+%h2 Current available categories
 
 %table
   %thead
@@ -10,13 +12,11 @@
       %th Welsh name
       %th
       %th
-      %th
 
   %tbody
     - @categories.each do |category|
       %tr
         %td= category.english_name
         %td= category.welsh_name
-        %td= link_to 'Show', category
-        %td= link_to 'Edit', edit_category_path(category)
-        %td= link_to 'Destroy', category, :method => :delete, :data => { :confirm => 'Are you sure?' }
+        %td= link_to 'Edit', edit_category_path(category), class: 'button'
+        %td= link_to 'Delete', category, :method => :delete, :data => { :confirm => 'Are you sure?' }, class: 'button-warning'


### PR DESCRIPTION
Applied button styling to all action links.  Removed all the ’Show’
actions. Renamed the ’Destroy’ actions to ‘Delete’ and 'Add a Category'
action to 'Create a new category’.