### PR TITLE
Fix to seeding documents types

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -27,9 +27,9 @@ csv_text = File.read(Rails.root.join('lib', 'seeds', 'doc_attachment_types.csv')
 csv = CSV.parse(csv_text, :headers => true)
 csv.each do |row|
   t = DocAttachmentType.new
-  t.id = row[0]
-  t.english_name = row[1]
-  t.welsh_name = row[2]
+  t.id = row['id']
+  t.english_name = row['english_name']
+  t.welsh_name = row['welsh_name']
   t.save
 end
 

--- a/lib/seeds/doc_attachment_types.csv
+++ b/lib/seeds/doc_attachment_types.csv
@@ -1,4 +1,5 @@
 english_name,welsh_name
-Form,ffurflenLeaflet,taflen
+Form,ffurflen
+Leaflet,taflen
 Notes,nodiadau
 Guidance,Arweiniad


### PR DESCRIPTION
Amended a typo in the types seed data and replaced hard coded values in the seeds.rb  #DocumentAttachmentType structure.