### PR TITLE
Tidy document confirmation

### DIFF
--- a/app/views/documents/confirmation.html.haml
+++ b/app/views/documents/confirmation.html.haml
@@ -1,21 +1,23 @@
 - content_for :page_title do
   = "Confirmation your documents have been submitted to HMCTS Form finder"
 
-.confirmation-header
-  %h1.page-title.bold-large
-    %object{:type => 'image/svg+xml', :data => image_path('icons/tick-white.svg'), :class => "confirmation-tick"}
-    = "Successfully submitted"
+.grid-row
+  .column-full
+    .confirmation-header
 
-  .normal
-    = @document.attachment_file_name
+      %h1.page-title.bold-large
+        %object{:type => 'image/svg+xml', :data => image_path('icons/tick-white.svg'), :class => "confirmation-tick"}
+        = "Successfully submitted"
 
-  .bold-medium
-    = "To be published on"
+      .normal
+        = @document.attachment_file_name
 
-  .bold-large
-    = l @document.published_date
+      .bold-medium
+        = "To be published on"
 
-.button-holder
-  = link_to "Upload more documents", new_document_path, {class: 'button', role: 'button'}
-  = link_to "View your submissions", documents_path, {class: 'button-secondary button-left-spacing', role: 'button'}
-  = link_to "Assign Categories to the Document", link_document_categories_link_path(:document => @document.id ), {class: 'button-secondary button-left-spacing', role: 'button'}
+      .bold-large
+        = l @document.published_date
+
+    .button-holder
+      = link_to "Upload more documents", new_document_path, {class: 'button', role: 'button'}
+      = link_to "Assign Categories to this Document", link_document_categories_link_path(:document => @document.id ), {class: 'button-secondary button-left-spacing', role: 'button'}


### PR DESCRIPTION
Removed the 'view your submissions button' and renamed the 'Categories' button.