### PR TITLE
Document type dropdown to radio

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,46 +4,45 @@ ruby '2.3.1'
 gem 'aws-sdk', '< 2.0'
 gem 'coffee-rails', '~> 4.1.0'
 gem 'devise', '~>4.1.0'
-gem 'govuk_template',         '~> 0.17.2'
-gem 'govuk_frontend_toolkit', '>= 4.12.0'
-gem 'govuk_elements_rails',   '>= 1.2.0'
-gem 'govuk_elements_form_builder', git: 'https://github.com/ministryofjustice/govuk_elements_form_builder.git'
+gem 'factory_girl_rails', '~> 4.7'
 gem 'gov_uk_date_fields', '>= 1.0.7'
-
+gem 'govuk_elements_form_builder', git: 'https://github.com/ministryofjustice/govuk_elements_form_builder.git'
+gem 'govuk_elements_rails',   '>= 1.2.0'
+gem 'govuk_frontend_toolkit', '>= 4.12.0'
+gem 'govuk_template',         '~> 0.17.2'
 gem 'haml-rails', '~> 0.9.0'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.0'
 gem 'jquery-rails'
+gem 'paper_trail'
 gem 'paperclip', '4.3.6'
 gem 'pg'
-gem 'rails', '4.2.7.1'
 gem 'puma', '~> 3.4'
+gem 'rails', '4.2.7.1'
 gem 'sass-rails', '~> 5.0'
 gem 'susy', '~> 2.2', '>= 2.2.12'
 gem 'turbolinks'
 gem 'uglifier', '>= 1.3.0'
-gem 'paper_trail'
-gem 'factory_girl_rails', '~> 4.7'
-gem 'faker', '~> 1.6'
+
 # Use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development
 
 group :development, :test do
-  gem 'rb-readline'
   gem 'byebug'
+  gem 'faker', '~> 1.6'
   gem 'guard-livereload', '>= 2.5.2'
   gem 'guard-rspec'
   gem 'guard-rubocop'
+  gem 'rb-readline'
   gem 'rspec-rails', '~> 3.0'
 end
 
 group :development do
-  gem 'factory_girl_rails', '~> 4.7'
-  gem 'faker', '~> 1.6'
-  gem 'web-console', '~> 2.0'
   gem 'annotate'
+  gem 'web-console', '~> 2.0'
+
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,7 +101,7 @@ GEM
     factory_girl_rails (4.7.0)
       factory_girl (~> 4.7.0)
       railties (>= 3.0.0)
-    faker (1.6.6)
+    faker (1.7.3)
       i18n (~> 0.5)
     ffi (1.9.14)
     formatador (0.2.5)
@@ -368,4 +368,4 @@ RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.14.2
+   1.14.3

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -13,4 +13,9 @@
 //= require jquery
 //= require jquery_ujs
 //= require turbolinks
+//= require vendor/polyfills/bind
+//= require govuk/selection-buttons
+//= require govuk/shim-links-with-button-role
+//= require govuk/show-hide-content
+//= require details.polyfill
 //= require_tree .

--- a/app/assets/javascripts/formfinder.js
+++ b/app/assets/javascripts/formfinder.js
@@ -1,0 +1,43 @@
+/* global $ */
+/* global jQuery */
+/* global GOVUK */
+
+$(document).ready(function () {
+    // Turn off jQuery animation
+    jQuery.fx.off = true
+
+    // Use GOV.UK selection-buttons.js to set selected
+    // and focused states for block labels
+    var $blockLabels = $(".block-label input[type='radio'], .block-label input[type='checkbox']")
+    new GOVUK.SelectionButtons($blockLabels) // eslint-disable-line
+
+    // Where .block-label uses the data-target attribute
+    // to toggle hidden content
+    var showHideContent = new GOVUK.ShowHideContent()
+    showHideContent.init()
+
+    // Use GOV.UK shim-links-with-button-role.js to trigger a link styled to look like a button,
+    // with role="button" when the space key is pressed.
+    GOVUK.shimLinksWithButtonRole.init()
+
+    // Details/summary polyfill
+    // See /javascripts/vendor/details.polyfill.js
+})
+
+$(window).load(function () {
+    // Only set focus for the error example pages
+    if ($('.js-error-example').length) {
+        // If there is an error summary, set focus to the summary
+        if ($('.error-summary').length) {
+            $('.error-summary').focus()
+            $('.error-summary a').click(function (e) {
+                e.preventDefault()
+                var href = $(this).attr('href')
+                $(href).focus()
+            })
+        } else {
+            // Otherwise, set focus to the field with the error
+            $('.error input:first').focus()
+        }
+    }
+})

--- a/app/views/documents/_form.html.haml
+++ b/app/views/documents/_form.html.haml
@@ -8,8 +8,9 @@
   = f.text_field :title
 
   .form-group
-    = f.label :doc_attachment_type_id, 'Type', class: 'form-label'
-    = collection_select :document, :doc_attachment_type_id, DocAttachmentType.all, :id, :english_name, { include_blank: true }, { class: 'form-control' }
+    %fieldset
+      %legend What type of document is this?
+      = f.collection_radio_buttons(:doc_attachment_type_id, DocAttachmentType.all, :id, :english_name) do |b| b.label(class: "block-label selection-button-radio"){b.radio_button + b.text} end
 
   .form-group
     = f.label :language_id, 'Form language', class: 'form-label'


### PR DESCRIPTION
The add document form 'type' element (http://localhost:3000/documents) has been changed to radio buttons from a dropdown list.