### PR TITLE
Remove DOCKER_STATE env var

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,6 @@ RUN apt-get install -y nodejs
 ENV APP_HOME /rails
 
 ENV APP_PORT 3000
-ENV DOCKER_STATE=create
 
 EXPOSE $APP_PORT
 


### PR DESCRIPTION
DOCKER_STATE env var is supposed to control the rake tasks during a
deployment, however currently it is baked into the Dockerfile. Presumably
this first happened for running the container locally (on dev laptop),
as with a real environment that env var is always set to none or whatever
the deploy task was.

If the developer really needs this locally then it should be incorporated
as part of an env file or a docker runtime env var instead, as it is
dangerous to have this baked in (eg if someone runs this in production
without passing an --env-file).