### PR TITLE
Add legacy url

### DIFF
--- a/app/assets/stylesheets/formfinder.scss
+++ b/app/assets/stylesheets/formfinder.scss
@@ -1,23 +1,11 @@
 // === Colour definitions ================
-#admin-navigation ul {
-  border-bottom-color: $border-colour;
-}
 
-#admin-navigation ul li.active {
-  background-color: $grey-2;
-}
+#admin-navigation ul { border-bottom-color: $border-colour; }
+#admin-navigation ul li.active { background-color: $grey-2; }
+#admin-navigation ul li a { color: $text-colour; }
+#admin-navigation ul li a:hover { background-color: $grey-3; }
 
-#admin-navigation ul li a {
-  color: $text-colour;
-}
-
-#admin-navigation ul li a:hover {
-  background-color: $grey-3;
-}
-
-.button-warning {
-  @include button($red);
-}
+.button-warning { @include button($red); }
 
 .list li:nth-child(even),
 .un-assigned li:nth-child(even) {
@@ -25,9 +13,7 @@
   border-bottom-color: $panel-colour;
 }
 
-.no-result-message {
-  border-color: $error-colour;
-}
+.no-result-message { border-color: $error-colour; }
 
 .notice-summary {
   background-color: $turquoise;
@@ -42,46 +28,16 @@
 
 // === Class definitions =================
 
-@media (min-width: 641px) {
-  .action {
-    display: inline-block;
-    height: 100%;
-    width: 54px;
-  }
-}
-
-.attributes:after {
-  content: ")";
-}
-
-.attributes:before {
-  content: "(";
-}
-
+.attributes:after { content: ")"; }
+.attributes:before { content: "("; }
 .attributes {
   display: inline;
   font-size: smaller;
 }
 
-@media (min-width: 641px) {
-  .column-two-thirds #search_field {
-    width: 80%;
-  }
-}
+.item { display: block; }
 
-.list li {
-  margin-bottom: 1em;
-}
-
-@media (min-width: 641px) {
-  .list li {
-    height: 100%;
-    margin-bottom: 0;
-    padding: 15px;
-    width: 100%;
-  }
-}
-
+.list li { margin-bottom: 15px; }
 .list li:nth-child(even),
 .un-assigned li:nth-child(even) {
   border-bottom-style: solid;
@@ -97,9 +53,7 @@
   text-align: center;
 }
 
-.notice-summary {
-  text-align: center;
-}
+.notice-summary { text-align: center; }
 
 .reference {
   display: inline;
@@ -107,18 +61,36 @@
   margin-right: 0.4em;
 }
 
-#search_field {
-  margin-bottom: 5px;
-}
-
 .search-wrapper {
   border-bottom-style: solid;
   border-bottom-width: 1px;
   padding: 15px;
+  width: 20em;
 }
 
-.item {
-  display: block;
+@media (min-width: 641px) {
+  .action {
+    display: inline-block;
+    height: 100%;
+    width: 54px;
+  }
+}
+
+@media (min-width: 641px) {
+  .form-control { width: 100%; }
+}
+
+@media (min-width: 641px) {
+  .list li {
+    height: 100%;
+    margin-bottom: 0;
+    padding: 15px;
+    width: 100%;
+  }
+}
+
+@media (min-width: 641px) {
+  #search_field { margin-bottom: 5px; }
 }
 
 @media (min-width: 641px) {
@@ -138,6 +110,7 @@
 }
 
 // === Element definitions ===============
+
 body {
   #global-header .header-wrapper {
     .header-global,
@@ -174,7 +147,7 @@ body {
       }
     }
   }
-  @media screen and (max-width: 568px) {
+  @media screen and (max-width: 640px) {
     #admin-navigation ul {
       li {
         display: block;
@@ -207,23 +180,5 @@ form {
     padding-right: 0;
     text-align: center;
     width: 100%;
-  }
-}
-
-.column-half {
-  .search-wrapper {
-    #search_field {
-      margin-bottom: 0.5em;
-    }
-  }
-}
-
-@media (min-width: 641px) {
-  .column-half {
-    .search-wrapper {
-      #search_field {
-        width: 75%;
-      }
-    }
   }
 }

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -16,6 +16,7 @@
 #  language_id             :integer
 #  original_id             :integer
 #  creator_id              :integer
+#  original_url            :string
 #
 
 class Document < ActiveRecord::Base
@@ -54,13 +55,12 @@ class Document < ActiveRecord::Base
   validates :title, presence: true
   validates :language_id, presence: true
 
-
-
   def rename_file
     extension = File.extname(attachment_file_name).gsub(/^\.+/, '')
     attachment.instance_write(attachment_file_name.gsub(/\.#{extension}$/, ''),
                               "#{self.code}-#{self.language.english_name}.#{extension}")
   end
+
   def all_related
     Document.where("id IN (SELECT DISTINCT documents.id FROM documents, related_documents
     WHERE documents.id = related_documents.linked_document_id
@@ -71,10 +71,8 @@ class Document < ActiveRecord::Base
     AND  related_documents.linked_document_id =  #{self.id})")
   end
 
-
   def self.search(search)
     where("lower(code) LIKE ? or lower(title) LIKE ?", "%#{search.downcase}%","%#{search.downcase}%")
-
   end
 
 end

--- a/app/views/document_categories/link.haml
+++ b/app/views/document_categories/link.haml
@@ -7,12 +7,11 @@
 
   .grid-row
     .column-full
-      %h2.heading-large
-        Step 3 of 4
-      %h3.heading-medium
-        Find the category to assign to this document:
+      %h2.heading-large Step 3 of 4
 
   .grid-row
+    .column-one-third
+      %h3.heading-medium The document
     .column-two-thirds
       %span.reference
         = @document.code
@@ -21,7 +20,12 @@
         format
       .title
         = @document.title
-      %br
+      %hr
+
+  .grid-row
+    .column-one-third
+      %h3.heading-medium Find the category to assign to this document
+    .column-two-thirds
       .search-wrapper
         = form_tag url_for(:controller => 'document_categories', :action => 'links'), :method => 'get', id:'search', class:'search-box', role:'search' do
           = hidden_field_tag 'document', params[:document]
@@ -29,25 +33,19 @@
           = label_tag :'search_field', 'Enter the category name', class:'form-label'
           = text_field_tag :linksearch, params[:linksearch], :id => 'search_field', class:'form-control'
           = submit_tag "Search", :name => nil, role:"button", class:"button"
-    .column-one-third
-
-    -#- if @categories.empty?
-    -#
-    -#      -#%p.no-result-message No categories where found for this search
-    -#      %p
-    -#
+      - if @categories.empty?
+        -#%p.no-result-message No categories where found for this search
+        %p
 
 - else
 
   .grid-row
     .column-full
-
-      %h2.heading-large
-        Step 4 of 4
-      %h3.heading-medium
-        Choose a category to assign to this document
+      %h2.heading-large Step 4 of 4
 
   .grid-row
+    .column-one-third
+      %h3.heading-medium The document
     .column-two-thirds
       %span.reference
         = @document.code
@@ -56,13 +54,16 @@
         format
       .title
         = @document.title
-
       %hr
 
+  .grid-row
+    .column-one-third
+      %h3.heading-medium Choose a category
+    .column-two-thirds
       %p
         Your searched for
-        %i "#{params[:linksearch]}" returned the following results.
-
+        %i "#{params[:linksearch]}"
+        returned the following results:
       %ul.list
         - @categories.each do | doc_attachment |
           %li
@@ -73,23 +74,25 @@
                 Welsh:
                 = doc_attachment.welsh_name
             .action
-              = link_to "Assign", link_document_categories_connect_path(:related_category => doc_attachment.id, :document => params[:document], :document_title => params[:document_title], :linksearch => params[:linksearch]), class:'button', role:'button'
+              = link_to "Assign", link_document_categories_connect_path(:related_category => doc_attachment.id, :document => params[:document], :document_title => params[:document_title], :linksearch => params[:linksearch]), class:"button", role:"button"
 
 - if @linkedcategories.exists?
 
   .grid-row
     .column-full
-
       %hr
 
-      %h3.heading-medium
-        This document is already assigned to these categories:
-
   .grid-row
+    .column-one-third
+      %h3.heading-medium
+        The
+        = @document.code
+        %span.attributes
+          = @document.language.english_name
+          format
+        is already assigned to these categories:
     .column-two-thirds
-
       - if @linkedcategories.exists?
-
         %ul.list
           - @linkedcategories.each do | doc_attachment |
             %li
@@ -100,6 +103,4 @@
                   Welsh:
                 = doc_attachment.category.welsh_name
               .action
-                = link_to "Remove", link_document_categories_unconnect_path(:related_category => doc_attachment.id, :document => params[:document], :linksearch => params[:linksearch]), class:'button-warning', role:'button'
-
-    .column-one-third
+                = link_to "Remove", link_document_categories_unconnect_path(:related_category => doc_attachment.id, :document => params[:document], :linksearch => params[:linksearch]), class:"button-warning", role:"button"

--- a/app/views/document_categories/search.haml
+++ b/app/views/document_categories/search.haml
@@ -7,39 +7,35 @@
 
   .grid-row
     .column-full
-
-      %h2.heading-large
-        Step 1 of 4
-
-      %h3.heading-medium
-        Find the document you'd like to assign to a category
+      %h2.heading-large Step 1 of 4
 
   .grid-row
-    .column-half
-
+    .column-one-third
+      %h3.heading-medium Find the document you'd like to assign to a category
+    .column-two-thirds
       .search-wrapper
         = form_tag url_for(:controller => 'document_categories', :action => 'search'), :method => 'get', id:'search', class:'search-box', role:'search' do
           = label_tag :'search_field', 'Enter a document title or reference/number', class:'form-label'
           = text_field_tag :search, params[:search], :id => 'search_field', class:'form-control'
           = submit_tag "Search", :name => nil, role:"button", class:"button"
-
-    .column-half
+      - if @documents.empty?
+        -#%p.no-result-message No result found to display
+        %p
 
 - else
 
   .grid-row
     .column-full
+      %h2.heading-large Step 2 of 4
 
-      %h2.heading-large
-        Step 2 of 4
-
-      %h3.heading-medium
-        Select a document
-
+  .grid-row
+    .column-one-third
+      %h3.heading-medium Select a document
+    .column-two-thirds
       %p
         Your searched for
-        %i "#{params[:search]}"  returned the following results.
-
+        %i "#{params[:search]}"
+        returned the following results:
       %ul.list
         - @documents.each do | doc_attachment |
           %li

--- a/app/views/documents/link.haml
+++ b/app/views/documents/link.haml
@@ -4,14 +4,14 @@
 = render partial: 'layouts/header', locals: {page_heading: 'Link Documents'}
 
 - if @documents.count == 0
-  .grid-row
-    .column-full
-      %h2.heading-large
-        Step 3 of 4
-      %h3.heading-medium
-        Find the document to link to this one:
 
   .grid-row
+    .column-full
+      %h2.heading-large Step 3 of 4
+
+  .grid-row
+    .column-one-third
+      %h3.heading-medium 1st chosen document:
     .column-two-thirds
       %span.reference
         = @document.code
@@ -20,7 +20,12 @@
         format
       .title
         = @document.title
-      %br
+      %hr
+
+  .grid-row
+    .column-one-third
+      %h3.heading-medium Find the 2nd document to link to
+    .column-two-thirds
       .search-wrapper
         = form_tag url_for(:controller => 'documents', :action => 'links'), :method => 'get', id:'search', class:'search-box', role:'search' do
           = hidden_field_tag 'document', params[:document]
@@ -28,25 +33,20 @@
           = label_tag :'search_field', 'Enter the document title or reference/number', class:'form-label'
           = text_field_tag :linksearch, params[:linksearch], :id => 'search_field', class:'form-control'
           = submit_tag "Search", :name => nil, role:"button", class:"button"
-    .column-one-third
-
-  .grid-row
-    .column-full
       - if @documents.empty?
         -#%p.no-result-message No result found to display
-        -#%p
+        %p
 
 - else
 
   .grid-row
     .column-full
+      %h2.heading-large Step 4 of 4
 
-      %h2.heading-large
-        Step 4 of 4
-
-      %h3.heading-medium
-        Choose a document to link to this one
-
+  .grid-row
+    .column-one-third
+      %h3.heading-medium The document
+    .column-two-thirds
       %span.reference
         = @document.code
       %span.attributes
@@ -54,13 +54,16 @@
         format
       .title
         = @document.title
-
       %hr
 
+  .grid-row
+    .column-one-third
+      %h3.heading-medium To be linked to
+    .column-two-thirds
       %p
         Your searched for
-        %i "#{params[:linksearch]}" returned the following results.
-
+        %i "#{params[:linksearch]}"
+        returned the following results:
       %ul.list
         - @documents.each do | doc_attachment   |
           %li
@@ -76,17 +79,21 @@
               = link_to "Link", link_documents_connect_path(:related_document => doc_attachment.id, :document => params[:document], :document_title => params[:document_title], :linksearch => params[:linksearch]), {class:"button", role:"button"}
 
 - if @linkeddocuments.exists?
+
   .grid-row
     .column-full
-
       %hr
 
   .grid-row
-    .column-two-thirds
-
+    .column-one-third
       %h3.heading-medium
-        This document is already linked to:
-
+        The
+        = @document.code
+        %span.attributes
+          = @document.language.english_name
+          format
+        is already linked to:
+    .column-two-thirds
       %ul.list
         - @linkeddocuments.each do | doc_attachment   |
           %li
@@ -100,5 +107,3 @@
                 = doc_attachment.title
             .action
               = link_to "Remove", link_documents_unconnect_path(:related_document => doc_attachment.id, :document => params[:document], :document_title => params[:document_title], :linksearch => params[:linksearch]), {class:"button-warning", role:"button"}
-
-    .column-one-third

--- a/app/views/documents/search.html.haml
+++ b/app/views/documents/search.html.haml
@@ -7,27 +7,17 @@
 
   .grid-row
     .column-full
-
-      %h2.heading-large
-        Step 1 of 4
-
-      %h3.heading-medium
-        Search for one of the documents you would like to link
+      %h2.heading-large Step 1 of 4
 
   .grid-row
-    .column-half
-
+    .column-one-third
+      %h3.heading-medium Find a document
+    .column-two-thirds
       .search-wrapper
         = form_tag url_for(:controller => 'documents', :action => 'search'), :method => 'get', id:'search', class:'search-box', role:'search' do
-          = label_tag :'search_field', 'Enter a form title or reference/number', class:'form-label'
+          = label_tag :'search_field', 'Enter a document title or reference/number', class:'form-label'
           = text_field_tag :search, params[:search], :id => 'search_field', class:'form-control'
           = submit_tag "Search", :name => nil, role:"button", class:"button"
-
-    .column-half
-
-  .grid-row
-    .column-full
-
       - if @documents.empty?
         -#%p.no-result-message No result found to display
         %p
@@ -36,17 +26,16 @@
 
   .grid-row
     .column-full
+      %h2.heading-large Step 2 of 4
 
-      %h2.heading-large
-        Step 2 of 4
-
-      %h3.heading-medium
-        Select a document
-
+  .grid-row
+    .column-one-third
+      %h3.heading-medium Select a document
+    .column-two-thirds
       %p
         Your searched for
-        %i "#{params[:search]}" returned the following results.
-
+        %i "#{params[:search]}"
+        returned the following results:
       %ul.list
         - @documents.each do | doc_attachment |
           %li

--- a/db/migrate/20170406122330_add_original_url_to_documents.rb
+++ b/db/migrate/20170406122330_add_original_url_to_documents.rb
@@ -1,0 +1,5 @@
+class AddOriginalUrlToDocuments < ActiveRecord::Migration
+  def change
+    add_column :documents, :original_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170320134509) do
+ActiveRecord::Schema.define(version: 20170406122330) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -58,6 +58,7 @@ ActiveRecord::Schema.define(version: 20170320134509) do
     t.integer  "original_id"
     t.integer  "creator_id"
     t.boolean  "inactive",                default: false
+    t.string   "original_url"
   end
 
   create_table "languages", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -65,8 +65,9 @@ csv.each do |row|
   t.doc_attachment_type_id = row['doc_attachment_type_id']
   t.inactive = row['inactive']
   t.creator_id = row['creator_id']
-  t.original_id = row['original_id']
   t.published_date = row['published_date']
+  t.original_url = row['original_url']
+  t.original_id = row['original_id']
   t.save
 end
 

--- a/lib/seeds/documents.csv
+++ b/lib/seeds/documents.csv
@@ -1,1979 +1,1979 @@
-id,code,title,attachment_file_name,attachment_content_type,attachment_file_size,content_date,language_id,doc_attachment_type_id,inactive,creator_id,original_id,published_date
-1,N30,"Judgment for claimant (in default)",n30-eng.pdf,application/pdf,248517,04/2006,8,1,false,1,1,2017-03-17
-4,N30(CH),"Judgment for claimant (in default)",n30(hc)-eng.pdf,application/pdf,247657,04/2006,8,1,false,1,4,2017-03-17
-14,A/E,"Your Guide to the Attachment of Earnings Act 1971",ae-eng.pdf,application/pdf,180866,11/2014,8,4,false,1,14,2017-03-17
-15,Attachment Orders - A guide for employers,"Attachment Orders - A guide for employers",ao-employers-guide-eng.pdf,application/pdf,643856,08/2008,8,4,false,1,15,2017-03-17
-18,A20,"Adoption - A guide for family court users",a20-eng.pdf,application/pdf,449748,11/2016,8,4,false,1,18,2017-03-17
-19,A20,"Mabwysiadu:  Arweiniad i Ddefnyddwyr y Llysoedd | Adoption:  A Guide for Court Users",a020-bil.pdf,application/pdf,77228,10/2003,26,4,false,1,19,2017-03-17
-20,A20(1),"President's Intercountry Supplement",a020(1)-eng.pdf,application/pdf,49056,11/2008,8,2,false,1,20,2017-03-17
-21,A20(1),"Canolfannau Mabwysiadu Rhyngwladol - Arweiniad a gyhoeddwyd gan Lywydd yr Adran Deulu",a020(1)-cym.pdf,application/pdf,63777,11/2008,25,2,false,1,21,2017-03-17
-26,A4,"Application For Revocation Of An Order Freeing A Child For Adoption",a004-eng.pdf,application/pdf,34125,06/2001,8,1,false,1,26,2017-03-17
-27,A5,"Application For Substitution Of One Adoption Agency For Another",a005-eng.pdf,application/pdf,76647,05/2002,8,1,false,1,27,2017-03-17
-32,AE Faq,"Gorchmynion Atafaelu enillion gogyfer a dirwyon troseddol Peilot Cenedlaethol mis Ebrill 2004",ae-faq-cym.pdf,application/pdf,109948,07/2004,25,2,false,1,32,2017-03-17
-33,AE Canllaw,"Canllawiau i GyFLogwyr i Ddeddf Atafaelu Enillion 1971",ae-guide-cym.pdf,application/pdf,213589,07/2004,25,2,false,1,33,2017-03-17
-46,Attachment of Earnings Orders for criminal fines National Pilot April 2004,"Attachment of Earnings Orders for criminal fines national pilot (April 2004)",attachment-earnings-mags-faq-eng.pdf,application/pdf,98351,06/2004,8,2,false,1,46,2017-03-17
-48,C(PRA1),"Parental Responsibility Agreement",c(pra001)-eng.pdf,application/pdf,360750,08/2014,8,1,false,1,48,2017-03-17
-49,C1,"Cais am orchymyn (Deddf Plant 1989)",c1-cym.pdf,application/pdf,265983,06/2016,25,1,false,1,49,2017-03-17
-50,C1,"Application for an order",c1-eng.pdf,application/pdf,328888,06/2016,8,1,false,1,50,2017-03-17
-56,C11,"Atodiad i gais am Orchymyn Diogelu Brys | Supplement for an application for an Emergency Protection Order",c011-bil.pdf,application/pdf,171681,08/2004,26,1,false,1,56,2017-03-17
-57,C12,"Atodiad i gais am warant i helpu person a awdurdodir gan Orchymyn Amddiffyn Brys | Supplement for an application for a warrant to assist a person authorised by an Emergency Protection Order",c012-bil.pdf,application/pdf,129706,08/2004,26,1,false,1,57,2017-03-17
-58,C12,"Supplement for an application for a Warrant to assist a person authorised by an Emergency Protection Order",c012-eng.pdf,application/pdf,122025,08/2004,8,1,false,1,58,2017-03-17
-59,C13,"Supplement for an application for a Care or Supervision Order",c013-eng.pdf,application/pdf,14738,09/1999,8,1,false,1,59,2017-03-17
-60,C14,"Supplement for an application for authority to refuse contact with a child in care",c014-eng.pdf,application/pdf,12241,09/1999,8,1,false,1,60,2017-03-17
-61,C14,"Atodiad i gais am awdurdod i wrthod cyswllt â phlentyn mewn gofal | Supplement for an application for authority to refuse contact with a child in care",c014-bil.pdf,application/pdf,110190,09/1999,26,1,false,1,61,2017-03-17
-62,C15,"Supplement for an application for contact with a child in care",c015-eng.pdf,application/pdf,11195,09/1999,8,1,false,1,62,2017-03-17
-63,C15,"Atodiad i gais am gyswllt gyda phlentyn sydd mewn gofal | Supplement for an application for contact with a child in care",c015-bil.pdf,application/pdf,105555,09/1999,26,1,false,1,63,2017-03-17
-64,C16,"Supplement for an application for a Child Assessment Order",c016-eng.pdf,application/pdf,12628,09/1999,8,1,false,1,64,2017-03-17
-65,C16,"Atodiad i gais am Orchymyn Asesu Plentyn | Supplement for an application for a Child Assessment Order",c016-bil.pdf,application/pdf,116449,09/1999,26,1,false,1,65,2017-03-17
-66,C17,"Supplement for an application for an Education Supervision Order",c017-eng.pdf,application/pdf,149870,07/2010,8,1,false,1,66,2017-03-17
-68,C17A,"Supplement for an application for an extension of an Education Supervision Order",c017(a)-eng.pdf,application/pdf,10892,09/1999,8,1,false,1,68,2017-03-17
-69,C17A,"Atodiad i gais am estyniad i Orchymyn Goruchwylio Addysg | Supplement for an application for an extention of an Education Supervision Order",c017(a)-bil.pdf,application/pdf,110869,09/1999,26,1,false,1,69,2017-03-17
-70,C18,"Atodiad i gais am Orchymyn Adfer | Supplement for an application for a Recovery Order",c018-bil.pdf,application/pdf,145150,09/1999,26,1,false,1,70,2017-03-17
-71,C18,"Supplement for an application for a Recovery Order",c018-eng.pdf,application/pdf,19040,09/1999,8,1,false,1,71,2017-03-17
-72,C19,"Application for a warrant of assistance",c019-eng.pdf,application/pdf,364127,11/2014,8,1,false,1,72,2017-03-17
-74,C1A,"Allegations of harm and domestic violence (Supplemental information form)",c001a-eng.pdf,application/pdf,357564,01/2016,8,1,false,1,74,2017-03-17
-75,C1A,"Honiadau o niwed a thrais yn y cartref (Ffurflen gwybodaeth ategol) | Allegations of harm and domestic violence (Supplemental information form)",c001a-bil.pdf,application/pdf,212087,04/2011,26,1,false,1,75,2017-03-17
-76,C1A Nodiadau | C1A Notes,"Nodiadau Canllaw ar gyfer Ffurflen Gwybodaeth Ychwanegol C1A | Notes for Guidance for Supplemental Information Form C1A",c001a-notes-bil.pdf,application/pdf,213141,01/2005,26,4,false,1,76,2017-03-17
-77,C1A Notes,"Notes for Guidance for Supplemental Information Form C1A",c001a-notes-eng.pdf,application/pdf,238981,01/2005,8,4,false,1,77,2017-03-17
-78,C2,"Application: For permission to start proceedings; For an order or directions in existing proceedings; To be joined as, or cease to be, a party in existing family proceedings under the Children Act 1989",c2-eng.pdf,application/pdf,606202,06/2016,8,1,false,1,78,2017-03-17
-79,C2,"Cais: Am ganiatad i gychwyn achos; Am orchymyn neu gyfarwyddiadau mewn achos sydd eisoes ar waith; I ymuno fel parti, neu i roi'r gorau i fod yn barti, mewn achos teulu sydd eisoes ar waith o dan Ddeddf Plant 1989 | Application: For permission to start proceedings; For an order or directions in existing proceedings; To be joined as, or cease to be, a party in existing family proceedings under the Children Act 1989",c2-bil.pdf,application/pdf,118135,06/2016,26,1,false,1,79,2017-03-17
-80,C20,"Supplement for an application for an order to hold a child in Secure Accommodation",c20-eng.pdf,application/pdf,65271,08/2016,8,1,false,1,80,2017-03-17
-82,C3,"Application for an order authorising search for taking charge of and delivery of a child",c003-eng.pdf,application/pdf,12661,09/1999,8,1,false,1,82,2017-03-17
-83,C3,"Cais am orchymyn i awdurdodi chwilio am blentyn, cymryd cyfrifoldeb drosto/drosti a throsglwyddo'r plentyn i fan penodol | Application for an order authorising search for, taking charge of, and delivery of, a child",c003-bil.pdf,application/pdf,128333,09/1999,26,1,false,1,83,2017-03-17
-84,C4,"Application for an order for disclosure of a child's whereabouts",c004-eng.pdf,application/pdf,13201,09/1999,8,1,false,1,84,2017-03-17
-85,C4,"Cais am orchymyn i ddatgelu ble mae plentyn | Application for an order for disclosure of a child's whereabouts",c004-bil.pdf,application/pdf,118653,09/1999,26,1,false,1,85,2017-03-17
-86,C60,"Tystysgrif y cyfeirir ati yn Erthygl 33 Rheoliad y Cyngor (CE) Rhif 1347/2000 29 Mai 2000 sy'n ymwneud â dyfarniadau ynghylch cyfrifoldeb rhieni | Certificate referred to in Article 33 of Council Regulation (EC) No. 1347/2000 of 29 May 2000 concerning judgments on parental responsibility",c060-bil.pdf,application/pdf,140319,09/2001,26,1,false,1,86,2017-03-17
-87,C60,"Concerning Judgements on parental responsibility",c060-eng.pdf,application/pdf,278155,03/2005,8,1,false,1,87,2017-03-17
-88,C7,"Acknowledgement",c007-eng.pdf,application/pdf,201509,11/2013,8,1,false,1,88,2017-03-17
-89,C9,"Statement of service",c009-eng.pdf,application/pdf,28940,10/2004,8,1,false,1,89,2017-03-17
-90,C9,"Datganiad Cyflwyno | Statement of Service",c009-bil.pdf,application/pdf,122072,12/2004,26,1,false,1,90,2017-03-17
-91,Case Management Information Sheet,"Case Management Information Sheet",cmis-eng.doc,application/msword,24576,04/2005,8,2,false,1,91,2017-03-17
-93,CB1,"Making an Application - Children and the Family Courts",cb001-eng.pdf,application/pdf,286318,02/2015,8,2,false,1,93,2017-03-17
-94,CB2,"Urgent Hearings and Those Without Notice in Relation to Child Arrangements",cb002-eng.pdf,application/pdf,158078,11/2014,8,2,false,1,94,2017-03-17
-97,CB3,"Serving the Forms",cb003-eng.pdf,application/pdf,433687,04/2014,8,2,false,1,97,2017-03-17
-98,D11,"Application notice",d11-eng.pdf,application/pdf,201034,06/2016,8,1,false,1,98,2017-03-17
-99,D11,"Rhybudd o gais | Application notice",d11-bil.pdf,application/pdf,155917,06/2016,26,1,false,1,99,2017-03-17
-100,D13B,"Affidafid i gefnogi cais i hepgor cyflwyno'r ddeiseb ysgaru/diddymu/dirymu/ymwahaniad (cyfreithiol) i'r Atebydd | Affidavit in support of a request to dispense with service of the divorce/dissolution/nullity/(judicial) separation petition on the Respondent",d013b-bil.pdf,application/pdf,250827,04/2012,26,1,false,1,100,2017-03-17
-103,D180,"Tystysgrif y cyfeirir ati yn Erthygl 33 Rheoliad y Cyngor (CE) Rhif 1347/2000 29 Mai 2000 sy'n ymwneud â dyfarniadau mewn materion priodasol | Certificate referred to in Article 33 of Council Regulation (EC) NO. 1347/2000 of 29 May 2000 concerning judgments in matrimonial matters",d180-bil.pdf,application/pdf,261499,09/2001,26,1,false,1,103,2017-03-17
-104,D180,"Concerning judgments in matrimonial matters",d180-eng.pdf,application/pdf,251725,03/2005,8,1,false,1,104,2017-03-17
-105,D183,"Ynglyn ag ysgariad/diddymiad",d183-cym.pdf,application/pdf,142258,04/2014,25,2,false,1,105,2017-03-17
-106,D183,"About Divorce/Dissolution",d183-eng.pdf,application/pdf,168484,04/2014,8,2,false,1,106,2017-03-17
-108,D184,"Rydw i eisiau ysgariad/diddymiad - beth ddylwn i ei wneud?",d184-cym.pdf,application/pdf,140770,04/2014,25,2,false,1,108,2017-03-17
-109,D184,"I Want to Get a Divorce/Dissolution",d184-eng.pdf,application/pdf,168240,04/2014,8,2,false,1,109,2017-03-17
-111,D185,"Children and Divorce and Dissolution",d185-eng.pdf,application/pdf,156385,04/2014,8,2,false,1,111,2017-03-17
-112,D185,"Plant ac ysgariad a diddymiad",d185-cym.pdf,application/pdf,143891,04/2014,25,2,false,1,112,2017-03-17
-114,D186,"Mae'r atebydd wedi ateb fy neiseb",d186-cym.pdf,application/pdf,137439,04/2014,25,2,false,1,114,2017-03-17
-115,D186,"The respondent has replied to my petition. What must I do?",d186-eng.pdf,application/pdf,347722,04/2016,8,2,false,1,115,2017-03-17
-117,D187,"Mae gen i ddyfarniad nisi/gorchymyn amodol. Beth sydd rhaid i mi ei wneud nesaf?",d187-cym.pdf,application/pdf,151883,04/2014,25,2,false,1,117,2017-03-17
-119,D187,"I Have a Decree Nisi/Conditional Order.  What Must I do Next?",d187-eng.pdf,application/pdf,155595,11/2015,8,2,false,1,119,2017-03-17
-120,D190,"I Want to Apply for a Financial Order",d190-eng.pdf,application/pdf,145929,08/2015,8,2,false,1,120,2017-03-17
-121,D190,"Rwyf eisiau gwneud cais am orchymyn ariannol",d190-cym.pdf,application/pdf,158638,08/2015,25,2,false,1,121,2017-03-17
-122,D252,"Notice of commencement of assessment of bill of costs",d252-eng.pdf,application/pdf,32009,04/2011,8,1,false,1,122,2017-03-17
-123,D252,"Hysbysiad cychwyn asesu bil costau | Notice of commencement of assessment of bill of costs",d252-bil.pdf,application/pdf,67650,04/2011,26,1,false,1,123,2017-03-17
-124,D254,"Request for a Default Costs Certificate",d254-eng.pdf,application/pdf,26245,04/2014,8,1,false,1,124,2017-03-17
-125,D254,"Cais am Dystysgrif Costau Diffygdalu | Request for a Default Costs Certificate",d254-bil.pdf,application/pdf,57221,04/2011,26,1,false,1,125,2017-03-17
-126,D258,"Request for detailed assessment hearing (general form)",d258-eng.pdf,application/pdf,245134,04/2011,8,1,false,1,126,2017-03-17
-127,D258,"Cais am wrandawiad asesiad manwl (ffurflen gyffredinol) | Request for detailed assessment hearing (general form)",d258-bil.pdf,application/pdf,82981,04/2011,26,1,false,1,127,2017-03-17
-128,D258A,"Request for detailed assessment (Legal aid/Legal Services Commission only)",d258a-eng.pdf,application/pdf,251422,11/2014,8,1,false,1,128,2017-03-17
-129,D258A,"Cais am asesiad manwl (Y Comisiwn Gwasanaethau Cyfreithiol/Cymorth Cyfreithiol yn unig) | Request for detailed assessment (Legal aid/Legal Services Commission only)",d258a-bil.pdf,application/pdf,78386,04/2011,26,1,false,1,129,2017-03-17
-130,D259,"Notice of Appeal against a detailed assessment",d259-eng.pdf,application/pdf,44871,11/2014,8,1,false,1,130,2017-03-17
-131,D259,"Hysbysiad o Apel yn erbyn asesiad manwl | Notice of Appeal against a detailed assessment",d259-bil.pdf,application/pdf,75615,04/2011,26,1,false,1,131,2017-03-17
-133,D36,"Hysbysiad o gais i wneud dyfarniad nisi yn absoliwt neu i wneud gorchymyn amodol yn derfynol | Notice of application for decree nisi to be made absolute or conditional order to be made final",d036-bil.pdf,application/pdf,100493,11/2014,26,1,false,1,133,2017-03-17
-134,D440,"Request for Search for Divorce Decree Absolute",d440-eng.pdf,application/pdf,567472,11/2014,8,2,false,1,134,2017-03-17
-135,D63,"Gwys Dyfarniad Rheolau Achosion Teulu 7.4(5) | Judgement Summons Family Proceedings Rules 7.4(5)",d063-bil.pdf,application/pdf,209473,01/2003,26,1,false,1,135,2017-03-17
-138,D8,"Deiseb ysgaru/diddymu/ymwahanu (cyfreithiol) | Divorce/dissolution/(judicial) separation petition",d8-bil.pdf,application/pdf,174151,06/2016,26,1,false,1,138,2017-03-17
-140,D8 Notes,"Supporting Notes for Guidance on Completing a Divorce/Dissolution/(Judicial) Separation Petition",d008-notes-eng.pdf,application/pdf,185581,04/2014,8,4,false,1,140,2017-03-17
-141,D8 Nodiadau | D8 Notes,"Nodiadau canllaw ar gyfer llenwi deiseb ysgaru/diddymu/ymwahanu (cyfreithiol) | Supporting notes for guidance on completing a divorce/dissolution/(judicial) separation petition",d008-notes-bil.pdf,application/pdf,172287,04/2014,26,4,false,1,141,2017-03-17
-142,D80A,"Statement in Support of Divorce/(Judicial) Separation - Adultery",d080a-eng.pdf,application/pdf,596713,04/2014,8,1,false,1,142,2017-03-17
-143,D80A,"Datganiad i gefnogi ysgariad/ymwahaniad (cyfreithiol) - godineb | Statement in support of divorce/(judicial) separation - adultery",d080a-bil.pdf,application/pdf,497406,04/2014,26,1,false,1,143,2017-03-17
-144,D80B,"Statement in Support of Divorce/Dissolution/(Judicial) Separation - Unreasonable Behaviour",d080b-eng.pdf,application/pdf,603453,04/2014,8,1,false,1,144,2017-03-17
-145,D8B,"Ateb i ddeiseb ysgaru/diddymu/ymwahanu (cyfreithiol) neu ddirymu | Answer to a divorce/dissolution/(judicial) separation or nullity petition",d008b-bil.pdf,application/pdf,235389,04/2012,26,1,false,1,145,2017-03-17
-146,D80C,"Statement in Support of Divorce/Dissolution/(Judicial) Separation - Desertion",d080c-eng.pdf,application/pdf,380452,04/2014,8,1,false,1,146,2017-03-17
-147,D80C,"Datganiad i gefnogi ysgariad/diddymiad/ymwahaniad (cyfreithiol) - gadael | Statement in support of divorce/dissolution/(judicial) separation - desertion",d080c-bil.pdf,application/pdf,123719,04/2014,26,1,false,1,147,2017-03-17
-148,D8D,"Deiseb am orchymyn/ddyfarniad rhagdybio marwolaeth a diddymu priodas/partneriaeth sifil | Petition for a presumption of death decree/order and the dissolution of a marriage/civil partnership",d008d-bil.pdf,application/pdf,170140,01/2014,26,1,false,1,148,2017-03-17
-149,D80D,"Statement in Support of Divorce/Dissolution/(Judicial) Separation - 2 Years' Consent",d080d-eng.pdf,application/pdf,609037,01/2014,8,1,false,1,149,2017-03-17
-150,D80E,"Statement in Support of Divorce/Dissolution/(Judicial) Separation - 5 Years' Consent",d080e-eng.pdf,application/pdf,592661,04/2014,8,1,false,1,150,2017-03-17
-151,D80E,"Datganiad i gefnogi ysgariad/diddymiad/ymwahaniad (cyfreithiol) - ymwahaniad 5 mlynedd | Statement in support of divorce/dissolution/(judicial) separation - 5 years' separation",d080e-bil.pdf,application/pdf,117553,04/2014,26,1,false,1,151,2017-03-17
-153,D81,"Datganiad gwybodaeth am orchymyn cydsynio yng nghyswllt rhwymedi ariannol | Statement of information for a consent order in relation to a financial remedy",d081-bil.pdf,application/pdf,293184,04/2012,26,1,false,1,153,2017-03-17
-154,D84,"Application for a decree nisi conditional order or (judicial) separation decreeorder",d084-eng.pdf,application/pdf,327965,04/2014,8,1,false,1,154,2017-03-17
-155,D84,"Cais am ddyfarniad nisi/gorchymyn amodol neu orchymyn/dyfarniad ymwahanu (cyfreithiol) | Application for a decree nisi/conditional order or (judicial) separation decree/order",d084-bil.pdf,application/pdf,158001,04/2012,26,1,false,1,155,2017-03-17
-156,D89,"Request for personal service by a court bailiff",d89-eng.pdf,application/pdf,111472,10/2016,8,1,false,1,156,2017-03-17
-157,D89,"Cais am gyflwyno personol gan feili llys | Request for personal service by a court bailiff",d089-bil.pdf,application/pdf,180199,04/2011,26,1,false,1,157,2017-03-17
-159,D8A,"Datganiad trefniadau ar gyfer plant | Statement of arrangements for children",d008a-bil.pdf,application/pdf,292368,04/2011,26,1,false,1,159,2017-03-17
-160,D151,"Application for registration of a maintenance order in the family court",d151-eng.pdf,application/pdf,145212,11/2015,8,1,false,1,160,2017-03-17
-161,EX107,"Tape transcription request",ex107-eng.pdf,application/pdf,358619,04/2014,8,1,false,1,161,2017-03-17
-162,EX107,"Cais am Drawsgrifio Tâp | Tape transcription request",ex107-bil.pdf,application/pdf,279747,01/2007,26,1,false,1,162,2017-03-17
-164,EX140,"Cofnod archwiliad (Unigolyn) | Record of examination (Individual)",ex140-bil.pdf,application/pdf,1128608,04/2003,26,1,false,1,164,2017-03-17
-165,EX140,"Record of evidence (Individual debtor)",ex140-eng.pdf,application/pdf,377873,04/2003,8,1,false,1,165,2017-03-17
-166,EX141,"Cofnod archwiliad (swyddog mewn cwmni neu gorfforaeth) | Record of examination (Officer of company or corporation)",ex141-bil.pdf,application/pdf,667221,04/2003,26,1,false,1,166,2017-03-17
-167,EX141,"Record of evidence (Officer of a company)",ex141-eng.pdf,application/pdf,267534,04/2003,8,1,false,1,167,2017-03-17
-170,EX97A,"Bailiff risk assessment questionnaire",ex97a-eng.pdf,application/pdf,87919,03/2015,8,1,false,1,170,2017-03-17
-175,EX20,"Paying your Judgment, what do I do?",ex020-eng.pdf,application/pdf,169328,04/2013,8,2,false,1,175,2017-03-17
-177,EX20,"Talu fy nyfarniad - Beth ddylwn i wneud?",ex020-cym.pdf,application/pdf,170336,04/2006,25,2,false,1,177,2017-03-17
-178,N1A,"Notes for claimant on completing a claim form",n001a-eng.pdf,application/pdf,51124,07/2014,8,3,false,1,178,2017-03-17
-179,EX301,"I'm in a dispute, what can I do?",ex301-eng.pdf,application/pdf,227014,06/2014,8,2,false,1,179,2017-03-17
-181,EX301,"Rwyf mewn anghydfod - beth alla i ei wneud?",ex301-cym.pdf,application/pdf,868803,03/2012,25,2,false,1,181,2017-03-17
-183,EX302,"How do I make a court claim? For people who want to take a dispute to court",ex302-eng.pdf,application/pdf,175970,04/2014,8,2,false,1,183,2017-03-17
-185,EX302,"Sut mae gwneud hawliad | How to make a claim",ex302-bil.pdf,application/pdf,254951,04/2006,26,2,false,1,185,2017-03-17
-187,EX303,"A court claim has been made against me, what Should I Do? For people whose dispute has been taken to court",ex303-eng.pdf,application/pdf,222127,06/2014,8,2,false,1,187,2017-03-17
-189,EX303,"Mae hawliad wedi'i wneud yn fy erbyn yn y llys - beth ddylwn i ei wneud?",ex303-cym.pdf,application/pdf,873947,11/2011,25,2,false,1,189,2017-03-17
-191,EX304,"I've started a claim in court, what happens next?",ex304-eng.pdf,application/pdf,212385,06/2014,8,2,false,1,191,2017-03-17
-193,EX304,"Rwyf wedi cychwyn hawliad yn y llys - beth sy'n digwydd nesaf?",ex304-cym.pdf,application/pdf,855927,10/2011,25,2,false,1,193,2017-03-17
-196,EX305,"The fast track and the multi-track in the civil courts",ex305-eng.pdf,application/pdf,467974,03/2017,8,2,false,1,196,2017-03-17
-197,EX305,"Y Trac Cyflym a'r Amldrac mewn llysoedd sifil",ex305-cym.pdf,application/pdf,147266,03/2017,25,2,false,1,197,2017-03-17
-199,EX306,"The small claims track in the civil courts (If your dispute has gone to court)",ex306-eng.pdf,application/pdf,478395,03/2017,8,2,false,1,199,2017-03-17
-201,EX306,"Y trac hawliadau bychain yn y llysoedd sifil (Os yw eich anghydfod wedi mynd ymlaen i'r llys)",ex306-cym.pdf,application/pdf,151418,03/2017,25,2,false,1,201,2017-03-17
-215,EX320,"Registered judgments, what does it mean?",ex320-eng.pdf,application/pdf,157668,06/2014,8,2,false,1,215,2017-03-17
-217,EX320,"Dyfarniad cofrestredig - Beth mae hynny'n ei olygu? | Registered judgments, what does it mean?",ex320-bil.pdf,application/pdf,232137,04/2006,26,2,false,1,217,2017-03-17
-219,EX321,"I have a judgment but the defendant hasn't paid, what do I do?",ex321-eng.pdf,application/pdf,180597,04/2016,8,2,false,1,219,2017-03-17
-221,EX321,"Mae gennyf ddyfarniad ond nid yw'r diffynnydd wedi talu - Beth ddylwn ei wneud?",ex321-cym.pdf,application/pdf,151478,04/2016,25,2,false,1,221,2017-03-17
-224,EX322,"How do I ask for a warrant of control?",ex322-eng.pdf,application/pdf,223093,04/2016,8,2,false,1,224,2017-03-17
-225,EX322,"Gwarantau Rheolaeth - Sut mae gofyn am warant reolaeth?",ex322-cym.pdf,application/pdf,597200,04/2016,25,2,false,1,225,2017-03-17
-227,EX323,"How do I ask for an attachment of earnings order?",ex323-eng.pdf,application/pdf,229604,04/2016,8,2,false,1,227,2017-03-17
-229,EX323,"Atafaelu enillion - Sut mae gofyn am orchymyn atafaelu enillion?",ex323-cym.pdf,application/pdf,410593,04/2016,25,2,false,1,229,2017-03-17
-231,EX324,"How do I apply for an order? Order to obtain information from a person who owes you money",ex324-eng.pdf,application/pdf,163670,04/2014,8,2,false,1,231,2017-03-17
-233,EX324,"Sut mae gwneud cais am orchymyn? Gorchymyn i gael gwybodaeth gan rywun sydd mewn dyled i chi",ex324-cym.pdf,application/pdf,153815,04/2014,25,2,false,1,233,2017-03-17
-234,EX325,"Third party debt orders and charging orders. How do I apply for an order? How do I respond to an order?",ex325-eng.pdf,application/pdf,204095,05/2016,8,2,false,1,234,2017-03-17
-236,EX325,"Gorchmynion dyled trydydd parti a gorchmynion arwystlo. Sut mae gwneud cais am orchymyn? Sut mae ymateb i orchymyn?",ex325-cym.pdf,application/pdf,195843,05/2016,25,2,false,1,236,2017-03-17
-237,EX326,"I cannot pay my judgment, what do I do?",ex326-eng.pdf,application/pdf,189007,04/2014,8,2,false,1,237,2017-03-17
-239,EX326,"Alla'i ddim talu fy nyfarniad - beth ddylwn i wneud?",ex326-cym.pdf,application/pdf,210281,04/2005,25,2,false,1,239,2017-03-17
-240,EX326,"Alla'i ddim talu fy nyfarniad - beth ddylwn i wneud? (PDF Print Bras)",ex326-large-cym.pdf,application/pdf,156540,04/2003,25,2,false,1,240,2017-03-17
-241,EX327,"I've got a maintenance order but it's not being paid",ex327-eng-20160107.pdf,application/pdf,174899,01/2016,8,2,false,1,241,2017-03-17
-244,EX327,"Mae gen i orchymyn cynhaliaeth ond nid yw'n cael ei dalu",ex327-cym.pdf,application/pdf,159743,08/2015,25,2,false,1,244,2017-03-17
-245,EX332,"Squatters - A quicker procedure",ex332-eng.pdf,application/pdf,175497,07/2014,8,2,false,1,245,2017-03-17
-246,EX332,"Sgwatwyr - Gorchymyn meddiannu dros dro trefn gyflymach - Gwydobaeth i berchnogion a thenantiaid",ex332-cym.pdf,application/pdf,153020,04/2005,25,2,false,1,246,2017-03-17
-247,EX333,"Squatters - Illegal occupation of premises",ex333-eng.pdf,application/pdf,192474,04/2005,8,2,false,1,247,2017-03-17
-248,EX333,"Sgwatwyr - Gorchymyn meddiannu interim - Dal eiddo yn anghyfreithlon - Gwybodaeth i ddeiliaid",ex333-cym.pdf,application/pdf,125089,04/2005,25,2,false,1,248,2017-03-17
-249,EX340,"I want to appeal, what should I do? For people who want to appeal against a court decision",ex340-eng.pdf,application/pdf,550282,11/2016,8,2,false,1,249,2017-03-17
-250,EX340,"Rwyf am apelio - beth ddylwn i ei wneud?",ex340-cym.pdf,application/pdf,166891,04/2014,25,2,false,1,250,2017-03-17
-251,EX341,"I Have Been Asked to Be a Witness - What Do I Do?",ex341-eng.pdf,application/pdf,161613,04/2014,8,2,false,1,251,2017-03-17
-252,EX341,"Gofynnwyd i mi fod yn dyst - beth ddylwn ei wneud? Bod yn dyst yn yr Uchel Lys a'r Llysoedd Sirol",ex341-cym.pdf,application/pdf,154444,04/2014,25,2,false,1,252,2017-03-17
-253,EX342,"Coming to a Court Hearing?  Some Things You Should Know.  Court Hearings in the High Court and County Courts",ex342-eng.pdf,application/pdf,176458,07/2014,8,2,false,1,253,2017-03-17
-254,EX343,"Unhappy With Our Service - What Can You Do?",ex343-eng.pdf,application/pdf,157575,10/2015,8,2,false,1,254,2017-03-17
-255,EX343,"Yn anfodlon gyda'n gwasanaeth - beth allwch chi ei wneud? Canllaw ar gyfer ein holl ddefnyddwyr",ex343-cym.pdf,application/pdf,143538,10/2015,25,2,false,1,255,2017-03-17
-256,EX343A,"Complaint form",ex343a-eng.pdf,application/pdf,117532,10/2015,8,1,false,1,256,2017-03-17
-257,EX343A,"Ffurflen gwyno",ex343a-cym.pdf,application/pdf,149594,04/2010,25,1,false,1,257,2017-03-17
-261,EX345,"About Bailiffs, Enforcement Officers and Enforcement Agents",ex345-eng.pdf,application/pdf,181739,04/2014,8,2,false,1,261,2017-03-17
-262,EX350,"A guide to debt recovery through the county courts for small businesses",ex350-eng.pdf,application/pdf,195407,05/2014,8,4,false,1,262,2017-03-17
-263,EX350,"Canllaw i fusnesau bach ynghylch adennill dyled drwy'r Llys Sirol",ex350-cym.pdf,application/pdf,174010,05/2014,25,2,false,1,263,2017-03-17
-264,EX50,"Civil and Family Court Fees (from 6th March 2017)",ex50-eng.pdf,application/pdf,741564,03/2017,8,2,false,1,264,2017-03-17
-266,EX501,"Mae'r hysbysiad hwn yn egluro ein gwasanaeth Welsh | This notice explains our Welsh language service",ex501-bil.pdf,application/pdf,112438,04/2012,26,1,false,1,266,2017-03-17
-267,EX503,"Human Rights Act",ex503-eng.pdf,application/pdf,166899,08/2014,8,2,false,1,267,2017-03-17
-269,EX550,"Affidavit of service",ex550-eng.pdf,application/pdf,33379,04/2005,8,1,false,1,269,2017-03-17
-270,EX50,"Ffioedd y Llys Sifil a'r Llys Teulu (O 6 Mawrth 2017)",ex50-cym.pdf,application/pdf,140559,03/2017,25,2,false,1,270,2017-03-17
-271,EX670,"Disclosure orders against the Inland Revenue",ex670-eng.doc,application/msword,47616,11/2003,8,1,false,1,271,2017-03-17
-272,EX670,"Gorchmynion dadleniad yn erbyn Cyllid y Wlad",ex670-cym.doc,application/msword,46080,11/2003,25,1,false,1,272,2017-03-17
-273,EX670 Notes,"Disclosure Orders Against the Inland Revenue Guidance from the Presidents Office",ex670-notes-eng.pdf,application/pdf,19914,12/2003,8,4,false,1,273,2017-03-17
-274,EX80A,"Legal Aid/Legal Aid Agency Assessment Certificate",ex080a-eng.pdf,application/pdf,85194,04/2013,8,1,false,1,274,2017-03-17
-275,EX80A,"Tystysgrif asesu Cymorth Cyfreithiol/Comisiwn Gwasanaethau Cyfreithiol | Legal aid/Legal Services Commission assessment certificate",ex080a-bil.pdf,application/pdf,166467,01/2005,26,1,false,1,275,2017-03-17
-280,Ffurflen B,"Hysbysiad o gais i ystyried sefyllfa ariannol yr Atebydd ar ol ysgariad/diddymiad",form-b-cym.pdf,application/pdf,57497,10/2016,25,1,false,1,280,2017-03-17
-285,Ffurflen P2 | Form P2,"Atodiad Atafaelu Pensiwn dan Adran 25B neu 25C Deddf Achosion Priodasol 1973 | Pension Attachment Annex under Section 25B or 25C of the Matrimonial Causes Act 1973",p02-bil.pdf,application/pdf,106447,02/2003,26,1,false,1,285,2017-03-17
-286,Fixing Sheet,"Fixing Sheet",fixing-sheet-eng.doc,application/msword,44544,09/2012,8,2,false,1,286,2017-03-17
-289,FL403,"Application to vary, extend or discharge an order in existing proceedings",fl403-eng.pdf,application/pdf,147332,01/2016,8,1,false,1,289,2017-03-17
-290,FL403,"Cais i amrywio, ymestyn neu ddiddymu gorchymyn mewn achos cyfredol | Application to vary, extend or discharge an order in existing proceedings",fl403-bil.pdf,application/pdf,186645,11/2014,26,1,false,1,290,2017-03-17
-291,FL407,"Cais am Warant Arestio | Application for a warrant of arrest",fl407-bil.pdf,application/pdf,113802,10/1997,26,1,false,1,291,2017-03-17
-292,FL410,"Ymrwymiad atebydd | Recognizance of respondent",fl410-bil.pdf,application/pdf,137200,10/1997,26,1,false,1,292,2017-03-17
-293,FL411,"Ymrwymiad ernes atebydd | Recognizance of respondent's surety",fl411-bil.pdf,application/pdf,164276,10/1997,26,1,false,1,293,2017-03-17
-294,FL415,"Statement of service",fl415-eng.pdf,application/pdf,593445,10/1997,8,1,false,1,294,2017-03-17
-295,FL415,"Datganiad Cyflwyno | Statement of Service",fl415-bil.pdf,application/pdf,124180,10/1997,26,1,false,1,295,2017-03-17
-296,FL700,"Domestic violence injunctions under the Family Law Act - How can it help me?",fl700-eng.pdf,application/pdf,277169,07/2016,8,2,false,1,296,2017-03-17
-297,Form 110,"Certificate for enforcement in a foreign country under [s.10 of the Administration of Justice Act 1920] [s.10 of the Foreign Judgments (Reciprocal Enforcement) Act 1933] [s.12 of the Civil Jurisdiction and Judgments Act 1982] (CPR 74.12 and PD 74A para.7)",form110-eng.doc,application/msword,33792,04/2016,8,1,false,1,297,2017-03-17
-298,Form 111,"Certificate of the enforcement in Scotland or Northern Ireland of a money judgment of the High Court or of the County Court (s.18 of and Schedule 6 to the Civil Jurisdiction and Judgments Act 1982) (CPR 74.17 and PD 74A para.8.2)",form111-eng.doc,application/msword,31744,04/2016,8,1,false,1,298,2017-03-17
-299,Form 112,"Certificate annexed to a sealed copy of judgment of the High Court or of the County Court for enforcement of non-money provisions in Scotland or Northern Ireland (s.18 of and Schedule 7 to the Civil Jurisdiction and Judgments Act 1982) (CPR 74.18 and PD 74A para.8.3)",form112-eng.doc,application/msword,31744,04/2016,8,1,false,1,299,2017-03-17
-328,Getting the best out of the court system,"Getting the best out of the court system. Information for local authorities and other social landlords",possession-claims-eng.pdf,application/pdf,308425,08/2003,8,2,false,1,328,2017-03-17
-335,Jury Summons Form,"Jury Summons Form",jury-summons-eng.pdf,application/pdf,98839,07/2014,8,1,false,1,335,2017-03-17
-336,Jury Summons Guide,"Guide to Jury Summons",jury-summons-guide-eng.pdf,application/pdf,82601,07/2014,8,4,false,1,336,2017-03-17
-337,N1,"Ffurflen hawlio (RTS rhan 7) | Claim form (CPR part 7)",n1-bil.pdf,application/pdf,85103,06/2016,26,1,false,1,337,2017-03-17
-338,N1,"Claim form (CPR Part 7)",n1-eng.pdf,application/pdf,83171,06/2016,8,1,false,1,338,2017-03-17
-340,N1(CC),"Claim Form",n001(cc)-eng.pdf,application/pdf,39271,04/2014,8,1,false,1,340,2017-03-17
-342,N11,"Ffuflen amddiffyniad | Defence form",n011-bil.pdf,application/pdf,152962,04/2006,26,1,false,1,342,2017-03-17
-343,N11,"Defence form",n011-eng.pdf,application/pdf,356407,12/2007,8,1,false,1,343,2017-03-17
-345,N117,"General form of undertaking",n117-eng.pdf,application/pdf,38589,10/2012,8,1,false,1,345,2017-03-17
-346,N117,"Ffurflen Gyffredinol Ymgymeriad",n117-cym.pdf,application/pdf,64359,04/1999,25,1,false,1,346,2017-03-17
-347,N119,"Particulars of claim for possession",n119-eng.pdf,application/pdf,256464,04/2010,8,1,false,1,347,2017-03-17
-350,N119,"Manylion hawliad i feddiannu (adeilad preswyl ar rent) | Particulars of claim for possession (Rented residential premises)",n119-bil.pdf,application/pdf,337635,08/2005,26,1,false,1,350,2017-03-17
-351,N119A,"Notes for guidance to complete particulars of claim",n119a-eng.pdf,application/pdf,154523,04/2010,8,4,false,1,351,2017-03-17
-355,N11B,"Defence form (Accelerated possession procedure) (Assured shorthold tenancy)",n011b-eng.pdf,application/pdf,318019,08/2011,8,1,false,1,355,2017-03-17
-358,N11B,"Ffurflen Amddiffyn (trefn meddiannu gyflymedig) (tenantiaeth fyrddaliadol sicr) | Defence form (Accelerated possession procedure) (Assured shorthold tenancy)",n011b-bil.pdf,application/pdf,111954,08/2011,26,1,false,1,358,2017-03-17
-359,N11D,"Defence form (Demotion of tenancy) (Suspension of right to buy)",n011d-eng.pdf,application/pdf,130288,08/2005,8,1,false,1,359,2017-03-17
-361,N11D,"Ffurflen amddiffyn (israddio tenantiaeth) | Defence form (Demotion of tenancy)",n011d-bil.pdf,application/pdf,738800,08/2005,26,1,false,1,361,2017-03-17
-362,N11M,"Ffurflen Amddiffyniad (eiddo preswyl dan forgais) | Defence form (Mortgaged residential premises)",n011m-bil.pdf,application/pdf,453986,04/2006,26,1,false,1,362,2017-03-17
-363,N11M,"Defence form (Mortgaged residential premises)",n011m-eng.pdf,application/pdf,521714,04/2006,8,1,false,1,363,2017-03-17
-366,N11R,"Ffurflen Amddiffyniad (adeilad preswyl ar rent) | Defence form (Rented residential premises)",n011r-bil.pdf,application/pdf,463710,04/2006,26,1,false,1,366,2017-03-17
-367,N11R,"Defence form",n011r-eng.pdf,application/pdf,490064,04/2006,8,1,false,1,367,2017-03-17
-369,N120,"Manylion hawliad i feddiannu (eiddo preswyl dan forgais) | Particulars of claim for possession (Mortgaged residential premises)",n120-bil.pdf,application/pdf,248763,10/2005,26,1,false,1,369,2017-03-17
-371,N120,"Particulars of claim (Mortgaged residential premises)",n120-eng.pdf,application/pdf,171091,08/2015,8,1,false,1,371,2017-03-17
-372,N121,"Manylion hawliad i feddiannu (tresmaswyr) | Particulars of claim for possession (Trespassers)",n121-bil.pdf,application/pdf,88368,10/2001,26,1,false,1,372,2017-03-17
-373,N121,"Particulars of claim (Trespassers)",n121-eng.pdf,application/pdf,41660,10/2001,8,1,false,1,373,2017-03-17
-375,N122,"Particulars of claim for demotion order/suspension of right to buy",n122-eng.pdf,application/pdf,123349,04/2010,8,1,false,1,375,2017-03-17
-377,N122,"Manylion hawliad gorchymyn israddio | Particulars of claim for demotion order",n122-bil.pdf,application/pdf,203751,08/2005,26,1,false,1,377,2017-03-17
-378,N130,"Cais am orchymyn meddiannu interim | Application for an interim possession order",n130-bil.pdf,application/pdf,221790,12/2002,26,1,false,1,378,2017-03-17
-379,N130,"Application for possession including application for interim possession order",n130-eng.pdf,application/pdf,166548,05/2014,8,1,false,1,379,2017-03-17
-380,N133,"Datganiad tyst y diffynnydd i wrthwynebu gwneud gorchymyn meddiannu interim | Witness statement of the defendant to oppose the making of an interim possession order",n133-bil.pdf,application/pdf,143597,12/2002,26,1,false,1,380,2017-03-17
-381,N133,"Witness statement of the defendant to oppose the making of an interim possession order",n133-eng.pdf,application/pdf,59327,12/2002,8,1,false,1,381,2017-03-17
-382,N15,"Acknowledgment of service (Arbitration claim)",n015-eng.pdf,application/pdf,404783,03/2002,8,1,false,1,382,2017-03-17
-383,N15,"Cydnabyddiad Cyflwyno (hawliad cyflafareddu) | Acknowledgment of service (Arbitration claim)",n015-bil.pdf,application/pdf,155311,03/2002,26,1,false,1,383,2017-03-17
-386,N150,"Holiadur Dyrannu | Allocation questionnaire",n150-bil.pdf,application/pdf,341751,11/2011,26,1,false,1,386,2017-03-17
-387,N151,"Holiadur Dyrannu (swm i'w benderfynu gan y llys) | Allocation questionnaire (Amount to be decided by the court)",n151-bil.pdf,application/pdf,351898,04/2008,26,1,false,1,387,2017-03-17
-388,N161,"Appellant's notice (all appeals except small claims track appeals and appeals to the Family Division of the High Court)",n161-eng.pdf,application/pdf,588066,10/2016,8,1,false,1,388,2017-03-17
-391,N161,"Hysbysiad apelydd (Pob apel ac eithrio apeliadau ar y trac hawliadau bychain) | Appellant's notice (All appeals except small claims track appeals)",n161-bil.pdf,application/pdf,139380,06/2016,26,1,false,1,391,2017-03-17
-392,N161A,"Guidance notes on completing form N161 - Appellant's notice (all appeals except small claims track appeals or appeals to the Family Division of the High Court)",n161a-eng.pdf,application/pdf,316437,10/2016,8,4,false,1,392,2017-03-17
-393,N161A,"Nodiadau cyfarwyddiadol ar gyfer llenwi rhybudd yr apelydd",n161a-cym.pdf,application/pdf,40443,10/2001,25,2,false,1,393,2017-03-17
-394,N161B,"Important Notes for Respondent",n161b-eng.pdf,application/pdf,24597,04/2000,8,3,false,1,394,2017-03-17
-396,N162,"Respondent's notice (For all appeals except appeals to the Family Division of the High Court)",n162-eng.pdf,application/pdf,97038,10/2016,8,1,false,1,396,2017-03-17
-398,N162A,"Guidance notes on completing the respondent's notice",n162a-eng.pdf,application/pdf,292215,04/2007,8,4,false,1,398,2017-03-17
-400,N163,"Skeleton arguments",n163-eng.pdf,application/pdf,63470,04/2000,8,1,false,1,400,2017-03-17
-401,N163,"Dadl fframwaith | Skeleton argument",n163-bil.pdf,application/pdf,140460,12/2004,26,1,false,1,401,2017-03-17
-402,N16A,"Application for injunction (General form)",n016a-eng.pdf,application/pdf,400112,05/2014,8,1,false,1,402,2017-03-17
-405,N16A,"Cais am Waharddeb (Ffurflen Gyffredinol) | Application for injunction (General form)",n016a-bil.pdf,application/pdf,298728,04/2007,26,1,false,1,405,2017-03-17
-406,N170,"Listing questionnaire (Pre-trial checklist)",n170-eng.pdf,application/pdf,111054,05/2014,8,1,false,1,406,2017-03-17
-408,N170,"Holiadur rhestru (Rhestr wirio cyn-treial) | Listing questionnaire (Pre-trial checklist)",n170-bil.pdf,application/pdf,419313,12/2002,26,1,false,1,408,2017-03-17
-409,N1A,"Nodiadau i'r hawlydd ar lenwi ffurflen hawlio | Notes for claimant on completing a claim form",n1a-bil.pdf,application/pdf,147823,07/2014,26,3,false,1,409,2017-03-17
-416,N1FD,"Notes for defendant (Consumer Credit Act cases)",n001(fd)-eng.pdf,application/pdf,40824,06/2014,8,3,false,1,416,2017-03-17
-417,N205A,"Notice of issue (Specified amount)",n205a-eng.pdf,application/pdf,329706,04/2006,8,1,false,1,417,2017-03-17
-418,N2,"Claim Form (Probate)",n002-eng.pdf,application/pdf,242688,05/2014,8,1,false,1,418,2017-03-17
-419,N2,"Ffurflen Hawliad (Hawliad Profiant) | Claim Form (probate claim)",n002-bil.pdf,application/pdf,140815,10/2001,26,1,false,1,419,2017-03-17
-420,N20,"Gwys Tyst | Witness summons",n020-bil.pdf,application/pdf,156452,09/2002,26,1,false,1,420,2017-03-17
-421,N20,"Witness summons",n020-eng.pdf,application/pdf,50705,05/2014,8,1,false,1,421,2017-03-17
-422,N205D,"Notice of issue(Probate claim)",n205d-eng.pdf,application/pdf,26509,10/2001,8,1,false,1,422,2017-03-17
-423,N208,"Ffurflen hawlio (RTS Rhan 8) | Claim form (CPR Part 8)",n208-bil.pdf,application/pdf,31765,06/2016,26,1,false,1,423,2017-03-17
-424,N208,"Claim form (CPR Part 8)",n208-eng.pdf,application/pdf,75915,06/2016,8,1,false,1,424,2017-03-17
-428,N208(CC),"Claim form (Part 8)",n208(cc)-eng.pdf,application/pdf,37680,04/2014,8,1,false,1,428,2017-03-17
-429,N208A,"Nodiadau i'r hawlydd ar lenwi ffurflen hawlio Rhan 8 | Notes for claimant (Part 8 claim form)",n208a-bil.pdf,application/pdf,137471,04/1999,26,3,false,1,429,2017-03-17
-431,N208A,"Notes for claimant  (Part 8 claim form)",n208a-eng.pdf,application/pdf,47310,06/2014,8,3,false,1,431,2017-03-17
-432,N208C,"Nodiadau i'r diffynnydd (ffurflen hawlio Rhan 8.) | Notes for defendant (Part 8 claim form)",n208c-bil.pdf,application/pdf,268616,08/2008,26,3,false,1,432,2017-03-17
-434,N208C,"Notes for defendant (Part 8 claim form)",n208c-eng.pdf,application/pdf,82124,06/2009,8,3,false,1,434,2017-03-17
-435,N208C(CC),"Notes for Defendant on Replying to the Part 8 Claim Form",n208c(cc)-eng.pdf,application/pdf,202539,10/2008,8,3,false,1,435,2017-03-17
-436,N210,"Cydnabyddiad Cyflwyno (Hawliadau rhan 8) | Acknowledgment of service (Part 8 claim)",n210-bil.pdf,application/pdf,893151,05/2007,26,1,false,1,436,2017-03-17
-437,N210,"Acknowledgment of service (CPR Part 8)",n210-eng.pdf,application/pdf,55891,03/2001,8,1,false,1,437,2017-03-17
-439,N210(CC),"Acknowledgment of service (Part 8)",n210(cc)-eng.pdf,application/pdf,37383,04/2014,8,1,false,1,439,2017-03-17
-440,N210A,"Cydnabyddiad Cyflwyno (Rhan 8 - Hawliad costau'n unig) | Acknowledgment of service (Part 8 costs - only claim)",n210a-bil.pdf,application/pdf,104258,12/2002,26,1,false,1,440,2017-03-17
-441,N210A,"Acknowledgment of service (Part 8 costs - only claim)",n210a-eng.pdf,application/pdf,146344,12/2002,8,1,false,1,441,2017-03-17
-442,N211,"Ffurflen hawlio (Hawliadau ychwanegol - RTS Rhan 20) | Claim form (Additional claims - CPR Part 20)",n211-bil.pdf,application/pdf,115887,06/2016,26,1,false,1,442,2017-03-17
-443,N211,"Claim form (Additional claims - CPR Part 20)",n211-eng.pdf,application/pdf,74098,06/2016,8,1,false,1,443,2017-03-17
-445,N211(CC),"Claim Form (Part 20)",n211(cc)-eng.pdf,application/pdf,58075,04/2014,8,1,false,1,445,2017-03-17
-446,N211A,"Notes for claimant (Part 20 claim form)",n211a-eng.pdf,application/pdf,54123,04/2013,8,3,false,1,446,2017-03-17
-449,N211C,"Nodiadau i'r diffynnydd ar ateb y ffurflen hawlio Rhan 20 | Notes for defendant (Part 20 claim form)",n211c-bil.pdf,application/pdf,159559,01/2003,26,3,false,1,449,2017-03-17
-451,N211C,"Notes for defendant (Part 20 claim form)",n211c-eng.pdf,application/pdf,31769,10/2002,8,3,false,1,451,2017-03-17
-452,N211C(CC),"Notes for Part 20 Defendant on Replying to the Part 20 Claim Form",n211c(cc)-eng.pdf,application/pdf,163243,04/2011,8,3,false,1,452,2017-03-17
-453,N213,"Cydnabyddiad Cyflwyno (Hawliad Rhan 20) | Acknowledgment of Service (Part 20 claim)",n213-bil.pdf,application/pdf,207121,04/2006,26,1,false,1,453,2017-03-17
-454,N213,"Acknowledgment of Service(Part 20 claim)",n213-eng.pdf,application/pdf,383427,10/2008,8,1,false,1,454,2017-03-17
-456,N213(CC),"Acknowledgment of service (Part 20 claim) - Commercial Court",n213(cc)-eng.pdf,application/pdf,37698,04/2014,8,1,false,1,456,2017-03-17
-459,N215,"Certificate of service",n215-eng.pdf,application/pdf,273887,10/2014,8,1,false,1,459,2017-03-17
-460,N215,"Tystysgrif cyflwyno | Certificate of service",n215-bil.pdf,application/pdf,82864,09/2011,26,1,false,1,460,2017-03-17
-461,N218,"Rhybudd cyflwyno i bartner | Notice of service on partner",n218-bil.pdf,application/pdf,62388,04/1999,26,1,false,1,461,2017-03-17
-462,N218,"Notice of service on a partner",n218-eng.pdf,application/pdf,14052,04/1999,8,1,false,1,462,2017-03-17
-463,N224,"Request for service out of England and Wales through the court",n224-eng.pdf,application/pdf,46532,04/1999,8,1,false,1,463,2017-03-17
-464,N224,"Cais i gyflwyno'r tu allan i Gymru a Lloegr drwy'r llys | Request for service out of England and Wales through the court",n224-bil.pdf,application/pdf,120379,10/2008,26,1,false,1,464,2017-03-17
-465,N225,"Request for judgment and reply to admission (Specified amount)",n225-eng.pdf,application/pdf,261025,04/2013,8,1,false,1,465,2017-03-17
-467,N225,"Cais am Ddyfarniad ac ateb i addefiad (swm penodol) | Request for judgment and reply to admission (specified amount)",n225-bil.pdf,application/pdf,583876,04/2006,26,1,false,1,467,2017-03-17
-468,N227,"Cais am Ddyfarniad trwy ddiffyg (y swm i'w benderfynu gan y llys) | Request for judgment by default (Amount to be decided by the court)",n227-bil.pdf,application/pdf,160433,04/2006,26,1,false,1,468,2017-03-17
-469,N227,"Request for judgment by default (Amount to be decided by the court)",n227-eng.pdf,application/pdf,266564,04/2006,8,1,false,1,469,2017-03-17
-471,N228,"Notice of admission - return of goods (Hire-purchase or conditional sale)",n228-eng.pdf,application/pdf,377549,04/2006,8,1,false,1,471,2017-03-17
-472,N235,"Tystysgrif addasrwydd cyfaill cyfreitha | Certificate of suitability of litigation friend",n235-bil.pdf,application/pdf,111916,03/2003,26,1,false,1,472,2017-03-17
-473,N235,"Certificate of suitability of litigation friend",n235-eng.pdf,application/pdf,705661,10/2007,8,1,false,1,473,2017-03-17
-475,N24,"General form of Judgment or order",n024-eng.pdf,application/pdf,392894,04/1999,8,1,false,1,475,2017-03-17
-476,N242,"Hysbysiad talu i'r llys (dan orchymyn - Rhan 37) | Notice of payment into court (Under order - Part 37)",n242-bil.pdf,application/pdf,88642,04/2003,26,1,false,1,476,2017-03-17
-477,N242,"Notice of payment into court (Under order - part 37)",n242-eng.pdf,application/pdf,117412,05/2012,8,1,false,1,477,2017-03-17
-478,N242A,"Notice of offer to settle (Section 1 - Part 36)",n242a-eng.pdf,application/pdf,108847,06/2015,8,1,false,1,478,2017-03-17
-479,N242A,"Hysbysiad o gynnig i setlo (Adran 1 - Rhan 36) | Notice of offer to settle (Section 1 - Part 36)",n242a-bil.pdf,application/pdf,101206,08/2011,26,1,false,1,479,2017-03-17
-483,N244,"Rhybudd cyflwyno cais | Application notice",n244-bil.pdf,application/pdf,125609,06/2016,26,1,false,1,483,2017-03-17
-484,N244,"Application notice",n244-eng.pdf,application/pdf,75180,06/2016,8,1,false,1,484,2017-03-17
-485,N244(CC),"Application Notice",n244(cc)-eng.pdf,application/pdf,71573,04/2014,8,1,false,1,485,2017-03-17
-486,N245,"Application for suspension of a warrant and/or variation of an order",n245-eng.pdf,application/pdf,305315,06/2016,8,1,false,1,486,2017-03-17
-488,N245,"Cais i ohirio gwarant a/neu i amrywio gorchymyn | Application for suspension of a warrant and/or variation of an order",n245-bil.pdf,application/pdf,199596,06/2016,26,1,false,1,488,2017-03-17
-490,N251,"Notice of funding of case or claim",n251-eng.pdf,application/pdf,291145,10/2009,8,1,false,1,490,2017-03-17
-491,N251,"Hysbysiad ynghylch ariannu achos neu hawliad | Notice of funding of case or claim",n251-bil.pdf,application/pdf,300366,04/2004,26,1,false,1,491,2017-03-17
-492,N252,"Notice of commencement of assessment",n252-eng.pdf,application/pdf,16802,12/1999,8,1,false,1,492,2017-03-17
-494,N253,"Notice of amount allowed on provisional assessment (Legal Aid only)",n253-eng.pdf,application/pdf,77855,07/2000,8,1,false,1,494,2017-03-17
-496,N253,"Rhybudd o'r Swm a ganiateir ar Asesiad Dros Dro | Notice of amount allowed on provisional assessment",n253-bil.pdf,application/pdf,57628,02/2002,26,1,false,1,496,2017-03-17
-497,N254,"Request for a default costs certificate",n254-eng.pdf,application/pdf,37058,05/2014,8,1,false,1,497,2017-03-17
-499,N254,"Cais am Dystysgrif Costau Diffygdalu | Request for a default costs certificate",n254-bil.pdf,application/pdf,950,07/2002,26,1,false,1,499,2017-03-17
-500,N255(CC),"Default costs certificate (County Court)",n255(cc)-eng.pdf,application/pdf,205479,04/2006,8,1,false,1,500,2017-03-17
-501,N255(HC),"Default costs certificate (High Court)",n255(hc)-eng.pdf,application/pdf,163514,04/2006,8,1,false,1,501,2017-03-17
-502,N256(CC),"Final costs certificate (County Court)",n256(cc)-eng.pdf,application/pdf,207466,04/2006,8,1,false,1,502,2017-03-17
-503,N256(HC),"Final costs certificate (High Court)",n256(hc)-eng.pdf,application/pdf,168353,04/2006,8,1,false,1,503,2017-03-17
-504,N258,"Request for provisional/general detailed assessment",n258-eng.pdf,application/pdf,55282,05/2014,8,1,false,1,504,2017-03-17
-506,N258,"Cais am Wrandawiad Asesu Manwl (ffurflen gyffredinol) | Request for detailed assessment hearing (General form)",n258-bil.pdf,application/pdf,103975,07/2000,26,1,false,1,506,2017-03-17
-507,N258A,"Request for detailed assessment (legal aid/Legal Services Commission only)",n258a-eng.pdf,application/pdf,27493,04/2013,8,1,false,1,507,2017-03-17
-509,N258A,"Cais am asesiad manwl (Y Comisiwn Gwasanaethau Cyfreithiol/Cymorth Cyfreithiol yn unig) | Request for detailed assessment (Legal aid/Legal Services Commission only)",n258a-bil.pdf,application/pdf,135686,07/2000,26,1,false,1,509,2017-03-17
-510,N258B,"Request for detailed assessment (Costs payable out of a fund other than the Community Legal Service Fund)",n258b-eng.pdf,application/pdf,25168,04/2013,8,1,false,1,510,2017-03-17
-512,N258B,"Cais am asesiad manwl (Costau'n daladwy o gronfa ar wahân i Gronfa'r Gwasanaeth Cyfreithiol Cymunedol) | Request for detailed assessment (Costs payable out of a fund other than the Community Legal Service Fund)",n258b-bil.pdf,application/pdf,134876,07/2000,26,1,false,1,512,2017-03-17
-513,N258C,"Request for detailed assessment hearing pursuant to an order under Part III of the Solicitors Act 1974",n258c-eng.pdf,application/pdf,133449,07/2000,8,1,false,1,513,2017-03-17
-515,N258C,"Cais am wrandawiad asesu manwl yn unol â gorchymyn dan Ran III Deddf Twrneiod 1974 | Request for detailed assessment hearing pursuant to an order under Part III of the Solicitors Act 1974",n258c-bil.pdf,application/pdf,138385,07/2000,26,1,false,1,515,2017-03-17
-516,N259,"Notice of appeal against a detailed assessment (Civil)",n259-eng.pdf,application/pdf,17864,03/2010,8,1,false,1,516,2017-03-17
-517,N260,"Statement of costs (Summary Assessment)",n260-eng.pdf,application/pdf,126536,06/2015,8,1,false,1,517,2017-03-17
-519,N260,"Datganiad Costau(asesiad diannod) | Statement of Costs(summary assessment)",n260-bil.pdf,application/pdf,175966,10/2001,26,1,false,1,519,2017-03-17
-520,N265,"Rhestr Dogfennau: dadleniad safonol | List of documents: standard disclosure",n265-bil.pdf,application/pdf,102574,04/1999,26,1,false,1,520,2017-03-17
-521,N265,"List of documents: standard disclosure",n265-eng.pdf,application/pdf,250657,10/2005,8,1,false,1,521,2017-03-17
-523,N265(CC),"List of documents",n265(cc)-eng.pdf,application/pdf,236275,10/2005,8,1,false,1,523,2017-03-17
-524,N266,"Notice to admit facts/admission of facts",n266-eng.pdf,application/pdf,21269,04/1999,8,1,false,1,524,2017-03-17
-525,N266,"Rhybudd i gydnabod ffeithiau | Notice to admit facts",n266-bil.pdf,application/pdf,950,04/1999,26,1,false,1,525,2017-03-17
-526,N268,"Notice to prove documents at trial",n268-eng.pdf,application/pdf,16914,04/1999,8,1,false,1,526,2017-03-17
-528,N270,"Administration orders - Notes for guidance",n270-eng.pdf,application/pdf,217328,05/2006,8,4,false,1,528,2017-03-17
-529,N270,"Canllawiau (PDF llenwi cais am orchymyn gweinyddu)",n270-cym.pdf,application/pdf,384586,04/1999,25,1,false,1,529,2017-03-17
-532,N279,"Notice of discontinuance",n279-eng.pdf,application/pdf,73640,06/1999,8,1,false,1,532,2017-03-17
-533,N285,"Ffurflen gyffredinol affidafid | General form of affidavit",n285-bil.pdf,application/pdf,32825,04/1999,26,1,false,1,533,2017-03-17
-534,N285,"General form of affidavit",n285-eng.pdf,application/pdf,19800,04/1999,8,1,false,1,534,2017-03-17
-535,N292,"Order on Settlement on behalf of child or patient",n292-eng.pdf,application/pdf,154069,09/2009,8,1,false,1,535,2017-03-17
-536,N293A,"Combined Certificate of Judgment and Request for Writ of Fieri Facias or Writ of Possession",n293a-eng.pdf,application/pdf,357879,04/2014,8,1,false,1,536,2017-03-17
-537,N293A,"Tystysgrif gyfunol o ddyfarniad a chais am writ fieri facias neu writ meddiant | Combined certificate of judgment and request for writ of fieri facias or writ of possession",n293a-bil.pdf,application/pdf,210818,04/2004,26,1,false,1,537,2017-03-17
-538,N294,"Cais yr Hawlydd am Orchymyn Amrywio (heb wrandawiad) | Claimant's application for a variation order (Without hearing)",n294-bil.pdf,application/pdf,64263,06/2004,26,1,false,1,538,2017-03-17
-539,N294,"Claimant's application for a variation order",n294-eng.pdf,application/pdf,21210,04/1999,8,1,false,1,539,2017-03-17
-541,N2A,"Probate Claim - Notes for Claimant on Completing a Claim Form",n002a-eng.pdf,application/pdf,139443,04/2011,8,3,false,1,541,2017-03-17
-542,N2A,"Hawliad Profiant Nodiadau i'r hawlydd ar lenwi ffurflen hawlio | Probate Claim Notes for claimant on completing a claim form",n002a-bil.pdf,application/pdf,106902,10/2001,26,3,false,1,542,2017-03-17
-543,N2B,"Probate Claim - Notes for the Defendant",n002b-eng.pdf,application/pdf,16107,10/2001,8,3,false,1,543,2017-03-17
-544,N2B,"Hawliad Profiant Nodiadau i'r diffynnydd | Probate Claim Notes for the defendant",n002b-bil.pdf,application/pdf,950,10/2001,26,3,false,1,544,2017-03-17
-545,N3,"Acknowledgment of service (probate claim)",n003-eng.pdf,application/pdf,679587,10/2007,8,1,false,1,545,2017-03-17
-546,N3,"Cydnabyddiad Cyflwyno (hawliad profiant) | Acknowledgment of service(probate claim)",n003-bil.pdf,application/pdf,186613,10/2001,26,1,false,1,546,2017-03-17
-547,N316,"Application for order that debtor attend court for questioning",n316-eng.pdf,application/pdf,145054,06/2016,8,1,false,1,547,2017-03-17
-549,N316,"Cais am orchymyn i ddyledwr ddod i'r llys ar gyfer ei holi | Application for order that debtor attend court for questioning",n316-bil.pdf,application/pdf,148999,03/2002,26,1,false,1,549,2017-03-17
-550,N316A,"Cais am orchymyn i swyddog cwmni'r dyledwr ddod i'r llys ar gyfer ei holi | Application for order that officer of the debtor company attend court for questioning",n316a-bil.pdf,application/pdf,176189,03/2002,26,1,false,1,550,2017-03-17
-551,N316A,"Application for order that officer of the debtor company attend court for questioning",n316a-eng.pdf,application/pdf,158229,05/2014,8,1,false,1,551,2017-03-17
-552,N322A,"Application to enforce an award",n322a-eng.pdf,application/pdf,557160,07/2009,8,1,false,1,552,2017-03-17
-553,N322A,"Cais i orfodi dyfarniad | Application to enforce an award",n322a-bil.pdf,application/pdf,731450,07/2009,26,1,false,1,553,2017-03-17
-554,N323,"Cais am warant reolaeth | Request for Warrant of Control",n323-bil.pdf,application/pdf,134454,06/2016,26,1,false,1,554,2017-03-17
-555,N323,"Request for Warrant of Control",n323-eng.pdf,application/pdf,71420,06/2016,8,1,false,1,555,2017-03-17
-557,N324,"Cais am Warant Trosglwyddiad o Nwyddau | Request for Warrant of Delivery of Goods",n324-bil.pdf,application/pdf,90185,04/1999,26,1,false,1,557,2017-03-17
-559,N324,"Request for Warrant of Delivery of Goods",n324-eng.pdf,application/pdf,69490,05/2014,8,1,false,1,559,2017-03-17
-560,N325,"Cais am Warant Meddiannu Tir | Request for Warrant of Possession of Land",n325-bil.pdf,application/pdf,59806,10/2010,26,1,false,1,560,2017-03-17
-562,N325,"Request for Warrant for Possession of Land",n325-eng.pdf,application/pdf,68066,05/2014,8,1,false,1,562,2017-03-17
-563,N336,"Request and result of search in the attachment of earnings index",n336-eng.pdf,application/pdf,29703,04/1999,8,1,false,1,563,2017-03-17
-565,N336,"Cais i gynnal chwiliad yn y mynegai atafaelu enillion, a'r canlyniad | Request for and result of search in the attachment of earnings index",n336-bil.pdf,application/pdf,138987,01/2005,26,1,false,1,565,2017-03-17
-566,N337,"Cais am Orchymyn Atafaelu Enillion | Request for Attachment of Earnings Order",n337-bil.pdf,application/pdf,63775,05/2014,26,1,false,1,566,2017-03-17
-567,N337,"Request for Attachment of Earnings Order",n337-eng.pdf,application/pdf,244029,05/2014,8,1,false,1,567,2017-03-17
-569,N342,"Cais am Wys Dyfarniad | Request for Judgment Summons",n342-bil.pdf,application/pdf,118125,03/2002,26,1,false,1,569,2017-03-17
-570,N342,"Request for Judgment Summons",n342-eng.pdf,application/pdf,98900,03/2002,8,1,false,1,570,2017-03-17
-572,N349,"Cais am orchymyn i'r trydydd parti dalu dyled | Application for Third Party Debt Order",n349-bil.pdf,application/pdf,190240,03/2002,26,1,false,1,572,2017-03-17
-573,N349,"Application for Third Party Debt Order",n349-eng.pdf,application/pdf,230417,05/2014,8,1,false,1,573,2017-03-17
-575,N379,"Cais am orchymyn arwystlo ar dir (RhTS Rhan 73) | Application for Charging Order on Land (CPR Part 73)",n379-bil.pdf,application/pdf,59707,06/2016,26,1,false,1,575,2017-03-17
-576,N379,"Application for Charging Order on Land (CPR Part 73)",n379-eng.pdf,application/pdf,130070,06/2016,8,1,false,1,576,2017-03-17
-577,N380,"Application for Charging Order on Securities (CPR Part 73)",n380-eng.pdf,application/pdf,135247,04/2016,8,1,false,1,577,2017-03-17
-578,N380,"Cais am orchymyn arwystlo ar warannau (RhTS Rhan 73)",n380-cym.pdf,application/pdf,92989,04/2016,25,1,false,1,578,2017-03-17
-581,N434,"Notice of Change of Solicitor",n434-eng.pdf,application/pdf,59603,04/2014,8,1,false,1,581,2017-03-17
-582,N434,"Rhybudd newid cyfreithiwr | Notice of change of solicitor",n434-bil.pdf,application/pdf,73611,07/2003,26,1,false,1,582,2017-03-17
-583,N440,"Notice of application for Time Order by Debtor or Hirer",n440-eng.pdf,application/pdf,57710,04/1999,8,1,false,1,583,2017-03-17
-584,N440,"Hysbysiad cais am orchymyn amser gan ddyledwr neu logwr  | Notice of application for Time Order by Debtor or Hirer",n440-bil.pdf,application/pdf,185452,04/1999,26,1,false,1,584,2017-03-17
-585,N441,"Notification of request for Certificate of Satisfaction or Cancellation",n441-eng.pdf,application/pdf,476176,04/2006,8,1,false,1,585,2017-03-17
-586,N445,"Cais am Ail-godi Gwarant | Request for re-issue of a Warrant",n445-bil.pdf,application/pdf,215458,04/1999,26,1,false,1,586,2017-03-17
-587,N445,"Request for re-issue of warrant",n445-eng.pdf,application/pdf,50411,12/2016,8,1,false,1,587,2017-03-17
-589,N446,"Cais am Ailgychwyn Gorfodaeth neu orchymyn i gael gwybodaeth gan ddyledwr dyfarniad (nid gwarant) | Request for re-issue of enforcement or an order to obtain information from judgment debtor (not warrant)",n446-bil.pdf,application/pdf,102680,03/2002,26,1,false,1,589,2017-03-17
-590,N446,"Request for re-issue of enforcement or an order to obtain information from judgment debtor",n446-eng.pdf,application/pdf,111814,08/2009,8,1,false,1,590,2017-03-17
-594,N461,"Judicial review claim form",n461-eng.pdf,application/pdf,396413,06/2016,8,1,false,1,594,2017-03-17
-598,N461 Notes,"Guidance Notes on Completing the Judicial Review Claim Form",n461-notes-eng.pdf,application/pdf,272524,11/2013,8,4,false,1,598,2017-03-17
-602,N462,"Judicial Review Acknowledgment of service",n462-eng.pdf,application/pdf,191760,07/2015,8,1,false,1,602,2017-03-17
-605,N463,"Judicial Review Application for Urgent Consideration",n463-eng.pdf,application/pdf,104506,09/2015,8,1,false,1,605,2017-03-17
-606,N463,"Adolygiad Barnwrol Cais am ystyriaeth frys | Judicial Review Application for urgent consideration",n463-bil.pdf,application/pdf,181842,03/2002,26,1,false,1,606,2017-03-17
-608,N5,"Claim form for possession of property",n005-eng.pdf,application/pdf,84077,05/2014,8,1,false,1,608,2017-03-17
-610,N5,"Ffurflen hawlio ar gyfer meddiannu eiddo | Claim form for possession of property",n005-bil.pdf,application/pdf,745930,08/2011,26,1,false,1,610,2017-03-17
-611,N56,"Form for replying to an attachment of earnings application (statement of means)",n056-eng.pdf,application/pdf,417312,06/2008,8,1,false,1,611,2017-03-17
-613,N56,"Ffurflen Ateb Cais am Atafaelu Enillion | Form for replying to an attachment of earnings application",n056-bil.pdf,application/pdf,391936,04/2003,26,1,false,1,613,2017-03-17
-614,N5A,"Ffurflen Hawlio ar gyfer osgoi fforffediad | Claim form for relief against forfeiture",n005a-bil.pdf,application/pdf,137242,10/2001,26,1,false,1,614,2017-03-17
-616,N5A,"Claim form for relief against forfeiture",n005a-eng.pdf,application/pdf,53715,05/2014,8,1,false,1,616,2017-03-17
-618,N5B,"Claim form for possession of property (Accelerated procedure) (Assured shorthold tenancy)",n005b-eng.pdf,application/pdf,317265,05/2014,8,1,false,1,618,2017-03-17
-620,N5B,"Ffurflen hawlio ar gyfer meddiannu eiddo (trefn gyflymedig) (tenantiaeth fyrddaliadol sicr) | Claim form for possession of property (Accelerated procedure) (Assured shorthold tenancy)",n5b-bil.pdf,application/pdf,239916,05/2014,26,1,false,1,620,2017-03-17
-622,N54A,"Notice of further attempt at eviction (Specimen form)",n054a-eng.pdf,application/pdf,104470,08/2015,8,1,false,1,622,2017-03-17
-626,N6,"Claim form for demotion of tenancy/suspension of right to buy",n006-eng.pdf,application/pdf,61503,05/2014,8,1,false,1,626,2017-03-17
-627,N6,"Ffurflen hawlio israddio tenantiaeth | Claim form for demotion of tenancy",n006-bil.pdf,application/pdf,130773,06/2004,26,1,false,1,627,2017-03-17
-628,N7,"Notes for defendant - Mortgaged residential premises",n007-eng.pdf,application/pdf,40751,09/2013,8,3,false,1,628,2017-03-17
-629,N7,"Nodiadau i'r diffynnydd (eiddo preswyl ar forgais) | Notes for defendant (Mortgaged residential premises)",n007-bil.pdf,application/pdf,115372,04/2006,26,3,false,1,629,2017-03-17
-631,N77,"Notice as to consequences of disobedience to court order",n077-eng.pdf,application/pdf,9206,05/1999,8,1,false,1,631,2017-03-17
-634,N7A,"Notes for defendant (Rented residential premises claim)",n007a-eng.pdf,application/pdf,101702,04/2013,8,3,false,1,634,2017-03-17
-636,N7A,"Nodiadau i'r diffynnydd - hawliad adeilad preswyl ar rent | Notes for defendant - Rented residential premises claim",n007a-bil.pdf,application/pdf,121025,04/2006,26,3,false,1,636,2017-03-17
-637,N7B,"Notes for defendant - Forfeiture of the lease (Residential premises)",n007b-eng.pdf,application/pdf,40269,09/2013,8,3,false,1,637,2017-03-17
-638,N7B,"Nodiadau i'r diffynnydd - fforffedu'r les (adeilad preswyl) | Notes for defendant - Forfeiture of the lease (Residential premises)",n007b-bil.pdf,application/pdf,132420,04/2006,26,3,false,1,638,2017-03-17
-641,N7D,"Notes for defendant (Demotion/suspension claim)",n007d-eng.pdf,application/pdf,39688,09/2013,8,3,false,1,641,2017-03-17
-642,N7D,"Nodiadau i'r diffynnydd (hawliad israddio) | Notes for defendant (Demotion claim)",n007d-bil.pdf,application/pdf,88137,06/2004,26,3,false,1,642,2017-03-17
-643,N8,"Claim form (Arbitration)",n008-eng.pdf,application/pdf,59172,01/2003,8,1,false,1,643,2017-03-17
-644,N8A,"Arbitration claim - Notes for the claimant",n008a-eng.pdf,application/pdf,58662,04/2011,8,3,false,1,644,2017-03-17
-645,N8B,"Arbitration claim - Notes for the defendant",n008b-eng.pdf,application/pdf,140543,10/2008,8,3,false,1,645,2017-03-17
-647,N9,"Response pack",n009-eng.pdf,application/pdf,266343,04/2014,8,1,false,1,647,2017-03-17
-648,N9,"Pecyn Ymateb | Response pack",n009-bil.pdf,application/pdf,200977,10/2008,26,1,false,1,648,2017-03-17
-649,N9(CC),"Acknowledgment of Service",n009(cc)-eng.pdf,application/pdf,362373,04/2011,8,1,false,1,649,2017-03-17
-651,N92,"Application for an Administration Order",n092-eng.pdf,application/pdf,715787,04/2006,8,1,false,1,651,2017-03-17
-652,N92,"Cais am orchymyn gweinyddu | Application for an Administration Order",n092-bil.pdf,application/pdf,275826,04/2006,26,1,false,1,652,2017-03-17
-653,N93,"List of creditors furnished under the Act of 1971",n093-eng.pdf,application/pdf,25836,04/1999,8,1,false,1,653,2017-03-17
-655,N93,"Rhestr Credydwyr | List of creditors",n093-bil.pdf,application/pdf,147329,04/1999,26,1,false,1,655,2017-03-17
-656,N9A,"Ffurflen addefiad (swm penodol) | Form of admission (Specified amount)",n009a-bil.pdf,application/pdf,245534,04/2006,26,1,false,1,656,2017-03-17
-657,N9A,"Form of admission (Specified Amount)",n009a-eng.pdf,application/pdf,125175,04/2014,8,1,false,1,657,2017-03-17
-659,N9B,"Defence/Counterclaim (Specified amount)",n009b-eng.pdf,application/pdf,351955,04/2013,8,1,false,1,659,2017-03-17
-661,N9B,"Amddiffyniad a Gwrth-hawliad (swm penodol) | Defence and counterclaim (Specified amount)",n009b-bil.pdf,application/pdf,487287,04/2008,26,1,false,1,661,2017-03-17
-663,N9C,"Addefiad (swm amhenodol,hawliadau anariannol a dychwelyd nwyddau) | Admission (Unspecified amount, non-money and return of goods claims)",n009c-bil.pdf,application/pdf,242242,04/2006,26,1,false,1,663,2017-03-17
-664,N9C,"Admission (unspecified amount and non-money claims)",n009c-eng.pdf,application/pdf,368458,04/2006,8,1,false,1,664,2017-03-17
-666,N9D,"Defence/Counterclaim (Unspecified amount and non-money claims)",n009d-eng.pdf,application/pdf,669207,04/2008,8,1,false,1,666,2017-03-17
-668,N9D,"Amddiffyniad a Gwrth-hawliad (symiau amhenodol, hawliadau anari-annol a dychwelyd nwyddau) | Defence and counterclaim (Unspecified amount, non-money and return of goods claim)",n009d-bil.pdf,application/pdf,1299505,04/2008,26,1,false,1,668,2017-03-17
-669,No. 100,"Notice of bail (sched.1- RSC O.79 r.9(7))",no100-eng.doc,application/msword,7168,04/2005,8,1,false,1,669,2017-03-17
-672,No. 109,"Order for reference to the European Court (Sched 1- RSC O.114 r.2)",no109-eng.doc,application/msword,13312,04/2005,8,1,false,1,672,2017-03-17
-677,No. 32,"Order for examination within jurisdiction of witness before trial or hearing (rule 34.8)",no.32-eng.doc,application/msword,28160,04/2016,8,1,false,1,677,2017-03-17
-678,No. 33,"Application for an order for the issue of a letter of request to judicial authorities out of the jurisdiction (rule 34.13 and PD34A para 5)",no.33-eng.doc,application/msword,27136,04/2016,8,1,false,1,678,2017-03-17
-679,No. 34,"Order for the issue of a letter of request to judicial authorities out of the jurisdiction (rule 34.13)",no.34-eng.doc,application/msword,27648,04/2016,8,1,false,1,679,2017-03-17
-680,No. 35,"Draft Letter of request for examination of witness out of jurisdiction (to be filed by a party under rule 34.13(6))",no.35-eng.doc,application/msword,29184,04/2016,8,1,false,1,680,2017-03-17
-681,No. 37,"Order for appointment of special examiner to take evidence of witness out of jurisdiction (rule 34.13(4) and PD34A para 5.8)",no.37-eng.doc,application/msword,29696,04/2016,8,1,false,1,681,2017-03-17
-682,No. 41,"Default judgment upon request in claim relating to detention of goods (rule 12.4(1)(c))",no.41-eng.doc,application/msword,25088,04/2016,8,1,false,1,682,2017-03-17
-683,No. 42,"Default judgment in claim for possession of land (rule 12.4(2)(a))",no042-eng.doc,application/msword,11264,04/2005,8,1,false,1,683,2017-03-17
-684,No. 42A,"Order for possession (sched.1- RSC O.113)",no042a-eng.doc,application/msword,9728,04/2005,8,1,false,1,684,2017-03-17
-685,No. 44,"Part 24 - Judgment for claimant",no.44-eng.doc,application/msword,28160,04/2016,8,1,false,1,685,2017-03-17
-686,No. 44A,"Part 24 - Judgment for defendant",no.44a-eng.doc,application/msword,27136,04/2016,8,1,false,1,686,2017-03-17
-687,No. 45,"Judgment after trial before Judge without Jury (Practice Direction 40B para 14.1(1))",no.45-eng.doc,application/msword,29184,04/2016,8,1,false,1,687,2017-03-17
-688,No. 46,"Judgment after trial before Judge with Jury (Practice Direction 40B para 14.1(2))",no.46-eng.doc,application/msword,28160,04/2016,8,1,false,1,688,2017-03-17
-689,No. 47,"Judgment after trial before a Master or District Judge (PD40B para 14)",no.47-eng.doc,application/msword,26112,04/2016,8,1,false,1,689,2017-03-17
-690,No. 48,"Order after separate trial of issue under rule 3.1(2)(i)",no.48-eng.doc,application/msword,25600,04/2016,8,1,false,1,690,2017-03-17
-691,No. 49,"Judgment against personal representative (PD40B para 14.3)",no.49-eng.doc,application/msword,26624,04/2016,8,1,false,1,691,2017-03-17
-694,No. 52,"Notice of Claim to non-parties (CPR 19.8A(4)(a)(i))",no.52-eng.doc,application/msword,47513,04/2016,8,1,false,1,694,2017-03-17
-695,No. 52A,"Notice of Judgment or Order to non-parties (CPR 19.8(4)(a)(i))",no.52a-eng.doc,application/msword,30208,04/2016,8,1,false,1,695,2017-03-17
-696,No. 53,"Writ of control",no053-eng.doc,application/msword,36352,04/2014,8,1,false,1,696,2017-03-17
-697,No. 54,"Writ of control on order for costs",no054-eng.doc,application/msword,52736,04/2014,8,1,false,1,697,2017-03-17
-699,No. 56,"Writ of control (For part)",no056-eng.doc,application/msword,53248,04/2014,8,1,false,1,699,2017-03-17
-700,No. 57,"Writ of control against personal representative",no057-eng.doc,application/msword,53760,04/2014,8,1,false,1,700,2017-03-17
-701,No. 58,"Writ of fieri facias de bonis ecclesiasticis (sched.1- RSC O.45 r.12)",no058-eng.doc,application/msword,12288,04/2005,8,1,false,1,701,2017-03-17
-702,No. 59,"Writ of sequestrari de bonis ecclesiasticis (sched.1- RSC O.45 r.12)",no059-eng.doc,application/msword,12800,04/2005,8,1,false,1,702,2017-03-17
-703,No. 62,"Writ of fieri facias to enforce Northern Irish or Scottish judgment",no062-eng.doc,application/msword,32768,04/2004,8,1,false,1,703,2017-03-17
-704,No. 63,"Writ of control to enforce foreign registered judgment",no063-eng.doc,application/msword,56832,04/2014,8,1,false,1,704,2017-03-17
-705,No. 64,"Writ of delivery: delivery of goods, damages and costs",no064-eng.doc,application/msword,52736,04/2014,8,1,false,1,705,2017-03-17
-706,No. 65,"Writ of delivery: delivery of goods or value damages and costs",no065-eng.doc,application/msword,29184,04/2004,8,1,false,1,706,2017-03-17
-707,No. 66,"Combined writ of possession and control",no066-eng.doc,application/msword,52224,04/2014,8,1,false,1,707,2017-03-17
-708,No. 66a,"Combined writ of possession and control for costs of action",no066a-eng.doc,application/msword,46080,04/2014,8,1,false,1,708,2017-03-17
-709,No. 67,"Writ of sequestration (rule 81.20(1) and rule 81.27)",no.67-eng.doc,application/msword,27648,04/2016,8,1,false,1,709,2017-03-17
-710,No. 68,"Writ of restitution",no068-eng.doc,application/msword,24064,04/2004,8,1,false,1,710,2017-03-17
-711,No. 69,"Writ of assistance",no069-eng.doc,application/msword,24576,04/2004,8,1,false,1,711,2017-03-17
-712,No. 71,"Notice of extension of writ of control",no071-eng.doc,application/msword,43008,04/2014,8,1,false,1,712,2017-03-17
-716,No. 75,"Charging order to show cause (sched. 1- RSC O.50 rr.1,2 and 4)",no075-eng.doc,application/msword,11264,04/2005,8,1,false,1,716,2017-03-17
-717,No. 76,"Charging order absolute (sched. 1- RSC O.50 rr.3 and 4)",no076-eng.doc,application/msword,12288,04/2005,8,1,false,1,717,2017-03-17
-718,No. 79,"Stop order on capital and income of funds in court (sched. 1- RSC O.50 r.10)",no079-eng.doc,application/msword,11264,04/2005,8,1,false,1,718,2017-03-17
-719,No. 80,"Affidavit/witness statement And stop notice (sched 1- RSC O.50 r.11)",no080-eng.doc,application/msword,12288,04/2005,8,1,false,1,719,2017-03-17
-720,No. 81,"Order on claim to restrain transfer of stock (sched 1- RSC O.50 r.15)",no081-eng.doc,application/msword,11264,04/2005,8,1,false,1,720,2017-03-17
-721,No. 82,"Application for appointment of a receiver (sched. 1- RSC O.51 r.3)",no082-eng.pdf,application/pdf,5967,09/2000,8,1,false,1,721,2017-03-17
-722,No. 83,"Order directing application for appointment of receiver and granting injunction meanwhile (sched. 1- RSC O.51 r.3)",no083-eng.doc,application/msword,11264,04/2005,8,1,false,1,722,2017-03-17
-723,No. 84,"Order appointing receiver by way of equitable execution (Supreme Court Act 1981 s.37; sched. 1- RSC O.51)",no084-eng.doc,application/msword,14848,04/2005,8,1,false,1,723,2017-03-17
-724,No. 85,"Order of committal or other penalty upon finding of contempt of court (sched. 1- RSC O.52)",no085-eng.doc,application/msword,12800,04/2005,8,1,false,1,724,2017-03-17
-726,No. 93,"Order under the evidence (Proceedings in other jurisdictions) Act 1975 (sched. 1- RSC O.70 r.1)",no093-eng.doc,application/msword,23552,04/2005,8,1,false,1,726,2017-03-17
-727,No. 94,"Order for production of documents in marine insurance claim (Part 49D PD para. 7)",no094-eng.doc,application/msword,15872,04/2005,8,1,false,1,727,2017-03-17
-728,No. 95,"Certificate of order against the Crown (sched. 1- RSC O.77 r.15 and s.25 of the Crown Proceedings Act 1947)",no095-eng.doc,application/msword,11264,04/2005,8,1,false,1,728,2017-03-17
-729,No. 96,"Certificate of order for costs against the Crown (sched. 1- RSC O.77 r.15 and s.25 of the Crown Proceedings Act 1947)",no096-eng.doc,application/msword,11264,04/2005,8,1,false,1,729,2017-03-17
-730,No. 97,"Claim form to grant bail (criminal proceedings) (sched.1- RSC O.79 r.9(1))",no097-eng.pdf,application/pdf,5922,09/2000,8,1,false,1,730,2017-03-17
-731,No. 97A,"Claim form to vary arrangements for bail (criminal proceedings) (sched.1- RSC O.79 r.9(1))",no097a-eng.doc,application/msword,20480,04/2005,8,1,false,1,731,2017-03-17
-732,No. 98,"Order to release prisoner on bail (sched.1- RSC O.79 r.9(6) (6A) and (6B))",no098-eng.doc,application/msword,22528,04/2005,8,1,false,1,732,2017-03-17
-733,No. 98A,"Order varying arrangements for bail (sched.1- RSC O.79 r.9(10))",no098a-eng.doc,application/msword,10240,04/2005,8,1,false,1,733,2017-03-17
-734,No. 99,"Order of Court of Appeal to admit prisoner to bail (sched. 1- RSC O.59 r.20(5))",no099-eng.doc,application/msword,10240,04/2005,8,1,false,1,734,2017-03-17
-735,PA1,"Probate application",pa1-eng.pdf,application/pdf,189608,11/2016,8,1,false,1,735,2017-03-17
-736,PA1,"Ffurflen Gais Profiant | Probate application form",pa001-bil.pdf,application/pdf,440959,04/2011,26,1,false,1,736,2017-03-17
-739,PA1S,"Postal search of the Probate records of England and Wales",pa01s-eng-20160223.pdf,application/pdf,91466,03/2016,8,1,false,1,739,2017-03-17
-740,No. 44B,"Order under refusing judgment under Part 24 and giving directions as to the future conduct of the case",no.44b-eng.doc,application/msword,31744,04/2016,8,1,false,1,740,2017-03-17
-741,PA2,"Sut i gael profiant - Canllaw i bobl sy'n gweithredu heb gyfreithiwr",pa002-cym.pdf,application/pdf,220470,08/2014,25,2,false,1,741,2017-03-17
-744,No. 44C,"Order under Part 24 imposing condition of payment into court (rule 3.1(3) and PD 24 paras 5.1 and 5.2)",no.44c-eng.doc,application/msword,31232,04/2016,8,1,false,1,744,2017-03-17
-748,No. 44D,"Order under Part 24 for detailed assessment of solicitor's bill of costs and for judgment on the amount found due thereunder",no.44d-eng.doc,application/msword,28160,04/2016,8,1,false,1,748,2017-03-17
-751,PF1,"Application for time (rule 3.1(2)(a)) (other than an application to extend time for service of a claim form)",pf001-eng.doc,application/msword,30720,04/2016,8,1,false,1,751,2017-03-17
-753,PF102,"Bench warrant",pf102-eng.doc,application/msword,25600,04/2016,8,1,false,1,753,2017-03-17
-754,PF103,"Warrant of committal (general) (rule 81.30)",pf103-eng.doc,application/msword,25088,04/2016,8,1,false,1,754,2017-03-17
-755,PF104,"Warrant of committal (contempt in face of court) (rules 81.16 and 81.30)",pf104-eng.doc,application/msword,25600,04/2016,8,1,false,1,755,2017-03-17
-756,PF105,"Bench warrant (failure of witness to attend)",pf105-eng.doc,application/msword,25600,04/2016,8,1,false,1,756,2017-03-17
-757,PF106,"Warrant of committal {of prisoner) (rule 81.30)",pf106-eng.doc,application/msword,25088,04/2016,8,1,false,1,757,2017-03-17
-759,PF11,"Application for Part 24 Judgment on the whole of a claim or on a particular issue (rule 24.2)",pf011-eng.doc,application/msword,30720,04/2016,8,1,false,1,759,2017-03-17
-760,PF113,"Evidence on Application for Service by an Alternative Method or at an Alternative Place (rules 6.15, 6.27 and PD6A paragraph 9)",pf113-eng.doc,application/msword,28672,04/2016,8,1,false,1,760,2017-03-17
-765,PF130,"Form of advertisement of service by an alternative method (rule 6.15)",pf130-eng.doc,application/msword,27136,04/2016,8,1,false,1,765,2017-03-17
-768,PF141,"Witness statement/affidavit of personal service of judgment or order (rules 81.6 and 81.9)",pf141-eng.doc,application/msword,26112,04/2016,8,1,false,1,768,2017-03-17
-769,PF147,"Application by another party for order declaring that solicitor has ceased to act by reason of death etc. (rule 42.4 and PD42 para 4)",pf147-eng.doc,application/msword,25088,04/2016,8,1,false,1,769,2017-03-17
-770,PF148,"Order declaring that solicitor has ceased to act by reason of death etc. (rule 42.4 and PD42 para 4)",pf148-eng.doc,application/msword,27136,04/2016,8,1,false,1,770,2017-03-17
-771,PF149,"Application by solicitor for declaration that he has ceased to act (rule 42.3 and PD42 para 3)",pf149-eng.doc,application/msword,25088,04/2016,8,1,false,1,771,2017-03-17
-774,PF150,"Order declaring that Solicitor has ceased to act for a party (rule 42.3 and PD42 para 3.3)",pf150-eng.doc,application/msword,26624,04/2016,8,1,false,1,774,2017-03-17
-775,PF152,"Evidence in support of application for examination of a witness and production of documents under the evidence (Proceedings in other jurisdictions) Act 1975 (rule 34.17 and PD34 paragraph  6.3)",pf152-eng.doc,application/msword,33792,04/2016,8,1,false,1,775,2017-03-17
-776,PF153,"Certificate following examination under the evidence (Proceedings in Other jurisdictions) Act 1975 (rule 34.19(2))",pf153-eng.doc,application/msword,31744,04/2016,8,1,false,1,776,2017-03-17
-778,PF16,"Notice of court's proposal to make an order of its own initiative (rules 3.3(2) and 3.3(3))",pf016-eng.doc,application/msword,30720,04/2016,8,1,false,1,778,2017-03-17
-779,PF166,"Certificate as to finality, etc. of Arbitration Award for Enforcement Abroad (Arbitration Act 1996, s.58)",pf166-eng.doc,application/msword,25600,04/2016,8,1,false,1,779,2017-03-17
-780,PF167,"Order to stay proceedings under Section 9 of the Arbitration Act 1996 (rule 62.8)",pf167-eng.doc,application/msword,25600,04/2016,8,1,false,1,780,2017-03-17
-781,PF168,"Order on application to transfer claim from High Court to County Court (sections 40(1) and (2) County Courts Act 1984; High Court and County Court Jurisdiction Order 1991 (as amended); rule 30.3)",pf168-eng.doc,application/msword,26624,04/2016,8,1,false,1,781,2017-03-17
-783,PF17,"Order made on court's own initiative without notice (rule 3.3(4) and (5))",pf017-eng.doc,application/msword,26624,04/2016,8,1,false,1,783,2017-03-17
-784,PF170A,"Application for approval of settlement or compromise for a child or protected party in personal injury or Fatal Accidents Act claim before proceedings are begun (rule 21.10(2) and PD21 paras.5 and 7)",pf170a-eng.doc,application/msword,29696,04/2016,8,1,false,1,784,2017-03-17
-785,PF170B,"Application for approval of settlement or compromise for a child or protected party in personal injury or Fatal Accidents Act claim after proceedings have been issued (rule 21.10(2) and PD21 paras.6.1 and 7)",pf170b-eng.doc,application/msword,26624,04/2016,8,1,false,1,785,2017-03-17
-786,PF172,"Request for directions in respect of funds in court or to be brought into court (rule 21.11 and PD para 8)",pf172-eng.doc,application/msword,25600,04/2005,8,1,false,1,786,2017-03-17
-787,PF177,"Order for partnership membership statement (PD7A para 5B)",pf177-eng.doc,application/msword,26624,04/2016,8,1,false,1,787,2017-03-17
-788,PF179,"Evidence on registration of a Bill of Sale given by way of security for the payment of money (Bills of Sales Act 1878 ss.8 and 10; Bills of Sale Act (1878) Amendment Act 1882 s.10)",pf179-eng.doc,application/msword,27648,04/2016,8,1,false,1,788,2017-03-17
-790,PF180,"Evidence on registration of an Absolute Bill of Sale, Settlement and Deed of Gift (Bills of Sales Act 1878, ss.8 and 10)",pf180-eng.doc,application/msword,26112,04/2016,8,1,false,1,790,2017-03-17
-791,PF181,"Evidence on renewal of registration of a Bill of Sale (Bills of Sale Act 1878, s.11)",pf181-eng.doc,application/msword,25088,04/2016,8,1,false,1,791,2017-03-17
-792,PF182,"Order for extension of time to register a Bill of Sale or an affidavit of renewal thereof (Bills of Sale Act 1878, s.14; PD8A para 10A.3)",pf182-eng.doc,application/msword,25600,04/2016,8,1,false,1,792,2017-03-17
-793,PF183,"Evidence for permission to enter Memorandum of Satisfaction on Bill of Sale (Bills of Sale Act 1878, s.15; PD8A para 11.5)",pf183-eng.doc,application/msword,33280,04/2016,8,1,false,1,793,2017-03-17
-794,PF184,"Claim form for an order that a memorandum of satisfaction be written of the registered copy of a Bill of Sale (Bills of Sale Act 1878, s.15; PD8A para 11.2)",pf184-eng.doc,application/msword,26112,04/2016,8,1,false,1,794,2017-03-17
-795,PF185,"Order for entry of Memorandum of Satisfaction on the registered copy of a Bill of Sale (Bills of Sale Act 1878, s.15; PD8A para 11.5)",pf185-eng.doc,application/msword,25088,04/2016,8,1,false,1,795,2017-03-17
-796,PF186,"Evidence on application to register Assignment of Book Debts (s.344 Insolvency Act 1986; ss.8 and 10 Bills of Sales Act 1878; PD8A para 15B.4)",pf186-eng.doc,application/msword,28672,04/2016,8,1,false,1,796,2017-03-17
-797,PF187,"Application for solicitor's charging order (s.73 Solicitors Act 1974)",pf187-eng.doc,application/msword,25600,04/2016,8,1,false,1,797,2017-03-17
-798,PF188,"Charging order; solicitor's costs (s.73 Solicitors Act 1974)",pf188-eng.doc,application/msword,26624,04/2016,8,1,false,1,798,2017-03-17
-800,PF19,"Group Litigation Order (rule 19.11)",pf019-eng.doc,application/msword,43520,04/2016,8,1,false,1,800,2017-03-17
-801,PF197,"Application for order for transfer from the Royal Courts of Justice to a district registry or vice-versa or from one district registry to another (rule 30.2(4))",pf197-eng.doc,application/msword,26112,04/2016,8,1,false,1,801,2017-03-17
-802,PF198,"Order for transfer from the Royal Courts of Justice to a district registry or vice-versa or from one district registry to another (rule 30.2(4))",pf198-eng.doc,application/msword,26624,04/2016,8,1,false,1,802,2017-03-17
-804,PF2,"Order for time (rule 3.1(2)(a))",pf002-eng.doc,application/msword,26624,04/2016,8,1,false,1,804,2017-03-17
-806,PF205,"Evidence in support of application for permission to execute for costs of previous attempts to enforce judgment (s.15(3) and (4) of the Courts and Legal Services Act 1990)",pf205-eng.doc,application/msword,28160,04/2016,8,1,false,1,806,2017-03-17
-808,PF21,"Order for permission to make an additional claim under rules 20.4(2)(b), 20.5(1) or 20.7(3)(b) and directions following such permission",pf021-eng.doc,application/msword,29184,04/2016,8,1,false,1,808,2017-03-17
-811,PF22,"Notice claiming contribution or indemnity against another defendant (rule 20.6)",pf022-eng.doc,application/msword,33792,04/2016,8,1,false,1,811,2017-03-17
-813,PF23,"Group litigation order",pf023-eng.doc,application/msword,22528,04/2004,8,1,false,1,813,2017-03-17
-815,PF24,"Notice by execution creditor of admission or dispute of title of interpleader claimant",pf024-eng.doc,application/msword,20992,04/2004,8,1,false,1,815,2017-03-17
-818,PF25,"Interpleader application",pf025-eng.doc,application/msword,21504,04/2004,8,1,false,1,818,2017-03-17
-820,PF26,"Interpleader application by an Enforcement Officer",pf026-eng.doc,application/msword,21504,04/2004,8,1,false,1,820,2017-03-17
-822,PF27,"Evidence in support of interpleader application (sched. 1- RSC O.17 r.3(4))",pf027-eng.doc,application/msword,24064,04/2005,8,1,false,1,822,2017-03-17
-824,PF28,"Interpleader order (1) - Claim barred where an Enforcement Officer interpleads",pf028-eng.doc,application/msword,23552,04/2004,8,1,false,1,824,2017-03-17
-826,PF29,"Interpleader order (1a) - Enforcement Officer to withdraw",pf029-eng.doc,application/msword,22016,04/2004,8,1,false,1,826,2017-03-17
-828,PF3,"Application for an extension of time for serving a claim form (rule 7.6)",pf003-eng.doc,application/msword,30720,04/2016,8,1,false,1,828,2017-03-17
-829,PF30,"Interpleader order (2) - Interpleader Claimant substituted as defendant (sched. 1-RSC O.17)",pf030-eng.doc,application/msword,19456,04/2005,8,1,false,1,829,2017-03-17
-831,PF31,"Interpleader order (3) - Trial of issue",pf031-eng.doc,application/msword,23040,04/2004,8,1,false,1,831,2017-03-17
-833,PF32,"Interpleader order (4) - Conditional order for an Enfocement Officer to withdraw and trial of issue",pf032-eng.doc,application/msword,23040,04/2004,8,1,false,1,833,2017-03-17
-836,PF34,"Interpleader order (6) - Summary disposal",pf034-eng.doc,application/msword,24576,04/2004,8,1,false,1,836,2017-03-17
-842,PF4,"Order for an extension of time for serving a claim form (rule 7.6)",pf004-eng.doc,application/msword,31232,04/2016,8,1,false,1,842,2017-03-17
-843,PF43,"Application for security for costs under rule 25.12 and 25.13",pf043-eng.doc,application/msword,25600,04/2016,8,1,false,1,843,2017-03-17
-844,PF44,"Order for security for costs (rules 25.12 and 25.13)",pf044-eng.doc,application/msword,27136,04/2016,8,1,false,1,844,2017-03-17
-845,PF48,"Court record form",pf048-eng.doc,application/msword,33792,04/2016,8,1,false,1,845,2017-03-17
-846,PF49,"Request to parties to state convenient dates for hearing of 1st CMC - Form to be returned with allocation questionnaire",pf049-eng.pdf,application/pdf,3834,08/2000,8,1,false,1,846,2017-03-17
-847,PF5,"Order as to service in claim for possession where premises empty (sched.1- RSC O.10 r.4)",pf005-eng.doc,application/msword,18944,04/2005,8,1,false,1,847,2017-03-17
-848,PF50,"Application for directions (Part 29)",pf050-eng.pdf,application/pdf,5714,08/2000,8,1,false,1,848,2017-03-17
-849,PF52,"Order in the Queen's Bench Division for case and costs management directions in the multi-track (Part 29)",pf052-eng.doc,application/msword,54784,04/2016,8,1,false,1,849,2017-03-17
-850,PF53,"Order for separate trial of an issue (rule 3.1(2)(i))",pf053-eng.doc,application/msword,31744,04/2016,8,1,false,1,850,2017-03-17
-851,PF56,"Request for further information or clarification (Rule 18 and Practice Direction 18)",pf056-eng.doc,application/msword,36352,04/2016,8,1,false,1,851,2017-03-17
-852,PF57,"Application for further information or clarification (Rule 18 and Practice Direction 18, para 5)",pf057-eng.doc,application/msword,27648,04/2016,8,1,false,1,852,2017-03-17
-853,PF58,"Order for further information or clarification (Rule 18 and Practice Direction 18)",pf058-eng.doc,application/msword,27136,04/2016,8,1,false,1,853,2017-03-17
-855,PF63,"Interim Order for Receiver in Pending Claim (CPR Part 69)",pf063-eng.doc,application/msword,26624,04/2016,8,1,false,1,855,2017-03-17
-856,PF67,"Evidence in support of application to make Order of the Supreme Court of the United Kingdom an Order of the High Court of Justice (PD40B 13.2)",pf067-eng.doc,application/msword,28672,04/2016,8,1,false,1,856,2017-03-17
-857,PF68,"Order making an Order of the Supreme Court of the United Kingdom an Order of the High Court of Justice (PD40B para. 13.3)",pf068-eng.doc,application/msword,39424,04/2016,8,1,false,1,857,2017-03-17
-858,PF6A,"Application for permission to serve claim form out of jurisdiction (rules 6.36 and 6.37)",pf006a-eng.doc,application/msword,30208,04/2016,8,1,false,1,858,2017-03-17
-859,PF6B,"Order for permission to serve claim form out of jurisdiction (rule 6.37(5))",pf006b-eng.doc,application/msword,26624,04/2016,8,1,false,1,859,2017-03-17
-862,PF72,"List of exhibits handed in at trial (PD39A paragraph 7)",pf072-eng.doc,application/msword,33792,04/2016,8,1,false,1,862,2017-03-17
-863,PF74,"Order for trial of whole claim or of an issue by Master or District Judge (PD2B para. 4.1)",pf074-eng.doc,application/msword,28672,04/2016,8,1,false,1,863,2017-03-17
-864,PF78,"Solicitor's undertaking as to expenses (rule 34.13(6)(b))",pf078-eng.doc,application/msword,25088,04/2016,8,1,false,1,864,2017-03-17
-866,PF8,"Standard 'Unless' Order or other Order upon failure to file directions questionnaire (rule 26.3, PD 26 para. 2.5, and Form N181)",pf008-eng.doc,application/msword,27648,04/2016,8,1,false,1,866,2017-03-17
-867,PF83,"Judgment on non-attendance of party at trial (rule 39.3 and PD39A paragraph 2)",pf083-eng.doc,application/msword,28160,04/2016,8,1,false,1,867,2017-03-17
-868,PF84A,"Request for Judgment on failure to comply with an order made under rule 3.5(1) (rule 3.5(2))",pf084a-eng.doc,application/msword,27136,04/2016,8,1,false,1,868,2017-03-17
-869,PF84B,"Judgment on request arising from failure to comply with an order made under rule 3.5(1) (rule 3.5(2))",pf084b-eng.doc,application/msword,26624,04/2016,8,1,false,1,869,2017-03-17
-871,PF85B,"Order on application arising from a failure to comply with a condition imposed under rule 3.1(3)",pf085b-eng.doc,application/msword,31232,04/2016,8,1,false,1,871,2017-03-17
-872,PF86A,"Combined request for a Writ of Control, Writ of Possession, Writ of Delivery",pf086a-eng.doc,application/msword,38400,04/2016,8,1,false,1,872,2017-03-17
-873,PF87,"Request for issue of Writ of Sequestration (rule 83.9(3))",pf087-eng.doc,application/msword,26624,04/2016,8,1,false,1,873,2017-03-17
-875,PF9,"Application for judgment for possession of land (rule 12.4(2))",pf009-eng.pdf,application/pdf,5997,08/2000,8,1,false,1,875,2017-03-17
-876,PF91,"Application for permission to issue a writ of possession (rule 83.13)",pf091-eng.doc,application/msword,26112,04/2016,8,1,false,1,876,2017-03-17
-877,PF97,"QB order for sale by an Enforcement Officer by private contract",pf097-eng.doc,application/msword,23040,04/2004,8,1,false,1,877,2017-03-17
-896,PRA Form,"PRA form to be completed for a private room appointment before a Queen's Bench Master",pra-eng-20160115.doc,application/msword,59904,01/2016,8,1,false,1,896,2017-03-17
-897,PRA Cancellation Form,"Notice of cancellation of a private room appointment following lodging of consent order",pra-cancel-eng-20160115.doc,application/msword,39936,01/2016,8,1,false,1,897,2017-03-17
-898,Progress Monitoring Information Sheet,"Progress Monitoring Information Sheet",progress-monitoring-eng.doc,application/msword,19968,04/2005,8,2,false,1,898,2017-03-17
-903,TCC/CM1,"Case Management Information Sheet",tcc-cm1-eng.pdf,application/pdf,93875,03/2002,8,1,false,1,903,2017-03-17
-905,TCC/PTR1,"Pre-trial review questionnaire",tcc-ptr1-eng.pdf,application/pdf,251643,10/2005,8,1,false,1,905,2017-03-17
-906,A61,"Application for an order for parental responsibility prior to adoption abroad (Section 84 Adoption and Children Act 2002)",a61-eng.pdf,application/pdf,407640,11/2016,8,1,false,1,906,2017-03-17
-908,5222,"Your guide to Jury Service",5222-eng.pdf,application/pdf,195958,10/2016,8,4,false,1,908,2017-03-17
-914,MC100,"Make Sure You Can Pay Your Fine. (English)",mc100-eng.pdf,application/pdf,162515,12/2013,8,2,false,1,914,2017-03-17
-916,EX345,"Beiliaid a Swyddogion Gorfodi",ex345-cym.pdf,application/pdf,216186,10/2007,25,2,false,1,916,2017-03-17
-918,PA6,"Beth fydd yn digwydd yn fy nghyfweliad profiant?",pa006-cym.pdf,application/pdf,305538,08/2011,25,2,false,1,918,2017-03-17
-919,ADM15B,"Notes for defendant - Admiralty limitation claim",adm15(b)-eng.pdf,application/pdf,42074,02/2013,8,3,false,1,919,2017-03-17
-921,ADM1C,"Notes for Defendant on Replying to an Admiralty Claim Form",adm001(c)-eng.pdf,application/pdf,37856,02/2013,8,3,false,1,921,2017-03-17
-929,EX342,"Yn dod i wrandawiad llys? Ambell beth y dylech ei wybod - Gwrandawiadau llys yn yr Uchel Lts a'r Llysoedd Sirol",ex342-cym.pdf,application/pdf,130063,04/2005,25,2,false,1,929,2017-03-17
-930,FL700,"Sut gall hyn fy helpu i? Rhan 4 Deddf Cyfraith Teulu 1996",fl700-cym.pdf,application/pdf,278170,04/2016,25,2,false,1,930,2017-03-17
-932,MC100,"Make Sure You Can Pay Your Fine. (Croatian)",mc100-hrv.pdf,application/pdf,515340,12/2013,6,2,false,1,932,2017-03-17
-933,MC100,"Make Sure You Can Pay Your Fine (Greek)",mc100-gre.pdf,application/pdf,524633,12/2013,11,2,false,1,933,2017-03-17
-934,MC100,"Make Sure You Can Pay Your Fine (Gujarati)",mc100-guj.pdf,application/pdf,221796,12/2013,12,2,false,1,934,2017-03-17
-936,MC100,"Make Sure You Can Pay Your Fine (Hindi)",mc100-hin.pdf,application/pdf,226864,12/2013,13,2,false,1,936,2017-03-17
-937,MC100,"Make Sure You Can Pay Your Fine (Kurdish)",mc100-kur.pdf,application/pdf,174696,12/2013,14,2,false,1,937,2017-03-17
-938,MC100,"Make Sure You Can Pay Your Fine (Portuguese)",mc100-por.pdf,application/pdf,545387,12/2013,16,2,false,1,938,2017-03-17
-939,MC100,"Make Sure You Can Pay Your Fine (Punjabi)",mc100-pun.pdf,application/pdf,209038,12/2013,17,2,false,1,939,2017-03-17
-940,MC100,"Make Sure You Can Pay Your Fine (Serbian)",mc100-srp.pdf,application/pdf,545014,12/2013,18,2,false,1,940,2017-03-17
-941,MC100,"Make Sure You Can Pay Your Fine. (Chinese - Simplified)",mc100-zho.pdf,application/pdf,764766,12/2013,4,2,false,1,941,2017-03-17
-942,MC100,"Make Sure You Can Pay Your Fine (Spanish)",mc100-spa.pdf,application/pdf,541542,12/2013,20,2,false,1,942,2017-03-17
-943,MC100,"Make Sure You Can Pay Your Fine. (Chinese - Traditional)",mc100-chi.pdf,application/pdf,891491,12/2013,5,2,false,1,943,2017-03-17
-944,MC100,"Make Sure You Can Pay Your Fine (Turkish)",mc100-tur.pdf,application/pdf,544674,12/2013,23,2,false,1,944,2017-03-17
-945,MC100,"Make Sure You Can Pay Your Fine (Urdu)",mc100-urd.pdf,application/pdf,194660,12/2013,24,2,false,1,945,2017-03-17
-946,EX375,"European Enforcement Order",ex375-eng.pdf,application/pdf,152891,04/2014,8,2,false,1,946,2017-03-17
-947,EX710,"Can I Talk About My Case Outside Court?  A Guide for Family Court Users",ex710-eng.pdf,application/pdf,216966,07/2013,8,4,false,1,947,2017-03-17
-948,N119A,"Canllawiau ar gyfer llenwi manylion y ffurflen hawlio (adeilad preswyl ar rent) | Notes for guidance on completing particulars of claim form (Rented residential premises)",n119a-bil.pdf,application/pdf,98095,10/2005,26,4,false,1,948,2017-03-17
-949,A50 Notes,"Application for a Placement Order (Form A50) - Notes on completing the form",a050-notes-eng.pdf,application/pdf,133430,04/2014,8,3,false,1,949,2017-03-17
-950,A51 Notes,"Application for variation of a placement order (Form A51) - Notes on completing the form",a051-notes-eng.pdf,application/pdf,107004,04/2014,8,3,false,1,950,2017-03-17
-951,A52 Notes,"Application for Revocation of a Placement Order (Form 52) - Notes on Completing the Form",a052-notes-eng.pdf,application/pdf,110051,04/2014,8,3,false,1,951,2017-03-17
-952,A53 Notes,"Application for a Contact Order (Section 26 of the Adoption and Children Act 2002 or an order under section 51A of the Act) (Form A53). Notes on completing the form",a53-notes-eng.pdf,application/pdf,115201,11/2016,8,3,false,1,952,2017-03-17
-953,A54 Notes,"Application for variation or revocation of a Contact Order (Section 27(1)(b) or Section 51B(1)(c) of the Adoption and Children Act 2002) (Form A54). Notes on completing the form",a54-notes-eng.pdf,application/pdf,214465,11/2016,8,3,false,1,953,2017-03-17
-954,A55 Notes,"Application for permission to change a child's surname (Form A55). Notes on completing the form",a55-notes-eng.pdf,application/pdf,214257,11/2016,8,3,false,1,954,2017-03-17
-955,A56 Notes,"Application for permission to remove a child from the United Kingdom (Form A56). Notes on completing the form",a56-notes-eng.pdf,application/pdf,219398,11/2016,8,3,false,1,955,2017-03-17
-956,A57 Notes,"Application for a Recovery Order (Form A57). Notes on completing the form",a57-notes-eng.pdf,application/pdf,229525,11/2016,8,3,false,1,956,2017-03-17
-957,A58 Notes,"Application for an Adoption Order (Form A58). Notes on completing the form",a58-notes-eng.pdf,application/pdf,277877,11/2016,8,3,false,1,957,2017-03-17
-958,A59 Notes,"Application for a Convention Adoption Order (Form A59). Notes on completing the form",a59-notes-eng.pdf,application/pdf,266801,11/2016,8,3,false,1,958,2017-03-17
-959,A60 Notes,"Application for an Adoption Order (excluding a Convention adoption order) where the child is habitually resident outside the British islands and is brought into the United Kingdom for the purposes of adoption (Form A60). Notes on completing the form",a60-notes-eng.pdf,application/pdf,266990,11/2016,8,3,false,1,959,2017-03-17
-960,A61 Notes,"Application for an order for parental responsibilty prior to adoption abroad (Form A61). Notes on completing the form",a61-notes-eng.pdf,application/pdf,278515,11/2016,8,3,false,1,960,2017-03-17
-961,A62 Notes,"Application for a Direction under Section 88(1) of the Adoption and Children Act 2002 (Form A62) ? Notes on Completing the Form",a062-notes-eng.pdf,application/pdf,112556,04/2014,8,3,false,1,961,2017-03-17
-962,A63 Notes,"Application for an Order to Annul a Convention Adoption or Convention Adoption Order or for an Overseas Adoption or Determination Under Section 91 to Cease to be Valid (Form A63) - Notes on Completing the Form",a063-notes-eng.pdf,application/pdf,105923,04/2014,8,3,false,1,962,2017-03-17
-963,FP1A,"Application Under Part 19 of the Family Procedure Rules 2010 - Notes for Applicant on Completing the Application (Form FP1)",fp001a-eng.pdf,application/pdf,485457,04/2011,8,3,false,1,963,2017-03-17
-964,FP1B,"Application Under Part 19 of the Family Procedure 2010 - Notes for Respondent",fp001b-eng.pdf,application/pdf,484575,04/2011,8,3,false,1,964,2017-03-17
-965,CB4,"Special Guardianship - A Guide for Family Court Users",cb004-eng.pdf,application/pdf,313059,04/2014,8,4,false,1,965,2017-03-17
-966,D193,"Ynghylch diddymu",d193-cym.pdf,application/pdf,136546,08/2007,25,1,false,1,966,2017-03-17
-967,D194,"Rydw i eisiau cael diddymiad - Beth ddylwn ei wneud?",d194-cym.pdf,application/pdf,185759,08/2007,25,1,false,1,967,2017-03-17
-968,D195,"Plant a diddymu",d195-cym.pdf,application/pdf,149786,08/2007,25,1,false,1,968,2017-03-17
-969,D196,"Ma'r atebydd wedi ateb fy neiseb",d196-cym.pdf,application/pdf,155807,08/2007,25,1,false,1,969,2017-03-17
-970,D197,"Mae gen i orchymyn amodol",d197-cym.pdf,application/pdf,142596,08/2007,25,1,false,1,970,2017-03-17
-973,Form E Notes,"Notes to Financial Statement for a Financial Order or for Financial Relief After an Overseas Divorce or Dissolution etc",form-e-notes-eng.pdf,application/pdf,142559,04/2014,8,3,false,1,973,2017-03-17
-978,A52 Nodiadau | A52 Notes,"Cais am ddiddymu gorchymyn lleoli (Ffurflen 52). Nodiadau ar lenwi'r ffurflen | Application for revocation of a placement order (Form 52). Notes on completing the form",a052-notes-bil.pdf,application/pdf,199139,04/2011,26,3,false,1,978,2017-03-17
-979,A55 Nodiadau | A55 Notes,"Cais am ganiatâd i newid cyfenw plentyn (Ffurflen A55)Nodiadau ar lenwi'r ffurflen | Application for permission to change a child's surname (Form A55)Notes on completing the form",a055-notes-bil.pdf,application/pdf,100765,12/2005,26,3,false,1,979,2017-03-17
-980,A56 Nodiadau | A56 Notes,"Cais am ganiatâd i symud plentyn o'r Deyrnas Unedig (Ffurflen A56) Nodiadau ar lenwi'r ffurflen | Application for permission to remove a child from the United Kingdom (Form A56) Notes on completing the form",a056-notes-bil.pdf,application/pdf,103114,12/2005,26,3,false,1,980,2017-03-17
-981,A62 Nodiadau | A62 Notes,"Cais am gyfarwyddyd dan adran 88(1) Deddf Mabwysiadu a Phlant 2002 (Ffurflen A62)Nodiadau ar lenwi'r ffurflen | Application for a direction under section 88(1) of the Adoption and Children Act 2002 (Form A62) Notes on completing the form",a062-notes-bil.pdf,application/pdf,98772,12/2005,26,3,false,1,981,2017-03-17
-983,FP1B,"Cais dan Ran 19 Trefniadaeth Teulu 2010. Nodiadau i atebwyr | Application under Part 19 of the Family Procedure 2010. Notes for respondent",fp001b-bil.pdf,application/pdf,169261,04/2011,26,3,false,1,983,2017-03-17
-986,A63 Nodiadau | A63 Notes,"Cais am orchymyn i ddirymu mabwysiad dan y Cytundeb neu orchymyn mabwysiadu dan y Cytundeb neu i fabwysiad tramor neu benderfyniad dan adran 91 beidio â bod yn ddilys (Ffurflen A63) | Application for an order to annul a Convention adoption or Convention adoption order or for an overseas adoption or determination under section 91 to cease to be valid (Form A63)",a063-notes-bil.pdf,application/pdf,106172,12/2005,26,2,false,1,986,2017-03-17
-989,N8A,"Hawliad Cyflafareddu - nodiadau i'r hawlydd | Arbitration claim - Notes for the claimant",n008a-bil.pdf,application/pdf,143970,04/2006,26,3,false,1,989,2017-03-17
-990,Form 201,"Routes of appeal",form-201-eng.pdf,application/pdf,248013,04/2013,8,1,false,1,990,2017-03-17
-991,Form 202,"How to appeal to the Court of Appeal",form202-eng.pdf,application/pdf,181480,10/2016,8,1,false,1,991,2017-03-17
-993,Form 204,"How to prepare an appeal bundle for the Court of Appeal",form204-eng.pdf,application/pdf,210589,02/2017,8,1,false,1,993,2017-03-17
-994,Form 205,"Sources of help for unrepresented appellants",form205-eng-20160115.pdf,application/pdf,335909,12/2015,8,1,false,1,994,2017-03-17
-996,Form 56A,"Court of Appeal Mediation Scheme",form-056a-eng.pdf,application/pdf,38013,10/2012,8,1,false,1,996,2017-03-17
-997,Form 56B,"Court of Appeal mediation scheme - Form 56A and 56B",form-056b-eng.pdf,application/pdf,38768,10/2012,8,1,false,1,997,2017-03-17
-999,A21,"Intercountry adoption and the 1993 Hague Convention",a21-eng.pdf,application/pdf,406191,11/2016,8,2,false,1,999,2017-03-17
-1000,N86,"Interim Charging Order (CPR Part 73)",n086-eng.pdf,application/pdf,130309,04/2016,8,1,false,1,1000,2017-03-17
-1001,Form 206,"Applying for permission to appeal to the Court of Appeal",form206-eng.pdf,application/pdf,160092,10/2016,8,2,false,1,1001,2017-03-17
-1002,Form 207,"Time limits for appealing to the Court of Appeal",form207-eng.pdf,application/pdf,156394,10/2016,8,2,false,1,1002,2017-03-17
-1003,A50 Nodiadau | A50 Notes,"Cais am Orchymyn Lleoli (Ffurflen A50) Nodiadau ar lenwi'r ffurflen | Application for a Placement Order (Form A50) Notes on completing the form",a050-notes-bil.pdf,application/pdf,112182,12/2005,26,3,false,1,1003,2017-03-17
-1004,N87,"Final Charging Order (CPR Part 73)",n087-eng.pdf,application/pdf,126999,04/2016,8,1,false,1,1004,2017-03-17
-1005,A53 Nodiadau | A53 Notes,"Cais am orchymyn cyswllt dan adran 26 Deddf Mabwysiadu a Phlant 2002 (Ffurflen A53). Nodiadau ar lenwi'r ffurflen | Application for a contact order under section 26 of the Adoption and Children Act 2002 (Form A53). Notes on completing the form",a053-notes-bil.pdf,application/pdf,203053,04/2011,26,3,false,1,1005,2017-03-17
-1006,A54 Nodiadau | A54 Notes,"Cais i amrywio neu ddiddymu gorchymyn cyswllt a wnaed dan adran 26 Deddf Mabwysiadu a Phlant 2002 (Ffurflen A54) Nodiadau ar lenwi'r  ffurflen | Application for variation or revocation of a contact order made under section 26 of the Adoption and Children Act 2002 (Form A54) Notes on completing the form",a054-notes-bil.pdf,application/pdf,106074,12/2005,26,3,false,1,1006,2017-03-17
-1007,D50,"Notice of application under section 17 of the Married Women's Property Act 1882 section 66 of the Civil Partnership Act 2004",d050-eng.pdf,application/pdf,83053,11/2014,8,1,false,1,1007,2017-03-17
-1008,D50A,"Notice of proceedings acknowledgement of service under s17 of the Married Women's Property Act 1882 s66 of the Civil Partnership Act 2004",d050a-eng.pdf,application/pdf,355812,04/2012,8,1,false,1,1008,2017-03-17
-1009,A59 Nodiadau | A59 Notes,"Cais am orchymyn mabwysiadu dan y Cytundeb (Ffur en A59). Nodiadau ar lenwi'r ffur en | Application for a Convention adoption order (Form A59). Notes on completing the form",a59-notes-bil.pdf,application/pdf,178525,11/2016,26,3,false,1,1009,2017-03-17
-1011,ADM1,"Claim Form (Admiralty claim in rem)",adm001-eng.pdf,application/pdf,36716,02/2013,8,1,false,1,1011,2017-03-17
-1012,ADM10,"Standard Directions to the Admiralty Marshal",adm010-eng.pdf,application/pdf,76524,03/2002,8,1,false,1,1012,2017-03-17
-1013,ADM11,"Request for caution against Release",adm011-eng.pdf,application/pdf,67284,03/2002,8,1,false,1,1013,2017-03-17
-1014,ADM12,"Request and undertaking for release",adm012-eng.pdf,application/pdf,78074,03/2002,8,1,false,1,1014,2017-03-17
-1015,ADM12A,"Request for withdrawal of caution against Release",adm012(a)-eng.pdf,application/pdf,60608,03/2002,8,1,false,1,1015,2017-03-17
-1016,ADM13,"Application for judgment in default of filing an acknowledgment of service and/or defence or collision statement of case",adm013-eng.pdf,application/pdf,79248,03/2002,8,1,false,1,1016,2017-03-17
-1017,ADM14,"Order for sale of a ship",adm014-eng.pdf,application/pdf,82960,03/2002,8,1,false,1,1017,2017-03-17
-1018,ADM15,"Claim Form (Admiralty limitation claim)",adm015-eng.pdf,application/pdf,44583,02/2013,8,1,false,1,1018,2017-03-17
-1019,ADM16,"Notice of admission of right of claimant to limit liability",adm016-eng.pdf,application/pdf,71445,03/2002,8,1,false,1,1019,2017-03-17
-1020,ADM16A,"Defence to admiralty limitation claim",adm016(a)-eng.pdf,application/pdf,77596,03/2002,8,1,false,1,1020,2017-03-17
-1021,AJ26,"Courts Charter - Magistrates' Courts",aj26-eng.pdf,application/pdf,214668,11/2006,8,2,false,1,1021,2017-03-17
-1022,ADM17,"Application for restricted limitation decree",adm017-eng.pdf,application/pdf,76738,03/2002,8,1,false,1,1022,2017-03-17
-1023,ADM17A,"Application for general limitation decree",adm017(a)-eng.pdf,application/pdf,73674,11/2008,8,1,false,1,1023,2017-03-17
-1024,ADM18,"Restricted limitation decree",adm018-eng.pdf,application/pdf,83174,03/2002,8,1,false,1,1024,2017-03-17
-1025,ADM19,"General limitation decree",adm019-eng.pdf,application/pdf,85293,03/2002,8,1,false,1,1025,2017-03-17
-1026,ADM1A,"Claim Form (Admiralty claim)",adm001(a)-eng.pdf,application/pdf,35796,02/2013,8,1,false,1,1026,2017-03-17
-1027,ADM2,"Acknowledgment of Service (Admiralty claim)",adm002-eng.pdf,application/pdf,346285,04/2006,8,1,false,1,1027,2017-03-17
-1028,ADM20,"Defendant's claim in a limitation claim",adm020-eng.pdf,application/pdf,76562,03/2002,8,1,false,1,1028,2017-03-17
-1029,5222A,"Supporting you through Jury Service",5222a-eng.pdf,application/pdf,153457,11/2016,8,2,false,1,1029,2017-03-17
-1030,ADM3,"Collision statement of case",adm003-eng.pdf,application/pdf,78678,03/2002,8,1,false,1,1030,2017-03-17
-1031,ADM4,"Application and undertaking for arrest and custody",adm004-eng.pdf,application/pdf,79032,03/2002,8,1,false,1,1031,2017-03-17
-1032,ADM5,"Declaration in support of applicationfor warrant of arrest",adm005-eng.pdf,application/pdf,89824,03/2002,8,1,false,1,1032,2017-03-17
-1033,ADM6,"Notice to Consular Officer of intention to apply for warrant of arrest",adm006-eng.pdf,application/pdf,83975,03/2002,8,1,false,1,1033,2017-03-17
-1034,ADM7,"Request for caution against arrest",adm007-eng.pdf,application/pdf,74960,11/2008,8,1,false,1,1034,2017-03-17
-1035,ADM9,"Warrant of Arrest",adm009-eng.pdf,application/pdf,21958,11/2008,8,1,false,1,1035,2017-03-17
-1037,EX660 Notes,"Communicating with the Home Office in Family Proceedings",ex660-notes-eng.pdf,application/pdf,126215,10/2014,8,2,false,1,1037,2017-03-17
-1038,FL701,"Forced Marriage Protection Orders - How can they protect me?",fl701-eng.pdf,application/pdf,168241,07/2015,8,2,false,1,1038,2017-03-17
-1040,EX711,"A yw'r cyfryngau'n cael bod yn bresennol yn fy achos llys?",ex711-cym.pdf,application/pdf,194439,04/2014,25,2,false,1,1040,2017-03-17
-1041,EX715,"Datrys anghydfodau teuluol heb fynd i'r llys",ex715-cym.pdf,application/pdf,512915,08/2009,25,2,false,1,1041,2017-03-17
-1042,Control Order,"Claim form (under Section 11)",co-claim-eng.doc,application/msword,67072,05/2005,8,1,false,1,1042,2017-03-17
-1044,N344,"Request for Warrant of Committal (Judgment summons)",n344-eng.pdf,application/pdf,154038,03/2002,8,1,false,1,1044,2017-03-17
-1045,CB5,"Applications Related to Enforcement of a Child Arrangements Order",cb005-eng.pdf,application/pdf,218717,11/2014,8,2,false,1,1045,2017-03-17
-1046,CB6,"A guide to explain some words and expressions used in private children cases",cb006-eng.pdf,application/pdf,595648,07/2015,8,4,false,1,1046,2017-03-17
-1048,EX725,"Making a Cross Border Claim in the EU",ex725-eng.pdf,application/pdf,196658,04/2014,8,2,false,1,1048,2017-03-17
-1060,N500,"Claim form (Directors disqualification proceedings)",n500-eng.pdf,application/pdf,115772,05/2014,8,1,false,1,1060,2017-03-17
-1063,N501,"Claim form (Directors disqualification proceedings Section 8A application)",n501-eng.pdf,application/pdf,195669,06/2005,8,1,false,1,1063,2017-03-17
-1066,N502,"Acknowledgment of service (Part 8)",n502-eng.pdf,application/pdf,201611,06/2005,8,1,false,1,1066,2017-03-17
-1067,N503,"Acknowledgment of service (Part 8) Section 8A applications",n503-eng.pdf,application/pdf,182465,06/2005,8,1,false,1,1067,2017-03-17
-1068,N504,"Pre-trial checklist (Directors disqualification)",n504-eng.pdf,application/pdf,408552,06/2005,8,1,false,1,1068,2017-03-17
-1069,N164,"Appellant's notice (Small claims track only)",n164-eng.pdf,application/pdf,250413,06/2016,8,1,false,1,1069,2017-03-17
-1070,N219,"Application for European Enforcement Order Certificate (Judgment by agreement/admission/settlement)",n219-eng.pdf,application/pdf,317289,10/2005,8,1,false,1,1070,2017-03-17
-1071,N219A,"Application for European Enforcement Certificate (Judgment in default of a defence or objection)",n219a-eng.pdf,application/pdf,382676,10/2005,8,1,false,1,1071,2017-03-17
-1072,N164,"Hysbysiad apelydd (Trac Hawliadau Bychain yn unig) | Appellant's notice (Small Claims Track only)",n164-bil.pdf,application/pdf,138048,06/2016,26,1,false,1,1072,2017-03-17
-1073,EX107 Info,"Guidance, transcription panel list and prices",ex107-info-eng.pdf,application/pdf,253192,03/2017,8,4,false,1,1073,2017-03-17
-1074,A50,"Application for a placement order (Section 22 Adoption and Children Act 2002)",a050-eng.pdf,application/pdf,616096,11/2014,8,1,false,1,1074,2017-03-17
-1075,A51,"Application for variation of a placement order (Section 23 Adoption and Children Act 2002)",a051-eng.pdf,application/pdf,617447,11/2014,8,1,false,1,1075,2017-03-17
-1076,A52,"Application for Revocation of a Placement Order - Section 24 Adoption and Children Act 2002",a052-eng.pdf,application/pdf,323721,11/2014,8,1,false,1,1076,2017-03-17
-1077,A53,"Application for a Contact Order (Section 26 Adoption and Children Act 2002 or an order for contact or prohibiting contact under section 51A of the Adoption and Children Act 2002)",a53-eng.pdf,application/pdf,612020,11/2016,8,1,false,1,1077,2017-03-17
-1078,A54,"Application for variation or revocation of a Contact Order (Section 27(1)(b) or Section 51B(1)(c) Adoption and Children Act 2002)",a54-eng.pdf,application/pdf,317093,11/2016,8,1,false,1,1078,2017-03-17
-1079,A55,"Application for permission to change a child's surname (Section 28 Adoption and Children Act 2002)",a55-eng.pdf,application/pdf,340449,11/2016,8,1,false,1,1079,2017-03-17
-1080,A56,"Application for permission to remove a child from the United Kingdom (Section 28 Adoption and Children Act 2002)",a56-eng.pdf,application/pdf,346384,11/2016,8,1,false,1,1080,2017-03-17
-1081,A57,"Application for a Recovery Order (Section 41 Adoption and Children Act 2002)",a57-eng.pdf,application/pdf,340420,11/2016,8,1,false,1,1081,2017-03-17
-1082,A58,"Application for an Adoption Order (Section 46 Adoption and Children Act 2002)",a58-eng.pdf,application/pdf,680284,11/2016,8,1,false,1,1082,2017-03-17
-1083,A59,"Application for a Convention Adoption Order (Section 46 Adoption and Children Act 2002)",a59-eng.pdf,application/pdf,387210,11/2016,8,1,false,1,1083,2017-03-17
-1084,A60,"Application for an Adoption Order (excluding a Convention adoption order) where the child is habitually resident outside the British islands and is brought into the United Kingdom for the purposes of adoption (Section 46 Adoption and Children Act 2002)",a60-eng.pdf,application/pdf,674771,11/2016,8,1,false,1,1084,2017-03-17
-1085,A61,"Cais am orchymyn cyfrifoldeb rhiant cyn mabwysiadu dramor (Adran 84 Deddf Mabwysiadu a Phlant 2002) | Application for an order for parental responsibility prior to adoption abroad (Section 84 Adoption and Children Act 2002)",a61-bil.pdf,application/pdf,456686,11/2016,26,1,false,1,1085,2017-03-17
-1086,A62,"Application for a direction under section 88(1) of the Adoption and Children Act 2002",a062-eng.pdf,application/pdf,623727,11/2014,8,1,false,1,1086,2017-03-17
-1087,A63,"Application for an order to annul a Convention adoption or Convention adoption order or for an overseas adoption or determination under section 91 to cease to be valid. Section 89 Adoption and Children Act 2002",a063-eng.pdf,application/pdf,354413,11/2014,8,1,false,1,1087,2017-03-17
-1088,A64,"Application to receive information from court records Section 60(4) Adoption and Children Act 2002",a064-eng.pdf,application/pdf,143522,11/2014,8,1,false,1,1088,2017-03-17
-1089,A65,"Confidential information",a065-eng.pdf,application/pdf,738978,12/2005,8,1,false,1,1089,2017-03-17
-1090,FP1,"Application under Part 19 of the Family Procedure Rules 2010",fp001-eng.pdf,application/pdf,298876,11/2014,8,1,false,1,1090,2017-03-17
-1091,FP2,"Application notice. Part 18 of the Family Procedure Rules 2010",fp002-eng.pdf,application/pdf,316881,11/2014,8,1,false,1,1091,2017-03-17
-1092,FP3,"Application for injunction (General form)",fp003-eng.pdf,application/pdf,288513,11/2014,8,1,false,1,1092,2017-03-17
-1093,FP5,"Acknowledgment of service (Application under Part 19 of the Family Procedure Rules 2010)",fp005-eng.pdf,application/pdf,321284,04/2011,8,1,false,1,1093,2017-03-17
-1094,FP6,"Certificate of service",fp006-eng.pdf,application/pdf,417532,04/2011,8,1,false,1,1094,2017-03-17
-1095,FP8,"Notice of change of solicitor",fp008-eng.pdf,application/pdf,442275,04/2011,8,1,false,1,1095,2017-03-17
-1096,FP9,"Certificate of suitability of litigation friend",fp009-eng.pdf,application/pdf,319666,11/2008,8,1,false,1,1096,2017-03-17
-1097,FP25,"Witness summons",fp25-eng-2016.03.16.pdf,application/pdf,346094,03/2016,8,1,false,1,1097,2017-03-17
-1098,C(PRA2),"Step-Parent Parental  Responsibility Agreement",c(pra002)-eng.pdf,application/pdf,351061,08/2014,8,1,false,1,1098,2017-03-17
-1099,C13A,"Supplement for an Application for a Special Guardianship Order",c013a-eng.pdf,application/pdf,300528,04/2014,8,1,false,1,1099,2017-03-17
-1105,D508,"Deiseb Diddymiad/Dissolution Petition",d508-cym.pdf,application/pdf,750088,08/2007,25,1,false,1,1105,2017-03-17
-1106,D508 Nodiadau | D508 notes,"Deiseb Diddymiad - Nodiadau Canllaw/Dissolution Petition Notes for Guidance",d508-notes-cym.pdf,application/pdf,192104,08/2007,25,4,false,1,1106,2017-03-17
-1112,D13B,"Statement in support to dispense with service of the divorce dissolution nullity (judicial) separation petition on the Respondent",d013b-eng.pdf,application/pdf,363991,04/2012,8,1,false,1,1112,2017-03-17
-1114,D36,"Notice of application for decree nisi to be made absolute or conditional order to be made final",d036-eng.pdf,application/pdf,109429,11/2014,8,1,false,1,1114,2017-03-17
-1115,D8,"Divorce/dissolution/(judicial) separation petition",d8-eng.pdf,application/pdf,507537,06/2016,8,1,false,1,1115,2017-03-17
-1116,D81,"Statement of information for a consent order in relation to a financial remedy",d081-eng.pdf,application/pdf,427959,04/2012,8,1,false,1,1116,2017-03-17
-1117,FL401,"Application for: a non-molestation order/an occupation order",fl401-eng-20160213.pdf,application/pdf,286566,01/2016,8,1,false,1,1117,2017-03-17
-1120,Form F,"Notice of allegation in proceedings for a financial remedy",form-f-eng.pdf,application/pdf,303658,04/2011,8,1,false,1,1120,2017-03-17
-1121,Form i,"Notice of Request for Periodical Payments Order at Same Rate as Order for Maintenance Pending Outcome of Proceedings",form-i-eng.pdf,application/pdf,64023,04/2014,8,1,false,1,1121,2017-03-17
-1122,Form P,"Pension Inquiry Form Information needed when a Pension Sharing Order or Pension Attachment Order may be made",form-p-eng.pdf,application/pdf,402244,04/2011,8,1,false,1,1122,2017-03-17
-1123,Form P1,"Pension sharing annex under [section 24B of the Matrimonial Causes Act 1973] [paragraph 15 of Schedule 5 to the Civil Partnership Act 2004]",p01-eng.pdf,application/pdf,390093,04/2016,8,1,false,1,1123,2017-03-17
-1124,Form P2,"Pension Attachment Annex Under [section 25B or 25C of the Matrimonial Causes Act 1973] [paragraph 25 or 26 of Schedule 5 to the Civil Partnership Act 2004]",p02-eng.pdf,application/pdf,150509,04/2014,8,1,false,1,1124,2017-03-17
-1125,Form E,"Financial Statement: For a Financial Order (Matrimonial Causes Act 1973/Civil Partnership Act 2004)/for Financial Relief After an Overseas Divorce Etc (Part 3 of the Matrimonial and Family Proceedings Act 1984/Schedule 7 to the Civil Partnership Act 2004)",form-e-eng-20160121.pdf,application/pdf,821231,01/2016,8,1,false,1,1125,2017-03-17
-1128,D650,"Notice of application to vary or set aside a financial order (Form E calculator error)",d650-eng-20160121.pdf,application/pdf,217204,01/2016,8,1,false,1,1128,2017-03-17
-1129,D651,"Notice of application to vary or set aside a financial remedy (Form E1 calculator error)",d651-eng-2016.02.24.pdf,application/pdf,205008,02/2016,8,1,false,1,1129,2017-03-17
-1131,D62,"Request for issue of judgment summons",d062-eng.pdf,application/pdf,330994,11/2014,8,1,false,1,1131,2017-03-17
-1134,A51,"Cais i amrywio gorchymyn lleoli. Adran 23 Deddf Mabwysiadu a Phlant 2002 | Application for variation of a placement order Section 23 Adoption and Children Act 2002",a051-bil.pdf,application/pdf,278091,04/2011,26,1,false,1,1134,2017-03-17
-1135,A52,"Cais am ddiddymu gorchymyn lleoli Adran 24 Deddf Mabwysiadu a Phlant 2002 | Application for revocation of a placement order Section 24 Adoption and Children Act 2002",a052-bil.pdf,application/pdf,260286,04/2011,26,1,false,1,1135,2017-03-17
-1136,A53,"Cais am orchymyn cyswllt Adran 26 Deddf Mabwysiadu a Phlant 2002 | Application for a contact order Section 26 Adoption and Children Act 2002",a053-bil.pdf,application/pdf,284280,04/2011,26,1,false,1,1136,2017-03-17
-1137,A54,"Cais i amrywio neu ddiddymu gorchymyn cyswllt (Adran 27(1)(b) Deddf Mabwysiadu a Phlant 2002) | Application for variation or revocation of a contact order (Section 27(1)(b) Adoption and Children Act 2002)",a54-bil.pdf,application/pdf,311952,11/2016,26,1,false,1,1137,2017-03-17
-1138,A55,"Cais am ganiatad i newid cyfenw plentyn (Adran 28 Deddf Mabwysiadu a Phlant 2002) | Application for permission to change a child's surname (Section 28 Adoption and Children Act 2002)",a55-bil.pdf,application/pdf,269452,11/2016,26,1,false,1,1138,2017-03-17
-1139,A56,"Cais am ganiatad i symud plentyn o'r Deyrnas Unedig (Adran 28 Deddf Mabwysiadu a Phlant 2002) | Application for permission to remove a child from the United Kingdom (Section 28 Adoption and Children Act 2002)",a56-bil.pdf,application/pdf,237392,11/2016,26,1,false,1,1139,2017-03-17
-1140,A57,"Cais am orchymyn dychwelyd plentyn (Adran 41 Deddf Mabwysiadu a Phlant 2002) | Application for a recovery order (Section 41 Adoption and Children Act 2002)",a57-bil.pdf,application/pdf,259747,11/2016,26,1,false,1,1140,2017-03-17
-1141,A64,"Cais i dderbyn gwybodaeth o gofnodion y llys Adran 60(4) Deddf Mabwysiadu a Phlant 2002 | Application to receive information from court records Section 60(4) Adoption and Children Act 2002",a064-bil.pdf,application/pdf,157036,12/2005,26,1,false,1,1141,2017-03-17
-1142,A65,"Gwybodaeth gyfrinachol | Confidential information",a065-bil.pdf,application/pdf,177564,12/2005,26,1,false,1,1142,2017-03-17
-1144,D580(F),"Affidafid gan ddeisebydd i gefnogi deiseb i ddiddymu dan Adran 12(g) | Affidavit by petitioner in support of petition for annulment under Section 12(g)",d580f-bil.pdf,application/pdf,132037,12/2005,26,1,false,1,1144,2017-03-17
-1145,Ffurflen A | Form A,"Hysbysiad o gais [o fwriad i fwrw ymlaen a chais] am orchymyn ariannol | Notice of [intention to proceed with] an application for a financial order",form-a-bil.pdf,application/pdf,264621,06/2016,26,1,false,1,1145,2017-03-17
-1146,Ffurflen E | Form E,"Datganiad ariannol | Financial statement",form-e-bil.pdf,application/pdf,349224,04/2012,26,1,false,1,1146,2017-03-17
-1147,N149,"Holiadur Dyrannu (Trac hawliadau bychain) | Allocation questionnaire (Small claims track)",n149-bil.pdf,application/pdf,316594,03/2012,26,1,false,1,1147,2017-03-17
-1150,Form H1,"Statement of costs (financial remedy)",form-h1-eng.pdf,application/pdf,190701,04/2011,8,1,false,1,1150,2017-03-17
-1153,N443,"Cais am dystysgrif boddhad/canslo | Application for a Certificate of Satisfaction or Cancellation",n443-bil.pdf,application/pdf,116033,04/2006,26,1,false,1,1153,2017-03-17
-1154,ADM2,"Cydnabyddiad Cyflwyno (hawliad Morlys)",adm002-cym.pdf,application/pdf,168634,04/2006,25,1,false,1,1154,2017-03-17
-1155,N213(CC),"Cydnabyddiad Cyflwyno (Hawliad Rhan 20) | Acknowledgment of Service (Part 20 claim)",n213(cc)-bil.pdf,application/pdf,198964,04/2006,26,1,false,1,1155,2017-03-17
-1156,N441,"Hysbysiad o Gais am Dystysgrif Bodlonrwydd neu Ddileu | Notification of Request for Certificate of Satisfaction or Cancellation",n441-bil.pdf,application/pdf,216354,04/2006,26,1,false,1,1156,2017-03-17
-1157,N443,"Application for a Certificate of Satisfaction or Cancellation",n443-eng.pdf,application/pdf,388670,04/2006,8,1,false,1,1157,2017-03-17
-1158,Ffurflen H1 | Form H1,"Datganiad costau (rhwymedi ariannol) | Statement of costs (financial remedy)",form-h1-bil.pdf,application/pdf,218711,04/2011,26,1,false,1,1158,2017-03-17
-1159,Ffurflen H | Form H,"Amcangyfrif o gostau (rhwymedi ariannol) | Estimate of costs (financial remedy)",form-h-bil.pdf,application/pdf,193945,04/2011,26,1,false,1,1159,2017-03-17
-1160,N9(CC),"Cydnabyddiad Cyflwyno | Acknowledgment of Service",n009(cc)-bil.pdf,application/pdf,226760,04/2006,26,1,false,1,1160,2017-03-17
-1161,N228,"Hysbysiad o Addefiad - Dychwelyd Nwyddau (hurbrynu neu werthiant amodol)",n228-cym.pdf,application/pdf,227621,04/2006,25,1,false,1,1161,2017-03-17
-1162,N255(CC),"Tystysgrif costau diffygdalu",n255(cc)-cym.pdf,application/pdf,168624,04/2006,25,1,false,1,1162,2017-03-17
-1163,N255(HC),"Tystysgrif costau diffygdalu",n255(hc)-cym.pdf,application/pdf,168550,04/2006,25,1,false,1,1163,2017-03-17
-1164,N256(CC),"Tystysgrif costau terfynol",n256(cc)-cym.pdf,application/pdf,245579,04/2006,25,1,false,1,1164,2017-03-17
-1166,Form 4,"Complaint against a certificated bailiff (Distress for Rent Rules 1988 Rule 8)",form-004-eng.pdf,application/pdf,218624,05/2012,8,1,false,1,1166,2017-03-17
-1187,Costs,"Bill of  Costs for Taxation by Registrar - Court of Appeal (Criminal Division)",co-acd-costs-eng.doc,application/msword,203776,05/2014,8,1,false,1,1187,2017-03-17
-1272,A50,"Cais am orchymyn lleoli. Adran 22 Deddf Mabwysiadu a Phlant 2002 | Application for a placement order Section 22 Adoption and Children Act 2002",a050-bil.pdf,application/pdf,309282,04/2011,26,1,false,1,1272,2017-03-17
-1273,C(PRA2),"Cytundeb Cyfrifoldeb Rhieni i Lys-riant | Step-Parent Parental Responsibility Agreement",c(pra002)-bil.pdf,application/pdf,134391,08/2014,26,1,false,1,1273,2017-03-17
-1274,A59,"Cais am orchymyn mabwysiadu dan y Cytundeb (Adran 46 Deddf Mabwysiadu a Phlant 2002) | Application for a Convention adoption order (Section 46 Adoption and Children Act 2002)",a59-bil.pdf,application/pdf,439346,11/2016,26,1,false,1,1274,2017-03-17
-1275,A62,"Cais am gyfarwyddyd dan adran 88(1) Deddf Mabwysiadu a Phlant 2002 | Application for a direction under section 88(1) of the Adoption and Children Act 2002",a062-bil.pdf,application/pdf,377678,04/2011,26,1,false,1,1275,2017-03-17
-1277,N225A,"Notice of part admission (Specified amount)",n225a-eng.pdf,application/pdf,404423,04/2013,8,1,false,1,1277,2017-03-17
-1278,EX660,"Court request for information to the Home Office",ex660-eng.pdf,application/pdf,329553,05/2016,8,1,false,1,1278,2017-03-17
-1279,EX105,"Request that the costs of transcripts be paid at public expense",ex105-eng.pdf,application/pdf,391870,01/2007,8,1,false,1,1279,2017-03-17
-1310,CH1,"Draft Chancery case management directions (amended February 2017)",ch1-eng.doc,application/msword,79360,02/2017,8,1,false,1,1310,2017-03-17
-1320,CH2,"Additional draft case management directions (amended February 2017)",ch2-eng.doc,application/msword,81408,02/2017,8,1,false,1,1320,2017-03-17
-1330,CH3,"Case and costs management conference",ch3-eng.doc,application/msword,37888,02/2017,8,1,false,1,1330,2017-03-17
-1340,CH4,"Unless order",ch04-eng-2016.04.01.doc,application/msword,36352,02/2016,8,1,false,1,1340,2017-03-17
-1350,CH5,"Order for service out of the jurisdiction",ch5-eng.doc,application/msword,51200,05/2016,8,1,false,1,1350,2017-03-17
-1360,CH6,"Group litigation order",ch06-eng-2016.04.01.doc,application/msword,79872,02/2016,8,1,false,1,1360,2017-03-17
-1370,CH7,"Notice of claim to non-parties",ch07-eng-2016.04.01.doc,application/msword,36352,02/2016,8,1,false,1,1370,2017-03-17
-1380,CH8,"Notice of judgment or order to non-parties",ch08-eng-2016.04.01.doc,application/msword,38400,02/2016,8,1,false,1,1380,2017-03-17
-1390,CH9,"[Witness Statement][Affidavit] in support of application for appointment by the Court of new litigation friend of child claimant (see CPR rules 21.7 and 8, rule 21 4(3) and PD21 paragraph 3.3)",ch09-eng-2016.04.01.doc,application/msword,25600,02/2016,8,1,false,1,1390,2017-03-17
-1400,CH10,"Order for an injunction (intended action)",ch10-eng-2016.04.01.doc,application/msword,36864,02/2016,8,1,false,1,1400,2017-03-17
-1410,CH11,"Order for interim injunction",ch11-eng-2016.04.01.doc,application/msword,53248,02/2016,8,1,false,1,1410,2017-03-17
-1420,CH12,"Stay for alternative dispute resolution",ch12-eng-2016.04.01.doc,application/msword,30720,02/2016,8,1,false,1,1420,2017-03-17
-1430,CH13,"Executors'/Administrators' account (CPR 64.2(b) and 64 PD paragraph 3)",ch13-eng-2016.04.01.doc,application/msword,53248,02/2016,8,1,false,1,1430,2017-03-17
-1440,CH14,"Order stating the result of proceedings on the usual accounts and inquiries in an administration claim",ch14-eng-2016.04.01.doc,application/msword,46080,02/2016,8,1,false,1,1440,2017-03-17
-1450,CH15,"Common form of order for sale",ch15-eng-2016.04.01.doc,application/msword,62976,02/2016,8,1,false,1,1450,2017-03-17
-1460,CH16,"Order nominating person to execute sale",ch16-eng-2016.04.01.doc,application/msword,45056,02/2016,8,1,false,1,1460,2017-03-17
-1470,CH17,"Order for account and inquiry",ch17-eng-2016.04.01.doc,application/msword,46592,02/2016,8,1,false,1,1470,2017-03-17
-1480,CH18,"Order for partnership account and inquiry",ch18-eng-2016.04.01.doc,application/msword,44544,02/2016,8,1,false,1,1480,2017-03-17
-1490,CH19,"Result of partnership account and inquiry",ch19-eng-2016.04.01.doc,application/msword,47104,02/2016,8,1,false,1,1490,2017-03-17
-1500,CH20,"Result of account of money due",ch20-eng-2016.04.01.doc,application/msword,45056,02/2016,8,1,false,1,1500,2017-03-17
-1501,D192,"Ynglyn a gorchmynion/dyfarniadau ymwahaniad (cyfreithiol)",d192-cym.pdf,application/pdf,205368,04/2014,25,2,false,1,1501,2017-03-17
-1503,Lwfansau,"lwfansau rheithwyr",jury-allowances-cym.pdf,application/pdf,165760,05/2011,25,2,false,1,1503,2017-03-17
-1510,CH21,"Order declaring that solicitor has ceased to act",ch21-eng-2016.04.01.doc,application/msword,36352,02/2016,8,1,false,1,1510,2017-03-17
-1512,PA10,"Sut i gychwyn chwiliad sefydlog. Arweiniad i bobl sydd eisiau gwybod am ystad rhywun sydd wedi marw'n ddiweddar",pa010-cym.pdf,application/pdf,178126,02/2012,25,2,false,1,1512,2017-03-17
-1516,UT1 Nodiadau,"Nodiadau i Geisyddion ac Apelyddion Ffurflen UT1 (Hawl Cymdeithasol)",ut001-notes-cym.pdf,application/pdf,100185,11/2008,25,2,false,1,1516,2017-03-17
-1517,UT8 Taflen,"Apelio yn erbyn penderfyniad gan y Siambr Gofal Iechyd, Addysg a Gwasanaethau Cymdeithasol y Tribiwnlys Haen Gyntaf (Iechyd Meddwl) (Apelau o benderfyniadau'r Tribiwnlys Haen Gyntaf)",ut008-leaflet-cym.pdf,application/pdf,227330,07/2008,25,2,false,1,1517,2017-03-17
-1518,UT9 Taflen,"Apelio yn erbyn penderfyniad gan y Siambr Gofal Iechyd, Addysg a Gwasanaethau Cymdeithasol y Tribiwnlys Haen Gyntaf (Anghenion Addysgol Arbennig Cymru) (Apelau o benderfyniadau'r Tribiwnlys Haen Gyntaf)",ut009-leaflet-cym.pdf,application/pdf,229508,06/2009,25,2,false,1,1518,2017-03-17
-1519,UT1 Taflen,"Apelio yn erbyn penderfyniad gan y Siambr Hawl Cymdeithasol y Tribiwnlys Haen Gyntaf (Welsh) (Apelau o benderfyniadau'r Tribiwnlys Haen Gyntaf)",ut001-leaflet-cym.pdf,application/pdf,227992,07/2008,25,2,false,1,1519,2017-03-17
-1520,CH22,"Mortgage: Suspended possession order",ch22-eng-2016.04.01.doc,application/msword,37376,02/2016,8,1,false,1,1520,2017-03-17
-1521,UT1 Nodiadau,"Nodiadau i Geisyddion ac Apelyddion Ffurflen UT1 (Hawl Cymdeithasol)",ut001-notes-cym.doc,application/msword,64512,11/2008,25,2,false,1,1521,2017-03-17
-1523,T118,"Gwybodaeth i ddioddefwyr",t118-cym.pdf,application/pdf,214619,04/2012,25,2,false,1,1523,2017-03-17
-1524,T001,"Taflen esbonio - Canllaw cryno i ddefnyddwyr",t001-cym.pdf,application/pdf,276293,04/2012,25,2,false,1,1524,2017-03-17
-1525,T002,"Cyfeiriadau - Ambell gwestiwn ac ateb",t002-cym.pdf,application/pdf,254084,04/2012,25,2,false,1,1525,2017-03-17
-1527,T006,"Canllawiau ar gyfer llenwi Cais I'r Tribiwnlys Haen Gyntaf (Elusennau) am Ganiatad i Apelio I'r Uwch Dribiwnlys",t006-cym.pdf,application/pdf,236666,04/2012,25,2,false,1,1527,2017-03-17
-1528,EX710,"A gaf i siarad am fy achos y tu allan I'r llys? - Arweiniad i ddefnyddwyr y llys teulu",ex710-cym.pdf,application/pdf,151590,04/2012,25,2,false,1,1528,2017-03-17
-1530,CH23,"Mortgage: Possession order",ch23-eng-2016.04.01.doc,application/msword,35840,02/2016,8,1,false,1,1530,2017-03-17
-1540,CH24,"Order appointing administrator pending determination of probate claim (CPR rule 57 Part 1 and 57PD paragraph 8)",ch24-eng-2016.04.01.doc,application/msword,44032,02/2016,8,1,false,1,1540,2017-03-17
-1547,Mynd i Lys Ynadon,"Mynd i Lys Ynadon - Gwybodaeth ar gyfer pobl gydag anableddau dysgu",going-to-magistrates-court-cym.pdf,application/pdf,443628,02/2013,25,2,false,1,1547,2017-03-17
-1550,CH25,"Security of receiver or of administrator pending determination of a probate claim (CPR PD57 paragraph 8)",ch25-eng-2016.04.01.doc,application/msword,43520,02/2016,8,1,false,1,1550,2017-03-17
-1560,CH26,"Order in probate claim involving compromise (CPR rule 57 Part 1 and 57PD paragraph 6.1)",ch26-eng-2016.04.01.doc,application/msword,48640,02/2016,8,1,false,1,1560,2017-03-17
-1570,CH27,"Handing out testamentary documents for examination",ch27-eng-2016.04.01.doc,application/msword,48128,02/2016,8,1,false,1,1570,2017-03-17
-1580,CH28,"Revocation/refusal of revocation of grant of probate",ch28-eng-2016.04.01.doc,application/msword,45568,02/2016,8,1,false,1,1580,2017-03-17
-1590,CH29,"Order pronouncing for some words, against others",ch29-eng-2016.04.01.doc,application/msword,46080,02/2016,8,1,false,1,1590,2017-03-17
-1600,CH30,"Pronouncing for completed copy/torn up will",ch30-eng.doc,application/msword,53000,02/2017,8,1,false,1,1600,2017-03-17
-1610,CH31,"Tomlin order - 1975 Act",ch31-eng-2016.04.01.doc,application/msword,45568,02/2016,8,1,false,1,1610,2017-03-17
-1620,CH32,"Order for approval of compromise",ch32-eng-2016.04.01.doc,application/msword,46592,02/2016,8,1,false,1,1620,2017-03-17
-1630,CH33,"Order granting permission to make application under the Inheritance (provision for family and dependants) Act 1975 after time expired",ch33-eng-2016.04.01.doc,application/msword,45568,02/2016,8,1,false,1,1630,2017-03-17
-1640,CH34,"Order for claimant to be defendant: Inheritance (provision for family and dependants) Act 1975",ch34-eng-2016.04.01.doc,application/msword,43520,02/2016,8,1,false,1,1640,2017-03-17
-1650,CH35,"Orders for provision under the Inheritance (provision for family and dependants) Act 1975",ch35-eng-2016.04.01.doc,application/msword,55296,02/2016,8,1,false,1,1650,2017-03-17
-1660,CH36,"Enforcing charging order (single defendant)",ch36-eng-2016.04.01.doc,application/msword,38912,02/2016,8,1,false,1,1660,2017-03-17
-1670,CH37,"Enforcing charging order (multiple defendants)",ch37-eng-2016.04.01.doc,application/msword,40960,02/2016,8,1,false,1,1670,2017-03-17
-1680,CH38,"Order for distribution of a Lloyd's Estate",ch38-eng-2016.04.01.doc,application/msword,27136,02/2016,8,1,false,1,1680,2017-03-17
-1690,CH39,"Lloyd's Estate form of witness statement",ch39-eng-2016.04.01.doc,application/msword,31232,02/2016,8,1,false,1,1690,2017-03-17
-1700,CH40,"Costs Management Order (For use where budgets have not been wholly agreed)",ch40-eng.doc,application/msword,37888,04/2016,8,1,false,1,1700,2017-03-17
-1702,CH41,"Order removing personal representative/appointing substitute",ch41-eng.doc,application/msword,54784,03/2017,8,1,false,1,1702,2017-03-17
-1704,PF7A,"Request for service of document abroad through foreign government, foreign judicial authority or British consular authority (rule 6.43)",pf007a-eng.doc,application/msword,34816,04/2016,8,1,false,1,1704,2017-03-17
-1706,CH42,"Presumption of Death Act 2013",ch42-eng.doc,application/msword,45568,01/2017,8,1,false,1,1706,2017-03-17
-1708,PF7B,"Request for service of document on a State (rule 6.44) (to be filed in the Central Office of the Royal Courts of Justice)",pf007b-eng.doc,application/msword,35328,04/2016,8,1,false,1,1708,2017-03-17
-1710,CH43,"Variation of trusts: confidentiality order",ch43-eng.doc,application/msword,26112,02/2017,8,1,false,1,1710,2017-03-17
-1712,PF10,"Anonymity and prohibition of publication order",pf010-eng.doc,application/msword,37888,04/2016,8,1,false,1,1712,2017-03-17
-1716,PF20A,"Application for permission to issue an additional claim under rules 20.4(2)(b), 20.5(1) or 20.7(3)(b)",pf020a-eng.doc,application/msword,28672,04/2016,8,1,false,1,1716,2017-03-17
-1720,PF20B,"Application for directions in an additional claim",pf020b-eng.doc,application/msword,26624,04/2016,8,1,false,1,1720,2017-03-17
-1724,PF52A,"Shortened PF52 in the Queen's Bench Division for multi-track case and costs management directions in Mesothelioma and Asbestosis claims",pf052a-eng.doc,application/msword,45056,04/2016,8,1,false,1,1724,2017-03-17
-1728,PF71,"PF 71 Evidence in support of application for relief from sanctions (CPR 3.8 and 3.9)",pf071-eng.doc,application/msword,27648,04/2016,8,1,false,1,1728,2017-03-17
-1732,PF84C,"Application for entry of judgment on failure to comply with an order made under rule 3.5(1) (rule 3.5(5))",pf084c-eng.doc,application/msword,24576,04/2016,8,1,false,1,1732,2017-03-17
-1736,PF84D,"Judgment on application arising from a failure to comply with an order made under rule 3.5(1) (rule 3.5(1) and (5))",pf084d-eng.doc,application/msword,28160,04/2016,8,1,false,1,1736,2017-03-17
-1740,PF85A,"Application for order arising on failure to comply with a condition imposed under rule 3.1(3)",pf085a-eng.doc,application/msword,24576,04/2016,8,1,false,1,1740,2017-03-17
-1744,PF86,"Request for issue of Writ of Control (rule 83.9(3))",pf086-eng.doc,application/msword,27648,04/2016,8,1,false,1,1744,2017-03-17
-1748,PF88,"Request for issue of Writ of Possession (rule 83.9(3) and rule 83.13)",pf088-eng.doc,application/msword,29696,04/2016,8,1,false,1,1748,2017-03-17
-1752,PF89,"Request for issue of Writ of Possession and Writ of Control combined (rule 83.9(3) and rule 83.13(9))",pf089-eng.doc,application/msword,28160,04/2016,8,1,false,1,1752,2017-03-17
-1756,PF90A,"Request for issue of a Writ of Specific Delivery where judgment or order does not give the alternative of paying the assessed value of the goods (rules 83.9(3) and 83.14(1))",pf090a-eng.doc,application/msword,27648,04/2016,8,1,false,1,1756,2017-03-17
-1760,PF90B,"Request for issue of a Writ of Delivery where judgment or order gives the alternative of paying the assessed value of the goods (rules 83.9(3) and 83.14(2)(a))",pf090b-eng.doc,application/msword,27648,04/2016,8,1,false,1,1760,2017-03-17
-1764,PF90C,"Request for issue of a Writ of Specific Delivery where order made under rule 83.14(2)(b) (rules 83.9(3) and 83.14(2)(b))",pf090c-eng.doc,application/msword,27648,04/2016,8,1,false,1,1764,2017-03-17
-1766,PF92,"Order for permission to issue a writ of possession in the High Court to enforce a Judgment or Order for giving of possession of land in proceedings in the County Court (other than a claim against trespassers under Part 55)(Rule 83.13(2) and (8))",pf092-eng.doc,application/msword,30208,04/2016,8,1,false,1,1766,2017-03-17
-1768,PF154,"Order for permission to register a foreign judgment under [s.9 of the Administration of Justice Act 1920] [s.2 of the Foreign Judgments (Reciprocal Enforcement) Act 1933] [s.4 of the Civil Jurisdiction and Judgments Act 1982] [EU Regulation 1215/2012] (rule 74.3 and 4)",pf154-eng.doc,application/msword,35328,04/2016,8,1,false,1,1768,2017-03-17
-1772,PF156,"Evidence in support of application for registration of a community judgment (rules 74.19 and 74.21)",pf156-eng.doc,application/msword,41472,04/2016,8,1,false,1,1772,2017-03-17
-1776,PF157,"Order for registration of a community judgment to be served on every person against whom the judgment is given (rule 74.22)",pf157-eng.doc,application/msword,42496,04/2016,8,1,false,1,1776,2017-03-17
-1780,PF159A,"Evidence in support of application for registration for enforcement in England and Wales of a foreign judgment under the Administration of Justice Act 1920 (CPR 74.3 and 74.4 and Practice Direction 74A paragraph 4.4 and paragraph 5)",pf159a-eng.doc,application/msword,45568,04/2016,8,1,false,1,1780,2017-03-17
-1784,PF159B,"Evidence in support of application for registration for enforcement in England and Wales of a foreign judgment under the Foreign Judgments (Reciprocal Enforcement) Act 1933 (CPR 74.3 and 74.4 and Practice Direction 74A paragraph 4.4 and paragraph 5)",pf159b-eng.doc,application/msword,47104,04/2016,8,1,false,1,1784,2017-03-17
-1788,PF159C,"Evidence in support of application for registration for enforcement in England and Wales of a foreign judgment under section 4 of the Civil Jurisdiction and Judgments Act 1982 (CPR 74.3 and 74.4 and Practice Direction 74A paragraph 4.4)",pf159c-eng.doc,application/msword,46080,04/2016,8,1,false,1,1788,2017-03-17
-1792,PF159D,"Evidence in support of application for registration for enforcement in England and Wales of a foreign judgment under the Lugano Convention (CPR 74.3 and 74.4 and Practice Direction 74A paragraphs 4 and 6A)",pf159d-eng.doc,application/msword,44544,04/2016,8,1,false,1,1792,2017-03-17
-1796,PF159E,"Evidence in support of application for registration for enforcement in England and Wales of a foreign judgment under section 4B of the Civil Jurisdiction and Judgments Act 1982 (registration and enforcement of Judgments under the 2005 Hague Convention) (CPR 74.3(1) and CPR 74.4(5A))",pf159e-eng.doc,application/msword,51712,04/2016,8,1,false,1,1796,2017-03-17
-1800,PF160,"Order for registration for enforcement in England and Wales of a foreign judgment under the Administration of Justice Act 1920, the Foreign Judgments (Reciprocal Enforcement) Act 1933, s.4 of the Civil Jurisdiction and Judgments Act 1982, s.4A of the Civil Jurisdiction and Judgments Act 1982 (the Lugano Convention) or s.4B of the Civil Jurisdiction and Judgments Act 1982 (the Hague Convention) (CPR 74.6)",pf160-eng.doc,application/msword,46080,04/2016,8,1,false,1,1800,2017-03-17
-1804,PF163,"PF 163 Evidence in support of application for certified copy of a judgment obtained in the High Court or in the County Court for enforcement in a foreign country  (CPR 74.12 and 74.13)",pf163-eng.doc,application/msword,50688,04/2016,8,1,false,1,1804,2017-03-17
-1808,PF164A,"Evidence in support of application to the High Court for the registration of a certificate for the enforcement of money provisions of a judgment given in another part of the United Kingdom (rule 74.15)",pf164a-eng.doc,application/msword,48128,04/2016,8,1,false,1,1808,2017-03-17
-1812,PF164B,"Evidence in support of application to the High Court for the registration for the enforcement of the non-money provisions of a judgment in another part of the United Kingdom (rule 74.16)",pf164b-eng.doc,application/msword,48640,04/2016,8,1,false,1,1812,2017-03-17
-1816,PF165,"Evidence in support of application for registration in the High Court of a Judgment of a court in another part of the United Kingdom containing non-money provisions (rule 74.16)",pf165-eng.doc,application/msword,48640,04/2016,8,1,false,1,1816,2017-03-17
-1820,PF168A,"Order of the court's own initiative to transfer claim from High Court to County Court (sections 40(1) and (2) County Courts Act 1984; High Court and County Court Jurisdiction Order 1991 (as amended); rule 30.3)",pf168a-eng.doc,application/msword,27648,04/2016,8,1,false,1,1820,2017-03-17
-1824,PF180A,"Evidence on application to extend time for registration of a bill of sale or an affidavit of its renewal (Bills of Sales Act 1878, s.14; PD8A para 10A)",pf180a-eng.doc,application/msword,26624,04/2016,8,1,false,1,1824,2017-03-17
-1828,PF180B,"Evidence on application to rectify an omission or misstatement in the registration or renewal of registration of a bill of sale (Bills of Sales Act 1878, s.14; PD 8A para 10A)",pf180b-eng.doc,application/msword,27136,04/2016,8,1,false,1,1828,2017-03-17
-2186,A63,"Cais am orchymyn i ddirymu mabwysiad dan y Cytundeb neu orchymyn mabwysiadu dan y Cytundeb neu i fabwysiad tramor neu benderfyniad dan adran 91 beidio a bod yn ddilys Adran 89 Deddf Mabwysiadu a Phlant 2002 | Application for an order to annul a Convention adoption or Convention adoption order or for an overseas adoption or determination under section 91 to cease to be valid Section 89 Adoption and Children Act 2002",a063-bil.pdf,application/pdf,271637,04/2011,26,1,false,1,2186,2017-03-17
-2187,FP2,"Rhybudd o gais Rhan 18 Rheolau Trefniadaeth Teulu 2010 | Application notice Part 18 of the Family Procedure Rules 2010",fp002-bil.pdf,application/pdf,230631,04/2011,26,1,false,1,2187,2017-03-17
-2190,N162,"Rhybudd yr Atebydd | Respondent's notice",n162-bil.pdf,application/pdf,346256,04/2007,26,1,false,1,2190,2017-03-17
-2195,PF244,"Application Notice (Part 23) in the High Court of Justice Queens Bench Division Administrative Court List",pf244-eng.doc,application/msword,49152,04/2014,8,1,false,1,2195,2017-03-17
-2209,PLO1,"Application for a care order or supervision order: Supplementary form",plo001-eng.doc,application/msword,91648,04/2008,8,1,false,1,2209,2017-03-17
-2210,PLO2,"The local authority's case summary",plo002-eng.doc,application/msword,98816,04/2008,8,1,false,1,2210,2017-03-17
-2211,PLO3,"Draft case management order",plo003-eng.doc,application/msword,78336,04/2008,8,1,false,1,2211,2017-03-17
-2212,PLO4,"Allocation record and timetable for the child(ren)",plo004-eng.doc,application/msword,75776,04/2008,8,1,false,1,2212,2017-03-17
-2213,PLO5,"Directions and allocation on issue of proceedings",plo005-eng.pdf,application/pdf,35057,04/2008,8,1,false,1,2213,2017-03-17
-2214,PLO6,"Directions and allocation at first appointment",plo006-eng.pdf,application/pdf,76625,04/2008,8,1,false,1,2214,2017-03-17
-2216,C8,"Confidential contact details (Family Procedure Rules 2010 Rule 29.1)",c008-eng-20160203.pdf,application/pdf,300199,01/2016,8,1,false,1,2216,2017-03-17
-2217,TE3,"Order for recovery of unpaid penalty charge (Parking)",te003-eng.pdf,application/pdf,334188,06/2015,8,1,false,1,2217,2017-03-17
-2235,N510,"Service out of the Jurisdiction",n510-eng.pdf,application/pdf,90192,07/2015,8,1,false,1,2235,2017-03-17
-2238,FL401A,"Application for a forced marriage protection order",fl401a-eng.pdf,application/pdf,366256,01/2016,8,1,false,1,2238,2017-03-17
-2239,FL407A,"Application for a Warrant of Arrest Forced Marriage Protection Order",fl407a-eng.pdf,application/pdf,341192,11/2008,8,1,false,1,2239,2017-03-17
-2240,FL431,"Application to be joined as, or cease to be a party to an Forced Marriage Protection Proceedings",fl431-eng.pdf,application/pdf,316470,01/2016,8,1,false,1,2240,2017-03-17
-2241,FL403A,"Application to vary, extend or discharge a forced marriage protection order",fl403a-eng.pdf,application/pdf,314382,01/2016,8,1,false,1,2241,2017-03-17
-2242,FL430,"Application for leave to apply for a Forced Marriage Protection Order",fl430-eng.pdf,application/pdf,297354,11/2014,8,1,false,1,2242,2017-03-17
-2250,5138,"Application for Extension of a Representation Order to More Than One Advocate, or to a QC Alone",5138-eng.doc,application/msword,271872,04/2014,8,1,false,1,2250,2017-03-17
-2251,C78,"Application for attachment of a warning notice to a child arrangements order",c078-eng.pdf,application/pdf,661755,01/2016,8,1,false,1,2251,2017-03-17
-2252,C79,"Application related to enforcement of a child arrangement order",c79-eng.pdf,application/pdf,707862,06/2016,8,1,false,1,2252,2017-03-17
-2253,C100,"Application under the Children Act 1989 for a child arrangements, prohibited steps, specific issue section 8 order or to vary or discharge a section 8 order",c100-eng.pdf,application/pdf,402639,10/2016,8,1,false,1,2253,2017-03-17
-2254,5050A,"Schedule of available or realisable assets",5050a-eng.doc,application/msword,113152,12/2008,8,1,false,1,2254,2017-03-17
-2256,5050A,"Schedule of available or realisable assets",5050a-eng.pdf,application/pdf,51690,12/ 2008,8,1,false,1,2256,2017-03-17
-2257,PA8A,"Caveat application form",pa8a-eng.pdf,application/pdf,29448,03/2017,8,1,false,1,2257,2017-03-17
-2258,PA7A,"Application to withdraw documents from safekeeping",pa007a-eng.pdf,application/pdf,33265,01/2009,8,1,false,1,2258,2017-03-17
-2262,LOC009,"I wish to apply to extend time for Registration of a Charge or to rectify a mis-statement or omission (in the Registered Particulars of a Charge or of a Memorandum of Satisfaction)",loc009-eng.pdf,application/pdf,242452,01/2013,8,1,false,1,2262,2017-03-17
-2264,N464,"Application for Directions as to Venue for Administration and Determination",n464-eng.pdf,application/pdf,406345,04/2009,8,1,false,1,2264,2017-03-17
-2266,N465,"Response to application as to venue for administration and determination",n465-eng.pdf,application/pdf,576844,04/2009,8,1,false,1,2266,2017-03-17
-2267,LOC010,"I wish to apply to rescind a winding up order. What do I do?",loc010-eng.pdf,application/pdf,167240,04/2011,8,1,false,1,2267,2017-03-17
-2270,LOC013,"I wish to apply for my cert of discharge",loc013-eng.doc,application/msword,78848,03/2014,8,1,false,1,2270,2017-03-17
-2278,Mercantile Directions,"Specimen Order for Directions",standard-directions-eng.doc,application/msword,48128,12/2010,8,1,false,1,2278,2017-03-17
-2279,LOC040,"Royal Courts of Justice Family Video Conferencing Booking Request",loc040-eng.doc,application/msword,100864,02/2011,8,1,false,1,2279,2017-03-17
-2340,N322B,"Application for an order to allow enforcement of a decision or an ACAS settlement (Form COT3) that does not require permission to proceed",n322b-eng.pdf,application/pdf,341509,06/2009,8,1,false,1,2340,2017-03-17
-2341,EX328,"I have a Tribunal decision but the respondent has not paid. How do I enforce it?",ex328-eng.pdf,application/pdf,149131,04/2014,8,1,false,1,2341,2017-03-17
-2342,EX80B,"Legal Aid/Legal Aid Agency assessment certificate in Family Proceedings where a fixed fee is payable",ex080b-eng.pdf,application/pdf,566525,04/2014,8,1,false,1,2342,2017-03-17
-2343,C23,"C23 - Emergency Protection Order",c023-eng.pdf,application/pdf,209387,04/2009,8,1,false,1,2343,2017-03-17
-2344,EX329,"I Have an Advisory, Conciliation and Arbitration Service (ACAS) settlement or conditional settlement (Form COT3) but the respondent has not paid. How do I enforce it?",ex329-eng.pdf,application/pdf,154262,04/2014,8,1,false,1,2344,2017-03-17
-2346,N461,"Ffurflen Hawlio Adolygiad Barnwrol | Judicial review claim form",n461-bil.pdf,application/pdf,146862,06/2016,26,1,false,1,2346,2017-03-17
-2348,N462,"Adolygiad Barnwrol Cydnabyddiad Cyflwyno | Judicial Review Acknowledgment of Service",n462-bil.pdf,application/pdf,180066,05/2009,26,1,false,1,2348,2017-03-17
-2349,N464,"Cais am gyfarwyddiadau ynghylch lleoliad ar gyfer gweinyddu a phenderfynu | Application for directions as to venue for administration and determination",n464-bil.pdf,application/pdf,215103,05/2009,26,1,false,1,2349,2017-03-17
-2350,N465,"Ymateb i gais am gyfarwyddiadau ynghylch lleoliad ar gyfer gweinyddu a phenderfynu | Response to application for directions as to venue for administration and determination",n465-bil.pdf,application/pdf,203423,05/2009,26,1,false,1,2350,2017-03-17
-2351,PF244,"Hysbysiad Cais (Rhan 23) yn rhestr llys Gweinyddol Adran Mainc y Frenhines yr Uchel lys Cyfiawnder | Application Notice (Part 23) in the High Court of Justice Queen's Bench Division Administrative Court list",pf244-bil.doc,application/msword,114176,05/2009,26,1,false,1,2351,2017-03-17
-2352,You have to go to court,"You have to go to court - What do you do?",go-to-court-eng.pdf,application/pdf,1120044,06/2009,8,1,false,1,2352,2017-03-17
-2354,You have to go to court,"You have to go to court - What do you do? (Bengali)",go-to-court-ben.pdf,application/pdf,1329521,06/2009,3,1,false,1,2354,2017-03-17
-2355,You have to go to court,"You have to go to court - What do you do? (Polish)",go-to-court-pol.pdf,application/pdf,1272180,06/2009,15,1,false,1,2355,2017-03-17
-2356,You have to go to court,"You have to go to court - What do you do? (Punjabi)",go-to-court-pun.pdf,application/pdf,1305301,06/2009,17,1,false,1,2356,2017-03-17
-2357,You have to go to court,"You have to go to court - What do you do? (Simplified Chinese)",go-to-court-zho.pdf,application/pdf,1403271,06/2009,4,1,false,1,2357,2017-03-17
-2358,You have to go to court,"You have to go to court - What do you do? (Somali)",go-to-court-som.pdf,application/pdf,1270835,06/2009,19,1,false,1,2358,2017-03-17
-2359,You have to go to court,"You have to go to court - What do you do? (Traditional Chinese)",go-to-court-chi.pdf,application/pdf,1392553,06/2009,5,1,false,1,2359,2017-03-17
-2360,You have to go to court,"You have to go to court - What do you do? (Gujarati)",go-to-court-guj.pdf,application/pdf,1286948,06/2009,12,1,false,1,2360,2017-03-17
-2361,You have to go to court,"You have to go to court - What do you do? (Arabic)",go-to-court-ara.pdf,application/pdf,1436080,06/2009,2,1,false,1,2361,2017-03-17
-2367,Mercantile Template 1,"Specimen Directions Template (Birmingham Mercantile Court)",specimen-birmingham-eng.doc,application/msword,992768,11/2011,8,1,false,1,2367,2017-03-17
-2368,Mercantile Template 2,"Specimen Directions Template (Bristol Mercantile Court)",specimen-bristol-eng.doc,application/msword,88576,11/2011,8,1,false,1,2368,2017-03-17
-2369,Mercantile Template 3,"Specimen Directions Template (Cardiff Mercantile Court)",specimen-cardiff-eng.doc,application/msword,1164800,11/2011,8,1,false,1,2369,2017-03-17
-2370,Mercantile Template 4,"Specimen Directions Template (Leeds Mercantile Court)",specimen-leeds-eng.doc,application/msword,1075712,11/2011,8,1,false,1,2370,2017-03-17
-2371,Mercantile Template 5,"Specimen Directions Template (London Mercantile Court)",specimen-london-eng.doc,application/msword,1480192,11/2011,8,1,false,1,2371,2017-03-17
-2372,Mercantile Template 6,"Specimen Directions Template (Manchester Mercantile Court)",specimen-manchester-eng.doc,application/msword,1353216,10/2012,8,1,false,1,2372,2017-03-17
-2375,N322B,"Cais am orchymyn i ganiatau gorfodi penderfyniad neu setliad ACAS (Ffurflen COT3) nad yw angen caniatâd i fynd rhagddo | Application for an order to allow enforcement of a decision or an ACAS settlement (Form COT3) that does not require permission to proceed",n322b-bil.pdf,application/pdf,601067,07/2009,26,1,false,1,2375,2017-03-17
-2376,EX328,"Rwyf wedi cael penderfyniad Tribiwnlys ond nid yw'r atebydd wedi talu - Sut maei ei orfodi?",ex328-cym.pdf,application/pdf,138709,04/2014,25,1,false,1,2376,2017-03-17
-2377,EX329,"Mae gennyf setliad neu setliad amodol y Gwasanaeth Cynghori, Cymodi a Chyflafareddu (ACAS) (Ffurflen COT3) ond nid yw'r atebydd wedi talu - Sut alla'  i ei orfodi?",ex329-cym.pdf,application/pdf,103523,04/2014,25,1,false,1,2377,2017-03-17
-2378,MC100,"Gwnewch yn siwr y gallwch dalu eich dirwy | Make sure you can pay your fine",mc100-bil.pdf,application/pdf,256650,12/2013,26,1,false,1,2378,2017-03-17
-2380,C(PRA3),"Parental Responsibility Agreement. Section 4ZA Children Act 1989 (Acquisition of parental responsibility by second female parent)",c(pra003)-eng.pdf,application/pdf,155791,08/2014,8,1,false,1,2380,2017-03-17
-2382,AC001,"Request for an Adjournment (Birmingham)",ac001-birmingham-eng.pdf,application/pdf,13047,09/2008,8,1,false,1,2382,2017-03-17
-2383,AC001,"Request for an Adjournment (Cardiff)",ac001-cardiff-eng.pdf,application/pdf,12911,09/2008,8,1,false,1,2383,2017-03-17
-2384,AC001,"Request for an Adjournment (Leeds)",ac001-leeds-eng.pdf,application/pdf,13590,04/2014,8,1,false,1,2384,2017-03-17
-2385,AC001,"Request for an Adjournment (London)",ac001-london-eng.pdf,application/pdf,12872,09/2008,8,1,false,1,2385,2017-03-17
-2386,AC001,"Request for an Adjournment (Manchester)",ac001-manchester-eng.pdf,application/pdf,13039,09/2008,8,1,false,1,2386,2017-03-17
-2387,N123,"Mortgage pre-action protocol checklist",n123-eng.pdf,application/pdf,97430,08/2015,8,1,false,1,2387,2017-03-17
-2388,A58,"Cais am orchymyn mabwysiadu (Adran 46 Deddf Mabwysiadu a Phlant 2002) | Application for an adoption order (Section 46 Adoption and Children Act 2002)",a58-bil.pdf,application/pdf,498888,11/2016,26,1,false,1,2388,2017-03-17
-2389,C(PRA1),"Cytundeb Cyfrifoldeb Rhieni | Parental Responsibility Agreement",c(pra001)-bil.pdf,application/pdf,128242,08/2014,26,1,false,1,2389,2017-03-17
-2390,C(PRA3),"Cytundeb Cyfrifoldeb Rhieni | Parental Responsibility Agreement",c(pra003)-bil.pdf,application/pdf,133558,08/2014,26,1,false,1,2390,2017-03-17
-2392,PA4,"Cyfeiriadur Cofrestrfeydd Profiant a Chanolfannau Apwyntiadau | Directory of Probate Registries and Appointment Venues",pa004-bil.pdf,application/pdf,191428,09/2014,26,2,false,1,2392,2017-03-17
-2393,EX727,"I have an Employment or an Employment Appeal Tribunal award but the respondent has not paid. How do I enforce it?",ex727-eng.pdf,application/pdf,214182,08/2016,8,2,false,1,2393,2017-03-17
-2394,SCCO,"Information for Litigants Enquiring About the Assessment of Costs Awarded Between Parties",scco-eng.pdf,application/pdf,190135,06/2012,8,2,false,1,2394,2017-03-17
-2395,A64A,"A64A - Application to receive information from court records about a parental order",a064a-eng.pdf,application/pdf,56560,11/2014,8,1,false,1,2395,2017-03-17
-2396,A101A,"Agreement to the making of a parental order in respect of my child. Section 54 of the Human Fertilisation and Embryology Act 2008",a101a-eng.doc,application/msword,32256,04/2011,8,1,false,1,2396,2017-03-17
-2397,C51,"Application for a Parental Order (Section 54 Human Fertilisation and Embryology Act 2008)",c51-eng.pdf,application/pdf,196217,06/2016,8,1,false,1,2397,2017-03-17
-2398,C52,"Acknowledgment (Section 54 Human Fertilisation and Embryology Act 2008)",c52-eng.pdf,application/pdf,130443,01/2016,8,1,false,1,2398,2017-03-17
-2400,N471,"Application to Enforce an Award of an Employment Tribunal and Request a Writ of Control",n471-eng.pdf,application/pdf,71181,05/2014,8,1,false,1,2400,2017-03-17
-2401,PLP10,"PLP10 - Order Menu - Directions Revised Private Law Programme",plp10-eng.doc,application/msword,141312,04/2010,8,1,false,1,2401,2017-03-17
-2402,PLO8,"Standard Directions on Issue",plo008-eng.doc,application/msword,79360,04/2010,8,1,false,1,2402,2017-03-17
-2403,PLO9,"Standard Directions at First Appointment",plo009-eng.doc,application/msword,101376,04/2010,8,1,false,1,2403,2017-03-17
-2404,EX727,"Rydw i wedi cael dyfarniad Tribiwnlys Cyflogaeth neu Dribiwnlys Apêl Cyflogaeth ond nid yw'r atebydd wedi talu. Sut mae ei orfodi?",ex727-cym.pdf,application/pdf,218479,04/2014,25,1,false,1,2404,2017-03-17
-2405,C1,"Cais am orchymyn | Application for an order",c001-bil.pdf,application/pdf,343282,04/2010,26,1,false,1,2405,2017-03-17
-2406,C110,"Application under the Children Act 1989 for a care or supervision order",c110-eng.pdf,application/pdf,683624,11/2014,8,1,false,1,2406,2017-03-17
-2407,C120,"Witness statement template - Child arrangements - Parental dispute",c120-eng.pdf,application/pdf,112097,11/2014,8,1,false,1,2407,2017-03-17
-2408,RTA1,"Claim notification form",rta001-eng.pdf,application/pdf,326810,04/2013,8,1,false,1,2408,2017-03-17
-2409,RTA2,"Defendant only claim notification form",rta02-eng.pdf,application/pdf,402691,04/2013,8,1,false,1,2409,2017-03-17
-2410,RTA3,"Medical report form",rta003-eng.pdf,application/pdf,74871,04/2015,8,1,false,1,2410,2017-03-17
-2411,RTA4,"Interim settlement pack form and response to interim settlement pack",rta04-eng.pdf,application/pdf,112511,04/2013,8,1,false,1,2411,2017-03-17
-2412,RTA5,"Stage 2 settlement pack form and response to settlement pack",rta05-eng.pdf,application/pdf,130646,04/2013,8,1,false,1,2412,2017-03-17
-2413,RTA6 - RTA 7,"Court proceedings pack (part A - part B) form",rta06-and-07-eng.pdf,application/pdf,153389,04/2013,8,1,false,1,2413,2017-03-17
-2420,EX343A,"Cwyn | Complaint",ex343a-bil.pdf,application/pdf,204981,04/2010,26,1,false,1,2420,2017-03-17
-2421,N471,"Cais i orfodi dyfarniad Tribiwnlys Cyflogaeth a gwneud cais am Writ Fieri Facias | Application to enforce an award of an Employment Tribunal and request a Writ of Fieri Facias",n471-bil.pdf,application/pdf,94382,04/2010,26,1,false,1,2421,2017-03-17
-2424,N209A,"Notice of Issue",n209a-eng.pdf,application/pdf,56519,04/2010,8,1,false,1,2424,2017-03-17
-2425,N210B,"Acknowledgment of Service",n210b-eng.pdf,application/pdf,161987,04/2010,8,1,false,1,2425,2017-03-17
-2426,Rent 3,"Application for Certificate to Levy Distress",rent3-eng.pdf,application/pdf,539323,05/2009,8,1,false,1,2426,2017-03-17
-2428,Tystysgrif Colli Enillion neu Fudd-dal,"Tystysgrif Colli Enillion neu Fudd-dal",loss-certificate-cym.pdf,application/pdf,36786,05/2011,25,1,false,1,2428,2017-03-17
-2429,N264,"Electronic documents questionnaire (Civil Procedure Rules Practice Direction 31B)",n264-eng.doc,application/msword,174592,10/2010,8,1,false,1,2429,2017-03-17
-2432,EX728,"I have an Advisory, Conciliation and Arbitration Service (Acas) settlement (Form COT3) but the respondent has not paid. How do I enforce it?",ex728-eng.pdf,application/pdf,222356,08/2016,8,1,false,1,2432,2017-03-17
-2433,N471A,"Application to enforce an ACAS settlement and request a Writ of Control",n471a-eng.pdf,application/pdf,71637,05/2014,8,1,false,1,2433,2017-03-17
-2438,N139,"Application for Warrant of Arrest",n139-eng.pdf,application/pdf,106609,02/2011,8,1,false,1,2438,2017-03-17
-2462,UT1,"Cais am ganiatad i apelio a hysbysiad am apêl o Dribiwnlys Haen Gyntaf (Siambr Hawl Cymdeithasol)",ut001-cym.pdf,application/pdf,206365,07/2012,25,1,false,1,2462,2017-03-17
-2463,UT8,"Cais am ganiatad i apelio a rhybudd o apêl yn sgil penderfyniadau Tribiwnlys Adolygu Iechyd Meddwl Cymru",ut008-cym.pdf,application/pdf,258555,04/2009,25,1,false,1,2463,2017-03-17
-2464,UT9,"Cais am ganiatad I apelio a rhybudd o apêl yn sgil penderfyniadau Tribiwnlys Anghenion Addysgol Arbennig Cymru",ut009-cym.pdf,application/pdf,97738,04/2009,25,1,false,1,2464,2017-03-17
-2465,UT1,"Cais am ganiatad i apelio a hysbysiad am apêl o Dribiwnlys Haen Gyntaf (Siambr Hawl Cymdeithasol)",ut001-cym.doc,application/msword,291840,11/2008,25,1,false,1,2465,2017-03-17
-2466,UT9,"Cais am ganiatad I apelio a rhybudd o apêl yn sgil penderfyniadau Tribiwnlys Anghenion Addysgol Arbennig Cymru",ut009-cym.doc,application/msword,269824,04/2009,25,1,false,1,2466,2017-03-17
-2470,T005,"Cais am ganiatad i apelio I'r Uwch Dribiwnlys",t005-cym.pdf,application/pdf,568561,04/2012,25,1,false,1,2470,2017-03-17
-2487,UT8,"Cais am ganiatad i apelio a rhybudd o apêl yn sgil penderfyniadau Tribiwnlys Adolygu Iechyd Meddwl Cymru",ut008-cym.doc,application/msword,326144,04/2009,25,1,false,1,2487,2017-03-17
-2488,T420,"Gwneud hawliad i Dribiwnlys Cyflogaeth",t420-cym.pdf,application/pdf,449114,03/2015,25,1,false,1,2488,2017-03-17
-2489,T421,"Eich hawliad - beth nesaf",t421-cym.pdf,application/pdf,216334,03/2015,25,1,false,1,2489,2017-03-17
-2490,T422,"Ymateb i hawliad i Dribiwnlys Cyflogaeth",t422-cym.pdf,application/pdf,246209,05/2014,25,1,false,1,2490,2017-03-17
-2491,T423,"Ymateb i hawliad i Dribiwnlys Cyflogaeth (Manylion gwrandawiad I'w hanfon)",t423-cym.pdf,application/pdf,330248,03/2015,25,1,false,1,2491,2017-03-17
-2492,T424,"Y gwrandawiad - cyfarwyddyd i hawlwyr",t424-cym.pdf,application/pdf,255982,03/2015,25,1,false,1,2492,2017-03-17
-2493,T425,"Y gwrandawiad - cyfarwyddyd i hawlwyr ac atebwyr",t425-cym.pdf,application/pdf,288254,03/2015,25,1,false,1,2493,2017-03-17
-2495,T426,"Y dyfarniad",t426-cym.pdf,application/pdf,267705,03/2015,25,1,false,1,2495,2017-03-17
-2499,D258B,"Cais am asesiad manwl (Costau'n daladwy o gronfa ar wahan i Gymorth Cyfreithiol Sifil)",d258b-cym.pdf,application/pdf,38709,04/2013,25,1,false,1,2499,2017-03-17
-2500,A107,"Consent by the child's parent to adoption by their partner. The Adoption and Children Act 2002",a107-eng.pdf,application/pdf,79425,04/2013,8,1,false,1,2500,2017-03-17
-2501,D192,"About (Judicial) Separation Decrees/Orders",d192-eng.pdf,application/pdf,249589,04/2014,8,2,false,1,2501,2017-03-17
-2502,N1C(CC),"Notes for Defendant on Replying to the Part 7 Claim Form",n001c(cc)-eng.pdf,application/pdf,34179,04/2014,8,3,false,1,2502,2017-03-17
-2503,C66,"Cais am orchymyn o dan awdurdodaeth gynhenid yr Uchel Lys yng nghyswllt plant | Application for an order under the High Court inherent jurisdiction in relation to children",c66-bil.pdf,application/pdf,345369,06/2016,26,1,false,1,2503,2017-03-17
-2504,C64,"Cais Am ddatganiad cyfreithustra neu gyfreithuso o dan adran 56(1)(b) a (2) o Ddeddf Cyfraith Teulu 1986 | Application For declaration of legitimacy or legitimation under section 56(1)(b) and (2) of the Family Law Act 1986.",c064-bil.pdf,application/pdf,159981,04/2011,26,1,false,1,2504,2017-03-17
-2505,C65,"Cais Am ddatganiad ynghylch mabwysiadu a wnaethpwyd dramor dan adran 57 Deddf Cyfraith Teulu 1986 | Application For declaration as to adoption effected overseas under section 57 of the Family Law Act 1986",c065-bil.pdf,application/pdf,188295,04/2011,26,1,false,1,2505,2017-03-17
-2507,C8,"Manylion cyswllt cyfrinachol Ffurflen C8. Rheolau Achosion Teulu 2010 Rheol 29.1 | Confidential contact details Form C8. Family Procedure Rules 2010 Rule 29.1",c008-bil.pdf,application/pdf,49071,04/2011,26,1,false,1,2507,2017-03-17
-2508,D151,"Cais i gofrestru gorchymyn cynhaliaeth mewn llys ynadon | Application for registration of a maintenance order in a magistrates' court",d151-bil.pdf,application/pdf,170629,04/2011,26,1,false,1,2508,2017-03-17
-2509,D20,"Archwiliad meddygol:datganiad y partion a'r archwilydd | Medical examination:statement of parties and examiner",d020-bil.pdf,application/pdf,138968,04/2012,26,1,false,1,2509,2017-03-17
-2510,D8D Notes,"Supporting Notes for Guidance on Completing a Petition for a Presumption of Death Decree/Order and Dissolution of the Marriage/Civil Partnership",d008d-notes-eng.pdf,application/pdf,155043,04/2014,8,4,false,1,2510,2017-03-17
-2511,D8N Notes,"Supporting Notes for Guidance on Completing a Nullity Petition",d008n-notes-eng.pdf,application/pdf,193961,04/2014,8,4,false,1,2511,2017-03-17
-2512,D5,"Hysbysiad I'w arnodi ar ddogfen a gyflwynir yn unol a rheol 6.14 | Notice to be indorsed on document served in accordance with rule 6.14",d005-bil.pdf,application/pdf,161286,04/2011,26,1,false,1,2512,2017-03-17
-2513,Canllawiau i Wys Rheithgor | Guide to Jury Summons,"Canllawiau i Wys Rheithgor | Guide to Jury Summons",jury-summons-guide-bil.pdf,application/pdf,221984,05/2011,26,4,false,1,2513,2017-03-17
-2514,Allowances,"Allowances",jurors-allowances-eng.pdf,application/pdf,115053,05/2011,8,2,false,1,2514,2017-03-17
-2515,PA97,"Notice to personal applicant",pa097-eng.doc,application/msword,90112,05/2014,8,2,false,1,2515,2017-03-17
-2516,D50C,"Cais ar sail methiant i ddarparu cynhaliaeth resymol | Application on ground of failure to provide reasonable maintenance",d050c-bil.pdf,application/pdf,119554,01/2014,26,1,false,1,2516,2017-03-17
-2517,D50D,"Cais i newid cytundeb cynhaliaeth yn dilyn marwolaeth un o'r partion dan adran 36 Deddf Achosion Priodasol 1973/paragraff 73 Atodlen 5 Deddf Partneriaeth Sifil 2004 | Application for alteration of maintenance agreement after the death of one of the parties under section 36 of the Matrimonial Causes Act 1973/paragraph 73 to Schedule 5 to the Civil Partnership Act 2004",d050d-bil.pdf,application/pdf,217592,04/2012,26,1,false,1,2517,2017-03-17
-2518,D50E,"Cais am ganiatad i wneud cais am gymorth ariannol ar ol ysgariad dramor ayb. dan adran 13 Deddf Achosion Priodasol a Theuluol 1984 | paragraff 4 Atodlen 7 Deddf Partneriaethau Sifil 2004 | Application for permission to apply for financial relief after an overseas divorce etc. under section 13 of the Matrimonial and Family Proceedings Act 1984/paragraph 4 of Schedule 7 to the Civil Partnership Act 2004",d050e-bil.pdf,application/pdf,186855,04/2011,26,1,false,1,2518,2017-03-17
-2519,D50F,"Cais am gymorth ariannol ar ol ysgariad dramor ayb. dan adran 12 Deddf Achosion Priodasol a Theuluol 1984/Atodlen 7 Deddf Partneriaethau Sifil 2004 | Application for financial relief after an overseas divorce etc. under section 12 of the Matrimonial and Family Proceedings Act 1984/Schedule 7 to the Civil Partnership Act 2004",d050f-bil.pdf,application/pdf,203661,04/2011,26,1,false,1,2519,2017-03-17
-2520,N161C,"Guidance Notes on Completing Form N161 - Appellant's Notice for Appeals Relating to Deduction Orders",n161c-eng.pdf,application/pdf,154063,03/2012,8,4,false,1,2520,2017-03-17
-2521,Juror Charter,"Juror Charter",jurors-charter-eng.pdf,application/pdf,150083,08/2014,8,2,false,1,2521,2017-03-17
-2522,D6,"Datganiad cymodi | Statement of reconciliation",d006-bil.pdf,application/pdf,145349,04/2011,26,1,false,1,2522,2017-03-17
-2523,Form PE3 Guidance,"Guidance Notes for Completion of the Application to File a Statutory Declaration out of Time and Statutory Declaration",pe003-guidance-eng.doc,application/msword,33792,05/2014,8,4,false,1,2523,2017-03-17
-2524,Form PE3 (Vehicle Emissions) Guidance,"Guidance Notes for Completion of the Application to File a Statutory Declaration out of Time and Statutory Declaration for Vehicle Emissions",pe003(ve)-guidance-eng.doc,application/msword,32768,05/2014,8,4,false,1,2524,2017-03-17
-2525,D80F,"Datganiad i gefnogi dirymiad - priodas/partneriaeth sifil ddi-rym | Statement in support of annulment - void marriage/civil partnership",d080f-bil.pdf,application/pdf,107187,04/2014,26,1,false,1,2525,2017-03-17
-2526,PA3,"Ffioedd Profiant o fis Ebrill 2011 ymlaen | Probate Fees from April 2011",pa003-bil.pdf,application/pdf,163785,04/2011,26,2,false,1,2526,2017-03-17
-2528,D8N,"Deiseb Dirymu | Nullity Petition",d008n-bil.pdf,application/pdf,180316,04/2014,26,1,false,1,2528,2017-03-17
-2529,Ffurflen F | Form F,"Hysbysiad am honiad mewn achos ar gyfer rhwymedi ariannol | Notice of allegation in proceedings for a financial remedy",form-f-bil.pdf,application/pdf,165170,04/2011,26,1,false,1,2529,2017-03-17
-2530,T10,"General Regulatory Chamber - Explanatory Leaflet. First-tier Tribunal (Claims Management Services)",t010-eng.pdf,application/pdf,248062,12/2011,8,2,false,1,2530,2017-03-17
-2531,T11,"Guide to Completing the Notice of Appeal Form.  First-tier Tribunal (Claims Management Services)",t011-eng.pdf,application/pdf,269217,12/2011,8,4,false,1,2531,2017-03-17
-2532,T12,"Guidance Notes on Completing the First-tier Tribunal (Claims Management Services) Application for Permission to Appeal to the Upper Tribunal",t012-eng.pdf,application/pdf,312479,12/2011,8,4,false,1,2532,2017-03-17
-2533,FP6,"Tystysgrif cyflwyno | Certificate of service",fp006-bil.pdf,application/pdf,244088,04/2011,26,1,false,1,2533,2017-03-17
-2535,T252,"At Your hearing - Explanatory Booklet",t252-eng.pdf,application/pdf,529271,03/2015,8,2,false,1,2535,2017-03-17
-2537,T251,"Guidance Notes on Completing the Notice of Appeal",t251-eng.pdf,application/pdf,540716,03/2015,8,4,false,1,2537,2017-03-17
-2538,T112,"Guidance Notes for Applications and Referrals",t112-eng.pdf,application/pdf,14819,01/2012,8,4,false,1,2538,2017-03-17
-2539,T117,"Information for Nearest Relatives",t117-eng.pdf,application/pdf,166030,11/2014,8,2,false,1,2539,2017-03-17
-2540,AC010,"Notice of appeal to the High Court (modification/renewal of Non-Derogating Control Orders)",ac010-eng.pdf,application/pdf,178892,08/2016,8,1,false,1,2540,2017-03-17
-2542,T120,"Guidance for the observation of tribunal hearings",t120-eng.pdf,application/pdf,230444,12/2016,8,4,false,1,2542,2017-03-17
-2543,T121,"Information for Restricted Patients Detained Under the Mental Health Act 1983 (as Amended by the Mental Health Act 2007)",t121-eng.pdf,application/pdf,59668,01/2012,8,2,false,1,2543,2017-03-17
-2544,AC011,"Claim form (under Section 11)",ac011-eng.pdf,application/pdf,165934,08/2016,8,1,false,1,2544,2017-03-17
-2545,T123,"Community Treatment Orders (CTO)",t123-eng.pdf,application/pdf,78880,04/2014,8,2,false,1,2545,2017-03-17
-2547,Form P10 guidance notes,"Form P10 Guidance Notes on Completing the Application Form for Permission to Appeal",p10-notes-eng.pdf,application/pdf,205464,01/2012,8,4,false,1,2547,2017-03-17
-2548,Form P9 guidance notes,"Form P9 Guidance Notes on Completing the Application Form to Set Aside a Decision, or Part of It",p09-notes-eng.pdf,application/pdf,188984,01/2012,8,4,false,1,2548,2017-03-17
-2549,T127,"Practice Guidance on Procedures Concerning Handling Representations from Victims in the First-tier Tribunal (Mental Health)",t127-eng.pdf,application/pdf,61324,01/2012,8,4,false,1,2549,2017-03-17
-2556,AC014,"Skeleton argument template",ac014-eng.pdf,application/msword,38000,08/2016,8,1,false,1,2556,2017-03-17
-2557,N161A,"Nodiadau canllaw ar lenwi ffurflen N161 - Hysbysiad apelydd (pob apel ac eithrio apeliadau ar y trac hawliadau bychain) | Guidance notes on completing form N161 - Appellant's notice (all appeals except small claims track appeals)",n161a-bil.pdf,application/pdf,224659,03/2012,26,4,false,1,2557,2017-03-17
-2558,N161C,"Nodiadau canllaw ar lenwi ffurflen N161 Hysbysiad Apelydd am apeliadau sy'n ymwneud a gorchmynion didynnu | Guidance notes on completing form N161 Appellant's notice for appeals relating to deduction orders",n161c-bil.pdf,application/pdf,168689,03/2012,26,4,false,1,2558,2017-03-17
-2564,EX711,"Can the Media Attend My Court Case?  A Guide for Family Court Users",ex711-eng.pdf,application/pdf,226915,04/2014,8,4,false,1,2564,2017-03-17
-2565,EX710,"A gaf i siarad am fy achos y tu allan i'r llys? - Arweiniad i ddefnyddwyr y llys teulu | Can I talk about my case outside court? A guide for family court users",ex710-bil.pdf,application/pdf,761000,05/2009,26,4,false,1,2565,2017-03-17
-2566,EX711,"A gaiff y cyfryngau fynychu fy achos llys? - Arweiniad i ddefnyddwyr y llys teulu | Can the media attend my court case? A guide for family court users",ex711-bil.pdf,application/pdf,772708,04/2009,26,4,false,1,2566,2017-03-17
-2568,T001,"Explanatory Leaflet - A Short Guide for Users",t001-eng.pdf,application/pdf,350260,04/2012,8,4,false,1,2568,2017-03-17
-2569,T002,"References - Some Questions and Answers",t002-eng.pdf,application/pdf,300265,04/2012,8,2,false,1,2569,2017-03-17
-2571,T006,"Guidance Notes on Completing the First-tier Tribunal (Charity) Application for Permission to Appeal to the Upper Tribunal",t006-eng.pdf,application/pdf,339518,04/2012,8,4,false,1,2571,2017-03-17
-2593,PA97,"Hysbysiad i geisydd personol | Notice to personal applicant",pa097-bil.doc,application/msword,553472,08/2014,26,2,false,1,2593,2017-03-17
-2596,Bill of costs (SCCO),"Information for Clients Enquiring About How to Have Their Solicitor's Bill of Costs Assessed - Senior Courts Costs Office",scco-bill-of-costs-eng.pdf,application/pdf,182175,06/2012,8,2,false,1,2596,2017-03-17
-2597,T97,"Guide to Completing the Notice of Appeal",t097-eng.pdf,application/pdf,160914,09/2016,8,4,false,1,2597,2017-03-17
-2598,T95,"Guidance Notes on Completing the First-tier General Regulatory Chamber Application for Permission to Appeal to the Upper Tribunal",t095-eng.pdf,application/pdf,154301,07/2012,8,4,false,1,2598,2017-03-17
-2600,A1,"Notice of [intention to proceed with] an application for a financial remedy (other than a financial order) in the county or High Court",a001-eng.pdf,application/pdf,332822,04/2014,8,1,false,1,2600,2017-03-17
-2601,A2,"Notice of [intention to proceed with] an application for a financial remedy in the magistrates' court",a002-eng.pdf,application/pdf,413491,04/2011,8,1,false,1,2601,2017-03-17
-2602,Form E1,"Financial Statement for a financial remedy (other than a financial order or financial relief after an overseas divorce or dissolution etc) in the county or High Court",form-e001-eng.pdf,application/pdf,302785,11/2014,8,1,false,1,2602,2017-03-17
-2603,Form E2,"Financial Statement for a variation of an order for a financial remedy",form-e002-eng.pdf,application/pdf,489564,11/2014,8,1,false,1,2603,2017-03-17
-2604,Form PPF,"Pension Protection Fund (PPF) Inquiry Form Information needed when a Pension Compensation Sharing Order or Pension Compensation Attachment Order may be made",ppf-eng.pdf,application/pdf,379891,04/2011,8,1,false,1,2604,2017-03-17
-2605,Form PPF1,"Pension Protection Fund (PPF) Sharing Annex to a Pension Compensation Sharing Order [section 24E of the Matrimonial Causes Act 1973] [paragraph 19A of Schedule 5 to the Civil Partnership Act 2004]",ppf1-eng.pdf,application/pdf,369633,04/2011,8,1,false,1,2605,2017-03-17
-2606,Form PPF2,"Pension Protection Fund (PPF) Attachment Annex to a Pension Compensation Attachment Order [section 25F of the Matrimonial Causes Act 1973] [paragraph 34A of Schedule 5 to the Civil Partnership Act 2004]",form-ppf002-eng.pdf,application/pdf,114645,04/2014,8,1,false,1,2606,2017-03-17
-2607,D50G,"Application to prevent transaction intended to defeat prospective applications for financial relief",d050g-eng.pdf,application/pdf,340596,11/2014,8,1,false,1,2607,2017-03-17
-2608,D50K,"Notice of Application for Enforcement by such method of enforcement as the court may consider appropriate Family Procedure Rules 2010 Rule 33.3(2)(b)",d50k-eng.pdf,application/pdf,388157,06/2016,8,1,false,1,2608,2017-03-17
-2609,D80G,"Datganiad i gefnogi dirymiad - priodas/partneriaeth sifil ddirymadwy | Statement in support of annulment - voidable marriage/civil partnership",d080g-bil.pdf,application/pdf,134403,04/2014,26,1,false,1,2609,2017-03-17
-2610,Ffurflen 6.28 Nodiadau | Form 6.28 Notes,"Canllawiau ar gyfer Llenwi'r Ffurflen Datganiad o Amgylchiadau Ariannol (Deiseb Dyledwr) dan Adran 272 Deddf Ansolfedd 1986 | Guidance Notes for Completion of your Statement of Affairs (Debtor's Petition) Form Under Section 272 of the Insolvency Act 1986",form-628-notes-bil.pdf,application/pdf,135542,10/2012,26,4,false,1,2610,2017-03-17
-2612,T36,"Guide to completing the notice of appeal form (T35) (Nitrate Vulnerable Zone)",t036-guidance-eng.pdf,application/pdf,406443,05/2012,8,4,false,1,2612,2017-03-17
-2613,T37,"Nitrate Vulnerable Zone appeals - A guide for individuals",t037-guidance-eng.pdf,application/pdf,284778,05/2012,8,4,false,1,2613,2017-03-17
-2616,IAFT-2 Guide,"A guide to completing IAFT-2 appeal form",iaft002-guide-eng.pdf,application/pdf,196884,09/2015,8,4,false,1,2616,2017-03-17
-2620,A100,"Consent to the placement of my child for adoption with any prospective adopters chosen by the Adoption Agency. Section 19 of the Adoption and Children Act 2002",a100-eng.pdf,application/pdf,119981,04/2013,8,1,false,1,2620,2017-03-17
-2621,A101,"Consent to the placement of my child for adoption with identified prospective adopters. Section 19 of the Adoption and Children Act 2002",a101-eng.pdf,application/pdf,115136,04/2013,8,1,false,1,2621,2017-03-17
-2622,A102,"Consent to the placement of my child for adoption with identified prospective adopter(s) and, if the placement breaks down, with any prospective adopter(s) chosen by the adoption agency. Section 19 of the Adoption and Children Act 2002",a102-eng.pdf,application/pdf,115970,04/2013,8,1,false,1,2622,2017-03-17
-2623,A103,"Advance Consent to Adoption. Section 20 of the Adoption and Children Act 2002",a103-eng.pdf,application/pdf,96748,04/2013,8,1,false,1,2623,2017-03-17
-2624,A104,"Consent to Adoption. The Adoption and Children Act 2002",a104-eng.pdf,application/pdf,129325,04/2013,8,1,false,1,2624,2017-03-17
-2625,A105,"Consent to the making of an Order under Section 84 of the. Adoption and Children Act 2002",a105-eng.pdf,application/pdf,123164,04/2013,8,1,false,1,2625,2017-03-17
-2626,A106,"Withdrawal of Consent. Sections 19 and 20 of the Adoption and Children Act 2002",a106-eng.pdf,application/pdf,156199,04/2011,8,1,false,1,2626,2017-03-17
-2627,T425,"The hearing - guidance for claimants and respondents",t425-eng.pdf,application/pdf,292105,03/2017,8,4,false,1,2627,2017-03-17
-2628,C5,"Application concerning the registration of a child-minder or provider of day-care",c005-eng.pdf,application/pdf,344975,11/2014,8,1,false,1,2628,2017-03-17
-2629,C61,"Certificate referred to in Article 41(1) of Council Regulation (EC) No. 2201/2003 of 27 November 2003(1) concerning judgments on rights of access",c061-eng.pdf,application/pdf,140519,04/2011,8,1,false,1,2629,2017-03-17
-2630,C62,"Certificate referred to in Article 42(1) of Council Regulation (EC) No. 2201/2003 of 27 November 2003(1) concerning the return of the child",c062-eng.pdf,application/pdf,93370,04/2011,8,1,false,1,2630,2017-03-17
-2631,C63,"Application for declaration of parentage under section 55A of the Family Law Act 1986",c63-eng.pdf,application/pdf,366916,06/2016,8,1,false,1,2631,2017-03-17
-2632,C64,"Application For declaration of legitimacy or legitimation under section 56(1)(b) and (2) of the Family Law Act 1986",c064-eng-20160203.pdf,application/pdf,341711,01/2016,8,1,false,1,2632,2017-03-17
-2633,C65,"Application for declaration as to adoption effected overseas under section 57 of the Family Law Act 1986",c65-eng.pdf,application/pdf,320644,01/2016,8,1,false,1,2633,2017-03-17
-2634,C66,"Application for an order under the High Court inherent jurisdiction in relation to children",c66-eng.pdf,application/pdf,533153,06/2016,8,1,false,1,2634,2017-03-17
-2635,C67,"Application under the Child Abduction and Custody Act 1985 or Article 11 of Council Regulation (EC) 2201/2003",c67-eng.pdf,application/pdf,442974,06/2016,8,1,false,1,2635,2017-03-17
-2636,C68,"Application for international transfer of jurisdiction to or from England and Wales",c68-eng.pdf,application/pdf,414271,01/2016,8,1,false,1,2636,2017-03-17
-2637,C69,"Application for registration, recognition or non recognition of a judgment under Council Regulation (EC) 2201/2003 or the 1996 Hague Convention",c069-eng-20160203.pdf,application/pdf,447807,01/2016,8,1,false,1,2637,2017-03-17
-2638,D20,"Medical examination statement of parties and examiner",d020-eng.pdf,application/pdf,303532,04/2012,8,1,false,1,2638,2017-03-17
-2639,D5,"Notice to be indorsed on document served in accordance with rule 6.14",d005-eng.pdf,application/pdf,127113,04/2011,8,1,false,1,2639,2017-03-17
-2640,D50B,"Application under s17 of the Married Women's Property Act 1882 s66 of the Civil Partnership Act 2004 Application to transfer a property",d050b-eng.pdf,application/pdf,363583,11/2014,8,1,false,1,2640,2017-03-17
-2641,D50C,"Application on ground of failure to provide reasonable maintenance",d050c-eng.pdf,application/pdf,324858,11/2014,8,1,false,1,2641,2017-03-17
-2642,D50D,"Application for alteration of maintenance agreement after the death of one of the parties, under s36 of the Matrimonial Causes Act 1973",d050d-eng.pdf,application/pdf,371397,11/2014,8,1,false,1,2642,2017-03-17
-2643,D50E,"Application for permission to apply for financial relief after an overseas divorce etc. under section 13 of the Matrimonial and Family Proceedings Act 1984/paragraph 4 of Schedule 7 to the Civil Partnership Act 2004",d050e-eng.pdf,application/pdf,346802,11/2014,8,1,false,1,2643,2017-03-17
-2644,D50F,"Application for financial relief after an overseas divorce etc. under section 12 of the Matrimonial and Family Proceedings Act 1984/Schedule 7 to the Civil Partnership Act 2004",d050f-eng.pdf,application/pdf,337488,11/2014,8,1,false,1,2644,2017-03-17
-2645,D50H,"Application for alteration of maintenance agreement during parties lifetime",d050h-eng.pdf,application/pdf,360008,11/2014,8,1,false,1,2645,2017-03-17
-2646,D50J,"Application for an order preventing avoidance under section 32L of the Child Support Act 1991",d050j-eng.pdf,application/pdf,362247,11/2014,8,1,false,1,2646,2017-03-17
-2647,D6,"Statement of reconciliation",d006-eng.pdf,application/pdf,381210,04/2011,8,1,false,1,2647,2017-03-17
-2648,D70,"Application for declaration of marital/civil partnership status",d070-eng.pdf,application/pdf,167989,04/2014,8,1,false,1,2648,2017-03-17
-2649,D80F,"Statement in Support of Annulment - Void Marriage/Civil Partnership",d080f-eng.pdf,application/pdf,562119,04/2014,8,1,false,1,2649,2017-03-17
-2650,D80G,"Statement in Support of Annulment - Voidable Marriage/Civil Partnership",d080g-eng.pdf,application/pdf,649276,04/2014,8,1,false,1,2650,2017-03-17
-2651,D8B,"Answer to a divorce/dissolution/(judicial) separation or nullity petition",d008b-eng.pdf,application/pdf,377668,04/2012,8,1,false,1,2651,2017-03-17
-2652,D8D,"Petition for a presumption of death decree/order and the dissolution of a marriage/civil partnership",d008d-eng.pdf,application/pdf,224966,04/2014,8,1,false,1,2652,2017-03-17
-2653,D8N,"Nullity Petition",d008n-eng.pdf,application/pdf,724307,11/2014,8,1,false,1,2653,2017-03-17
-2654,FM1,"Family Mediation Information and Assessment Meeting Form",fm001-eng.pdf,application/pdf,200055,10/2016,8,1,false,1,2654,2017-03-17
-2655,Form A,"Notice of [intention to proceed with] an application for a financial order",form-a-eng.pdf,application/pdf,320681,10/2016,8,1,false,1,2655,2017-03-17
-2656,Form A1,"Notice of [intention to proceed with] an application for a financial remedy (other than a financial order) in the county or High Court",form-a001-eng.pdf,application/pdf,270796,10/2016,8,1,false,1,2656,2017-03-17
-2657,Form A2,"Notice of [intention to proceed with] an application for a financial remedy in the magistrates' court",form-a2-eng.pdf,application/pdf,413491,04/2011,8,1,false,1,2657,2017-03-17
-2659,Form B,"Notice of an Application to Consider the Financial Position of the Respondent After Divorce/Dissolution",form-b-eng.pdf,application/pdf,738310,10/2016,8,1,false,1,2659,2017-03-17
-2660,Form H,"Estimate of costs (financial remedy)",form-h-eng.pdf,application/pdf,191836,04/2011,8,1,false,1,2660,2017-03-17
-2661,FP8,"Rhybudd newid cyfreithiwr | Notice of change of solicitor",fp008-bil.pdf,application/pdf,166918,04/2011,26,1,false,1,2661,2017-03-17
-2665,D258B,"Request for detailed assessment (Costs payable out of a fund other than the Community Legal Service Fund)",d258b-eng.pdf,application/pdf,261308,11/2014,8,1,false,1,2665,2017-03-17
-2666,D258C,"Request for detailed assessment hearing pursuant to an order under Part III of the Solicitors Act 1974",d258c-eng.pdf,application/pdf,45963,11/2014,8,1,false,1,2666,2017-03-17
-2667,LOC006,"Bankruptcy Court Guide",loc006-eng.pdf,application/pdf,190927,11/2013,8,4,false,1,2667,2017-03-17
-2668,N1(FD),"Nodiadau i'r diffynnydd ar ymateb i'r ffurflen hawlio (hawliad Deddf Credyd Defnyddwyr) | Notes for defendant on replying to the claim form (Consumer Credit Act claim)",n001(fd)-bil.pdf,application/pdf,50609,06/2014,26,3,false,1,2668,2017-03-17
-2669,N1C,"Nodiadau I'r diffynnydd ar ateb y ffurflen hawlio | Notes for defendant on replying to the claim form",n001c-bil.pdf,application/pdf,164994,04/2013,26,3,false,1,2669,2017-03-17
-2670,N1C,"Notes for defendant on replying to the claim form",n001c-eng.pdf,application/pdf,75912,04/2013,8,3,false,1,2670,2017-03-17
-2671,N1D,"Nodiadau i'r diffynnydd ar ateb i'r ffurflen hawlio y tu allan i'r awdurdodaeth | Notes for defendant on replying to the claim form out of the jurisdiction",n001d-bil.pdf,application/pdf,211773,10/2008,26,3,false,1,2671,2017-03-17
-2672,N1D,"Notes for defendant on replying to the claim form out of the jurisdiction",n001d-eng.pdf,application/pdf,83667,04/2013,8,3,false,1,2672,2017-03-17
-2673,LOC045,"Model directions for clinical negligence cases (2012) - before Master Roberts and Master Cook",loc045-eng.doc,application/msword,84480,08/2015,8,2,false,1,2673,2017-03-17
-2674,N8B,"Hawliad Cyflafareddu. Nodiadau i'r diffynnydd | Arbitration claim. Notes for the defendant",n008b-bil.pdf,application/pdf,124943,10/2008,26,3,false,1,2674,2017-03-17
-2675,N161B,"Nodiadau Pwysig i'r Atebydd | Important notes for respondent",n161b-bil.pdf,application/pdf,120011,04/2000,26,3,false,1,2675,2017-03-17
-2676,N208C(CC),"Nodiadau I'r diffynnydd ar ymateb i ffurflen hawlio Rhan 8 | Notes for defendant on replying to the Part 8 claim form",n208c(cc)-bil.pdf,application/pdf,217988,10/2008,26,3,false,1,2676,2017-03-17
-2677,N500A,"Notes for claimant on completing a Part 8 claim form (Directors disqualification application)",n500a-eng.pdf,application/pdf,107689,06/2005,8,3,false,1,2677,2017-03-17
-2678,N500B,"Notes for defendant (Directors disqualification application)",n500b-eng.pdf,application/pdf,101604,06/2005,8,3,false,1,2678,2017-03-17
-2679,N501A,"Notes for claimant on completing claim form N501",n501a-eng.pdf,application/pdf,153692,06/2005,8,3,false,1,2679,2017-03-17
-2680,N501B,"Notes for defendant (Directors disqualification proceedings, Section 8A application)",n501b-eng.pdf,application/pdf,99352,06/2005,8,3,false,1,2680,2017-03-17
-2683,T451,"Guidance on completing the application form for a Gender Recognition Certificate",t451-eng.pdf,application/pdf,610220,06/2016,8,4,false,1,2683,2017-03-17
-2684,T452,"Guidelines for Registered Medical Practitioners and Registered Psychologists.  To Facilitate Completion of the Medical Report Proforma for Gender Recognition",t452-eng.pdf,application/pdf,185666,10/2014,8,4,false,1,2684,2017-03-17
-2701,Ffurflen 6.27 Nodiadau | Form 6.27 Notes,"Deiseb Methdaliad Dyledwr | Debtor's Bankruptcy Petition",form-627-notes-bil.doc,application/msword,96256,10/2012,26,2,false,1,2701,2017-03-17
-2702,T246,"Guidance Notes on Completing the Application to Close Enquiry form",t246-eng.pdf,application/pdf,530906,03/2015,8,4,false,1,2702,2017-03-17
-2703,T241,"Guidance Notes on Completing the Notice of Appeal",t241-eng.pdf,application/pdf,548984,03/2015,8,4,false,1,2703,2017-03-17
-2704,T249,"Guidance to Accompany a Decision from the First-tier Tribunal (Tax Chamber)",t249-eng.pdf,application/pdf,533076,03/2015,8,4,false,1,2704,2017-03-17
-2705,EX506,"Family advocacy scheme - Advocates attendance form",ex506-eng.pdf,application/pdf,328684,06/2014,8,1,false,1,2705,2017-03-17
-2706,Certificate of Loss,"Certificate of Loss of Earnings or Benefit",loss-certificate-eng.pdf,application/pdf,60121,05/2011,8,1,false,1,2706,2017-03-17
-2708,Form PE2,"Application to File a Statutory Declaration Out of Time",pe002-eng.doc,application/msword,45568,05/2014,8,1,false,1,2708,2017-03-17
-2709,Form PE3,"Statutory Declaration - Unpaid Penalty Charge",pe003-eng.doc,application/msword,45568,05/2014,8,1,false,1,2709,2017-03-17
-2710,Form PE3 (Vehicle Emissions),"Statutory Declaration (Vehicle Emissions) - Unpaid Penalty Charge",pe003(ve)-eng.doc,application/msword,45568,05/2014,8,1,false,1,2710,2017-03-17
-2711,TE7,"Application to File a Statement Out of Time/Extension of Time (Parking)",te007-eng.doc,application/msword,67072,05/2014,8,1,false,1,2711,2017-03-17
-2712,TE7 (Dart Charge),"Application to File a Statement Out of Time/Extension of Time",te007-dart-eng.pdf,application/pdf,1175548,02/2015,8,1,false,1,2712,2017-03-17
-2713,TE9,"Witness statement - Unpaid Penalty Charge (Parking)",te009-eng.doc,application/msword,69632,05/2014,8,1,false,1,2713,2017-03-17
-2714,TE9 (Dart Charge),"Witness statement - Unpaid Penalty Charge",te009-dart-eng.pdf,application/pdf,330063,11/2015,8,1,false,1,2714,2017-03-17
-2715,Ffurflen E1 | Form E1,"Datganiad Ariannol am rwymedi ariannol (ar wahan i orchymyn ariannol neu gymorth ariannol ar ol ysgariad neu diddymiad dramor) yn y Llys Sirol neu'r Uchel Lys | Financial Statement for a financial remedy (other than a financial order or financial relief after an overseas divorce or dissolution etc) in the county or High Court",form-e1-bil.pdf,application/pdf,387548,04/2012,26,1,false,1,2715,2017-03-17
-2716,Ffurflen E2 | Form E2,"Datganiad Ariannol am rwymedi ariannol yn y llys ynadon | Financial Statement for a financial remedy in the magistrates' court",form-e2-bil.pdf,application/pdf,367507,04/2012,26,1,false,1,2716,2017-03-17
-2717,PPF2,"Cronfa Diogelu Pensiynau (PPF) - Atodiad Atafaelu i Orchymyn Atafaelu Iawndal Pensiwn [Adran 25F Deddf Achosion Priodasol 1973] [paragraff 34A Atodlen 5 Deddf Partneriaethau Sifil 2004] | Pension Protection Fund (PPF) Attachment Annex to a Pension Compensation Attachment Order [section 25F of the Matrimonial Causes Act 1973] [paragraph 34A of Schedule 5 to the Civil Partnership Act 2004]",ppf2-bil.pdf,application/pdf,280158,04/2011,26,1,false,1,2717,2017-03-17
-2719,SEND9,"Guidance for Summonsed Witnesses",send009-eng.pdf,application/pdf,233475,09/2014,8,4,false,1,2719,2017-03-17
-2720,SEND10,"Guidance for Expert Witnesses Giving Evidence in Special Educational Needs Appeals and Disability Discrimination Claims Hearings",send010-eng.pdf,application/pdf,165371,03/2013,8,4,false,1,2720,2017-03-17
-2721,CMIS,"Case Management Information Sheet",case-management-info-eng.doc,application/msword,37376,01/2012,8,1,false,1,2721,2017-03-17
-2724,SSCS1A,"How to Appeal Against a Decision Made by the Department for Work and Pensions",sscs001a-eng.pdf,application/pdf,256154,07/2015,8,2,false,1,2724,2017-03-17
-2725,FTC1 Notes,"Notes for Appellants",ftc001-notes-eng.pdf,application/pdf,547798,11/2014,8,3,false,1,2725,2017-03-17
-2726,FTC2 Notes,"Notes for Appellants Requesting an Order for Costs or Expenses",ftc002-notes-eng.pdf,application/pdf,536025,11/2014,8,3,false,1,2726,2017-03-17
-2727,SSCS1A,"How to appeal against a decision made by the Department for Work and Pensions (Large print)",sscs001a-large-eng.pdf,application/pdf,296574,07/2015,8,2,false,1,2727,2017-03-17
-2728,SEND18,"Carrying out our order in special educational needs cases: A parents' guide to what happens now",send018-eng.pdf,application/pdf,138886,08/2015,8,4,false,1,2728,2017-03-17
-2729,EX728,"Mae gennyf setliad gan y Gwasanaeth Cynghori, Cymodi a Chyflafareddu (Acas) (Ffurflen COT3) ond nid yw'r atebydd wedi talu",ex728-cym.pdf,application/pdf,194717,04/2014,25,2,false,1,2729,2017-03-17
-2730,T108,"Appealing to the First-tier Tribunal (Care Standards) - A Guide to the Appeals Procedures",t108-eng.pdf,application/pdf,362091,10/2014,8,4,false,1,2730,2017-03-17
-2731,EX725,"Gwneud hawliad trawsffiniol yn yr UE",ex725-cym.pdf,application/pdf,191870,04/2014,25,2,false,1,2731,2017-03-17
-2732,T108B,"Telephone Case Management Hearing Guide",t108b-eng.pdf,application/pdf,183406,10/2014,8,4,false,1,2732,2017-03-17
-2733,N244 Notes,"Application Notice (Form N244) - Notes for Guidance",n244-notes-eng.pdf,application/pdf,102827,10/2013,8,4,false,1,2733,2017-03-17
-2734,MC102,"A Guide on How and Where to Pay Your Fine",mc102-eng.pdf,application/pdf,715601,05/2013,8,4,false,1,2734,2017-03-17
-2735,EX730,"Hoffech chi setlo eich achos heb fynd i wrandawiad llys?",ex730-cym.pdf,application/pdf,158510,04/2014,25,2,false,1,2735,2017-03-17
-2736,T113,"CMR1 Case Management Request Form",t113-eng.doc,application/msword,110080,08/2014,8,1,false,1,2736,2017-03-17
-2737,T435,"Ffioedd tribiwnlys cyflogaeth ar gyfer unigolion (O'r 29 Gorffennaf 2013 ymlaen)",t435-cym.pdf,application/pdf,216381,03/2015,25,2,false,1,2737,2017-03-17
-2738,T114,"Witness expenses Form and Guidelines",t114-eng.pdf,application/pdf,357350,10/2014,8,4,false,1,2738,2017-03-17
-2739,T541,"Guidance on service charges, administration charges and other management matters. General information about the process",t541-eng.pdf,application/pdf,563819,01/2017,8,4,false,1,2739,2017-03-17
-2740,Form P9,"Form P9 - Application to set aside a decision or part of a decision (Rule 45)",p09-eng.doc,application/msword,60928,11/2011,8,1,false,1,2740,2017-03-17
-2741,Form P9,"Form P9 - Application to set aside a decision or part of a decision (Rule 45)",p09-eng.pdf,application/pdf,15151,11/2011,8,1,false,1,2741,2017-03-17
-2742,Form P10,"Form P10 - Application for permission to appeal (Rule 46)",p10-eng.doc,application/msword,68608,11/2011,8,1,false,1,2742,2017-03-17
-2743,Form P10,"Form P10 - Application for permission to appeal (Rule 46)",p10-eng.pdf,application/pdf,16074,11/2011,8,1,false,1,2743,2017-03-17
-2744,B1,"Application to be released on bail",b001-eng.doc,application/msword,182272,10/2014,8,1,false,1,2744,2017-03-17
-2745,CB7,"Canllaw i rieni wedi gwahanu: plant a'r llysoedd teulu",cb7-cym.pdf,application/pdf,264283,09/2015,25,1,false,1,2745,2017-03-17
-2746,ET1A,"Dalen flaen Ffioedd a Dileu Ffioedd",et001a-cym.pdf,application/pdf,257425,04/2014,25,1,false,1,2746,2017-03-17
-2747,ET1,"Ffurflen Hawlio",et001-cym.pdf,application/pdf,341584,05/2014,25,1,false,1,2747,2017-03-17
-2748,ET3,"Ffurflen ymateb",et003-cym.pdf,application/pdf,175989,07/2013,25,1,false,1,2748,2017-03-17
-2750,N244 Nodiadau | N244 Notes,"Rhybudd Cyflwyno Cais (Ffurflen N244) - Canllawiau | Application notice (Form N244) - Notes for guidance",n244-notes-bil.pdf,application/pdf,182668,07/2008,26,4,false,1,2750,2017-03-17
-2751,PPF,"Ffurflen Ymholi am y Gronfa Diogelu Pensiynau (CDP) Gwybodaeth sydd ei hangen pan ellir gwneud Gorchymyn Rhannu Iawndal Pensiwn neu Orchymyn Atafaelu Iawndal Pensiwn | Pension Protection Fund (PPF) Inquiry Form Information needed when a Pension Compensation Sharing Order or Pension Compensation Attachment Order may be made",ppf-bil.pdf,application/pdf,250341,04/2011,26,1,false,1,2751,2017-03-17
-2752,Ffurflen P1 | Form P1,"Atodiad Rhannu Pensiwn dan [adran 24B Deddf Achosion Priodasol 1973] [baragraff 15 Atodlen 5 Deddf Partneriaeth Sifil 2004] | Pension Sharing Annex under [section 24B of the Matrimonial Causes Act 1973] [paragraph 15 of Schedule 5 to the Civil Partnership Act 2004]",p01-bil.pdf,application/pdf,256417,04/2012,26,1,false,1,2752,2017-03-17
-2753,D50G,"Cais i atal trafodyn a fwriedir i rwystro ceisiadau tebygol am gymorth ariannol | Application to prevent transaction intended to defeat prospective applications for financial relief",d050g-bil.pdf,application/pdf,181386,04/2012,26,1,false,1,2753,2017-03-17
-2754,TALG964,"Protocol for Inspection of Land in Agricultural Land and Drainage Cases",talg964-eng.pdf,application/pdf,40158,07/2013,8,2,false,1,2754,2017-03-17
-2755,TALG900,"Practice Statement 2013",talg900-eng.pdf,application/pdf,77733,07/2013,8,2,false,1,2755,2017-03-17
-2756,CB7,"Guide for Separated Parents: Children and the Family Courts",cb007-eng.pdf,application/pdf,322902,09/2015,8,4,false,1,2756,2017-03-17
-2757,T005,"Application for permission to appeal to Upper Tribunal",t005-eng.pdf,application/pdf,226780,04/2012,8,1,false,1,2757,2017-03-17
-2758,SSCS6A,"Sut i apelio yn erbyn penderfyniad gan Weinyddwr y Cynllun Taliadau Mesothelioma Ymledol",sscs006a-cym.pdf,application/pdf,236403,10/2014,25,2,false,1,2758,2017-03-17
-2759,FTC3 Notes,"Notes for Applicants - Form FTC3 (Tax and Chancery Chamber)",ftc003-notes-eng.pdf,application/pdf,534515,11/2014,8,3,false,1,2759,2017-03-17
-2760,T399,"Appealing to the Upper Tribunal (Tax and Chancery Chamber): Tax, Charity and Land Registration Appeals",t399-eng.pdf,application/pdf,605745,11/2014,8,2,false,1,2760,2017-03-17
-2761,T400,"References to the Upper Tribunal (Tax and Chancery Chamber): Financial Services Cases",t400-eng.pdf,application/pdf,629559,11/2014,8,2,false,1,2761,2017-03-17
-2763,UT3,"Application for permission to appeal to an Upper Tribunal judge and notice of appeal form for mental health cases (England)",ut003-eng.doc,application/msword,314368,10/2011,8,1,false,1,2763,2017-03-17
-2764,UT4,"Application for Permission to Appeal and Notice of Appeal From First-Tier Tribunal Special Educational Needs and Disability Discrimination in Schools",ut004-eng.pdf,application/pdf,67403,04/2014,8,1,false,1,2764,2017-03-17
-2765,UT4,"Application for Permission to Appeal and Notice of Appeal From First-Tier Tribunal Special Educational Needs and Disability Discrimination in Schools",ut004-eng.doc,application/msword,264704,04/2014,8,1,false,1,2765,2017-03-17
-2766,T434,"Expenses and allowances payable to parties and witnesses attending an Employment Tribunal",t434-eng.pdf,application/pdf,168874,08/2013,8,2,false,1,2766,2017-03-17
-2767,UT5,"Application for permission to appeal to an Upper Tribunal judge and notice of appeal form for care standards and primary health lists cases",ut005-eng.doc,application/msword,372224,10/2011,8,1,false,1,2767,2017-03-17
-2768,UT6,"Application for permission to appeal to an Upper Tribunal judge and notice of appeal form for war pensions and armed forces compensation cases",ut006-eng.pdf,application/pdf,96987,10/2011,8,1,false,1,2768,2017-03-17
-2769,UT6,"Application for permission to appeal to an Upper Tribunal judge and notice of appeal form for war pensions and armed forces compensation cases",ut006-eng.doc,application/msword,248832,03/2013,8,1,false,1,2769,2017-03-17
-2770,COP5A,"Guidance notes on completing form COP5 (Acknowledgment of service/notification)",cop005a-eng.pdf,application/pdf,49600,09/2015,8,4,false,1,2770,2017-03-17
-2771,UT7,"Application/appeal form for the Secretary of State for war pensions and armed forces compensation cases",ut007-eng.doc,application/msword,185856,10/2011,8,1,false,1,2771,2017-03-17
-2772,UT8,"Application for permission to appeal to an Upper Tribunal judge and notice of appeal form against decisions of the Mental Health Review Tribunal Wales",ut008-eng.pdf,application/pdf,224701,04/2009,8,1,false,1,2772,2017-03-17
-2773,UT8,"Application for permission to appeal to an Upper Tribunal judge and notice of appeal form against decisions of the Mental Health Review Tribunal Wales",ut008-eng.doc,application/msword,319488,04/2009,8,1,false,1,2773,2017-03-17
-2774,UT9,"Application for permission to appeal to an Upper Tribunal judge and notice of appeal form against decisions of the Special Educational Needs Tribunal Wales",ut009-eng.pdf,application/pdf,190023,04/2009,8,1,false,1,2774,2017-03-17
-2775,UT9,"Application for permission to appeal to an Upper Tribunal judge and notice of appeal form against decisions of the Special Educational Needs Tribunal Wales",ut009-eng.doc,application/msword,265728,04/2009,8,1,false,1,2775,2017-03-17
-2777,UT10,"Form to Appeal Against a Decision of the Disclosure and Barring Service, England and Wales",ut010-eng.doc,application/msword,228352,04/2013,8,1,false,1,2777,2017-03-17
-2778,UT11,"Application for permission to appeal and notice of appeal from a decision of the First-tier Tribunal (General Regulatory Chamber) - but not for an information rights case",ut011-eng.pdf,application/pdf,657985,09/2015,8,1,false,1,2778,2017-03-17
-2781,UT12,"Form to appeal to the Upper Tribunal against a Traffic Commissioner decision",ut012-eng.doc,application/msword,218112,12/2013,8,1,false,1,2781,2017-03-17
-2782,UT12NI,"Appeal to the Upper Tribunal against a Goods Vehicle Operator licensing decision of the Department for Infrastructure (DfI)",ut12ni-eng.doc,application/msword,190976,11/2016,8,1,false,1,2782,2017-03-17
-2783,COP14A,"COP14 Guidance Notes",cop014a-eng.pdf,application/pdf,40876,09/2015,8,4,false,1,2783,2017-03-17
-2784,COP15A,"COP15 Guidance Notes",cop015a-eng.pdf,application/pdf,46700,09/2015,8,4,false,1,2784,2017-03-17
-2787,UT14,"Application for Permission and Notice of Appeal - Diffuse Mesothelioma Payments Scheme",ut014-eng.pdf,application/pdf,216603,09/2015,8,1,false,1,2787,2017-03-17
-2788,JR1,"Judicial Review Claim Form, England and Wales (Upper Tribunal - Administrative Appeals Chamber)",jr001(acc)-eng.doc,application/msword,327168,03/2013,8,1,false,1,2788,2017-03-17
-2789,JR2,"Judicial Review - Acknowledgment of Service Form (Upper Tribunal - Administrative Appeals Chamber)",jr002(aac)-eng.doc,application/msword,264704,10/2011,8,1,false,1,2789,2017-03-17
-2790,COP21A,"Guidance notes on completing form COP20A (Certificate of notification/non-notification of the person to whom the proceedings relate)",cop021a-eng.pdf,application/pdf,47097,09/2015,8,4,false,1,2790,2017-03-17
-2791,COP21B,"Guidance notes on completing form COP20B (Certificate of service non-service notification/non-notification)",cop021b-eng.pdf,application/pdf,42086,09/2015,8,4,false,1,2791,2017-03-17
-2797,T128,"Options for your Tribunal Referral Hearing",t128-eng.doc,application/msword,104960,12/2015,8,1,false,1,2797,2017-03-17
-2798,PA1T,"Cais am chwiliad sefydlog | Application for a standing search",pa001t-bil.pdf,application/pdf,142004,02/2012,26,1,false,1,2798,2017-03-17
-2799,T96,"Application for permission to appeal to the Upper Tribunal.  First-tier Tribunal (General Regulatory Chamber)",t096-eng.doc,application/msword,117760,07/2012,8,1,false,1,2799,2017-03-17
-2800,T98,"Notice of appeal. General Regulatory Chamber (GRC)",t098-eng.doc,application/msword,126464,09/2016,8,1,false,1,2800,2017-03-17
-2804,T604,"Explanatory leaflet for compulsory purchase compensation, land compensation disputes and other references",t604-eng.pdf,application/pdf,258081,01/2016,8,2,false,1,2804,2017-03-17
-2805,T605,"Explanatory leaflet for appeals against decisions of the First-tier Tribunal (Property Chamber) in England, and Leasehold Valuation and Residential Property Tribunals in Wales",t605-eng.pdf,application/pdf,341785,01/2016,8,2,false,1,2805,2017-03-17
-2806,T606,"Explanatory leaflet for appeals against decisions of the Valuation Tribunal for England and the Valuation Tribunal for Wales",t606-eng.pdf,application/pdf,326978,01/2016,8,2,false,1,2806,2017-03-17
-2807,T607,"Explanatory leaflet for applications for rights of light certificates",t607-eng.pdf,application/pdf,259868,01/2016,8,2,false,1,2807,2017-03-17
-2808,T608,"Explanatory leaflet for applications to discharge or modify restrictive covenants",t608-eng.pdf,application/pdf,337047,01/2016,8,2,false,1,2808,2017-03-17
-2809,T440,"I Want to Appeal to the Employment Appeal Tribunal",t440-eng-20151230.pdf,application/pdf,178627,12/2015,8,2,false,1,2809,2017-03-17
-2810,A64A,"Cais i dderbyn gwybodaeth o gofnodion y llys am orchymyn rhieni | Application to receive information from court records about a parental order",a064a-bil.pdf,application/pdf,77725,04/2010,26,1,false,1,2810,2017-03-17
-2812,MC100,"Make Sure You Can Pay Your Fine. (Czech)",mc100-cze.pdf,application/pdf,545874,12/2013,7,2,false,1,2812,2017-03-17
-2814,COP GN1,"Applications for the appointment of a deputy for property and financial affairs",cop-gn001-eng.pdf,application/pdf,148175,09/2015,8,2,false,1,2814,2017-03-17
-2815,COP GN2,"Guidance on the sale of jointly owned property",cop-gn002-eng.pdf,application/pdf,183964,09/2015,8,4,false,1,2815,2017-03-17
-2816,COP GN3,"Applications by existing deputies - Guidance note",cop-gn003-eng.pdf,application/pdf,138915,09/2015,8,4,false,1,2816,2017-03-17
-2817,COP GN4,"Making a personal welfare application to the Court of Protection",cop-gn004-eng.pdf,application/pdf,73556,09/2015,8,2,false,1,2817,2017-03-17
-2818,COP GN5,"Coming for a hearing at the Court of Protection in London or at one of our regional courts",cop-gn005-eng.pdf,application/pdf,53227,09/2015,8,2,false,1,2818,2017-03-17
-2819,C17,"Atodiad i gais am Orchymyn Goruchwylio Addysg | Supplement for an application for an Education Supervision Order",c017-bil.pdf,application/pdf,107821,09/1999,26,1,false,1,2819,2017-03-17
-2820,C51,"Cais am Orchymyn Rhiant (Adran 54 o Ddeddf Ffrwythloni Dynol ac Embryoleg 2008) | Application for a Parental Order (Section 54 Human Fertilisation and Embryology Act 2008)",c51-bil.pdf,application/pdf,171756,06/2016,26,1,false,1,2820,2017-03-17
-2821,COP GN8,"Applications for statutory wills, gifts, settlements and other dealings with P's property",cop-gn008-eng.pdf,application/pdf,118728,09/2015,8,2,false,1,2821,2017-03-17
-2822,COP FAQ,"Making an application to the Court of Protection - Frequently asked questions",cop-faq-eng.pdf,application/pdf,132079,11/2016,8,2,false,1,2822,2017-03-17
-2823,EX50A,"Full list of fees applicable in the Civil and Family Courts (from 25th July 2016)",ex50a-eng.doc,application/msword,391680,07/2016,8,2,false,1,2823,2017-03-17
-2824,C78,"Cais i ychwanegu hysbysiad rhybudd at orchymyn cyswllt | Application for attachment of a warning notice to a contact order",c078-bil.pdf,application/pdf,159870,04/2014,26,1,false,1,2824,2017-03-17
-2825,T455,"The general guide for all users (Gender Recognition Act 2004)",t455-eng-2016.04.01.pdf,application/pdf,672321,04/2016,8,4,false,1,2825,2017-03-17
-2827,T454,"Guidance on completing the Overseas application form for a Gender Recognition Certificate",t454-eng.pdf,application/pdf,540490,06/2016,8,4,false,1,2827,2017-03-17
-2828,Child Support: How to Appeal,"Child Support: How to Appeal",child-support-how-to-appeal-eng.pdf,application/pdf,52640,10/2013,8,2,false,1,2828,2017-03-17
-2829,Child Support: How to Appeal,"Child Support: How to Appeal (Scotland)",child-support-how-to-appeal-scotland.pdf,application/pdf,56097,10/2013,8,2,false,1,2829,2017-03-17
-2830,Your Appeal - What Happens Next,"Your Appeal - What Happens Next",information-leaflet-eng.pdf,application/pdf,32820,04/2012,8,2,false,1,2830,2017-03-17
-2832,T53,"Fee guidance notes for individuals",t053-eng.pdf,application/pdf,309604,10/2015,8,4,false,1,2832,2017-03-17
-2833,EX160A,"How to apply for help with fees",ex160a-eng.pdf,application/pdf,553609,02/2017,8,2,false,1,2833,2017-03-17
-2834,EX160B,"Undertaking to Apply for Remission of a Court Fee or Tribunal Fee, or to Pay a Court Fee or Tribunal Fee for Emergency Applications Only",ex160b-eng.pdf,application/pdf,112385,09/2013,8,2,false,1,2834,2017-03-17
-2835,EX160C,"Fee remissions contribution calculator",ex160c-eng.xls,application/vnd.ms-excel,28160,09/2013,8,2,false,1,2835,2017-03-17
-2837,UT Table of cases,"UTAAC Table of Cases",utaac-table-cases-eng.pdf,application/pdf,442261,06/2015,8,2,false,1,2837,2017-03-17
-2838,UTAAC FAQ,"Upper Tribunal (Administrative Appeals Chamber) - what to expect",utaac-faq-eng.pdf,application/pdf,574250,05/2015,8,2,false,1,2838,2017-03-17
-2839,JR1 Guidance,"Claim Form JR1 - Notes for Guidance  (Upper Tribunal - Administrative Appeals Chamber)",jr001(aac)-guidance-eng.doc,application/msword,53248,10/2011,8,4,false,1,2839,2017-03-17
-2841,T481 Notes,"Upper Tribunal - Immigration and Asylum Chamber. Guidance Notes on Completing the UTIAC Judicial Review Claim Form",t481-notes-eng.pdf,application/pdf,51394,08/2015,8,4,false,1,2841,2017-03-17
-2842,JR1 Guidance,"Claim Form JR1 - Notes for Guidance (Upper Tribunal - Tax & Chancery Chamber)",jr001(tcc)-guidance-eng.pdf,application/pdf,532174,11/2014,8,4,false,1,2842,2017-03-17
-2843,Application for Anonymity - Guidance Notes,"Application for Anonymity - Guidance Notes (UTIAC)",anonymity-guide-utiac-eng.pdf,application/pdf,8720,11/2013,8,4,false,1,2843,2017-03-17
-2844,JRC1 Notes,"Information Notes and Guidance for Completing Claim Form JRC1",jrc001-notes-eng.doc,application/msword,64512,07/2012,8,4,false,1,2844,2017-03-17
-2845,T03,"General Regulatory Chamber Guidance Note for Policy Makers",policy-makers-guidance-eng.pdf,application/pdf,71759,11/2013,8,4,false,1,2845,2017-03-17
-2848,AC013,"Guidance as to how the parties should assist the Court when applications for costs are made following settlement of claims for judicial review (April 2016)",ac13-eng.pdf,application/pdf,150515,09/2016,8,4,false,1,2848,2017-03-17
-2849,EX105,"Cais i gost trawsgrifau gael ei thalu ag arian cyhoeddus | Request that the costs of transcripts be paid at public expense",ex105-bil.pdf,application/pdf,475271,01/2007,26,1,false,1,2849,2017-03-17
-2850,AC015,"Regionalisation guidance",ac015-eng.pdf,application/pdf,107806,08/2016,8,4,false,1,2850,2017-03-17
-2851,FL401,"Cais am: orchymyn peidio â molestu/orchymyn anheddu | Application for: a non-molestation order/an occupation order",fl401-bil.pdf,application/pdf,238946,04/2014,26,1,false,1,2851,2017-03-17
-2852,FL401A,"Cais am Orchymyn Amddiffyn Priodi Dan Orfod | Application for a Forced Marriage Protection Order",fl401a-bil.pdf,application/pdf,242930,06/2014,26,1,false,1,2852,2017-03-17
-2853,FL403A,"Cais i amrywio, ymestyn neu ddiddymu gorchymyn amddiffyn priodi dan orfod | Application to vary, extend or discharge a forced marriage protection order",fl403a-bil.pdf,application/pdf,121104,11/2008,26,1,false,1,2853,2017-03-17
-2854,AC016,"Appeals under Section 289 of the Town and Country Planning Act 1990. Notes for guidance for court users",ac016-eng.pdf,application/pdf,88829,08/2016,8,4,false,1,2854,2017-03-17
-2855,FL430,"Cais am ganiatâd i wneud cais am Orchymyn Amddiffyn Priodi Dan Orfod | Application for leave to apply for a Forced Marriage Protection Order",fl430-bil.pdf,application/pdf,86219,11/2008,26,1,false,1,2855,2017-03-17
-2856,FL431,"Cais i ymuno fel parti, neu i roi'r gorau i fod yn barti, mewn Achos Amddiffyn Priodi Dan Orfod | Application to be joined as, or cease to be, a party to Forced Marriage. Protection Proceedings",fl431-bil.pdf,application/pdf,115560,11/2008,26,1,false,1,2856,2017-03-17
-2857,FP9,"Tystysgrif addasrwydd cyfaill cyfreitha | Certificate of suitability of litigation friend",fp09-bil.pdf,application/pdf,156675,11/2008,26,1,false,1,2857,2017-03-17
-2858,AC017,"Claims for planning statutory review. Notes for guidance for court users",ac017-eng.pdf,application/pdf,116718,08/2016,8,4,false,1,2858,2017-03-17
-2865,N264,"Holiadur dogfennau electronig (Rheolau Trefniadaeth Sifil Cyfarwyddyd Ymarfer 31B) | Electronic documents questionnaire (Civil Procedure Rules Practice Direction 31B)",n264-bil.doc,application/msword,468480,10/2010,26,1,false,1,2865,2017-03-17
-2866,Ground Rules Hearing Form,"Defence Ground Rules Hearing Form - multiple-defendants (Section 28)",ground-rules-hearing(multiple-defendants)-eng.doc,application/msword,104448,11/2014,8,1,false,1,2866,2017-03-17
-2867,Crown Court Preliminary Hearing Form,"Crown Court Preliminary Hearing Form - multiple-defendants (Section 28)",preliminary-hearing(multiple-defendants)-eng.doc,application/msword,284672,11/2014,8,1,false,1,2867,2017-03-17
-2868,N510,"Cyflwyno y tu allan i'r Awdurdodaeth | Service out of the Jurisdiction",n510-bil.pdf,application/pdf,201670,10/2008,26,1,false,1,2868,2017-03-17
-2869,N5C,"Nodiadau i'r hawlydd (trefn gyflymedig) | Notes for the claimant (Accelerated procedure)",n005c-bil.pdf,application/pdf,140187,04/2010,26,3,false,1,2869,2017-03-17
-2871,HQ1,"Hearing questionnaire 1 - To the patient's representative and to the responsible authority",hq1-eng-2016.03.24.doc,application/msword,1211904,03/2016,8,1,false,1,2871,2017-03-17
-2872,HQ1 Guardianship,"Hearing questionnaire 1 - To the patient's representative, the local social services authority and guardian (If not the LSSA)",hq1-guardianship-eng-2016.02.24.doc,application/msword,87552,02/2016,8,1,false,1,2872,2017-03-17
-2873,PCMH,"Gwrandawiad Pledio a Rheoli Achos. Holiadur I Adfocadau | Plea and Case Management Hearing",pcmh-bil.doc,application/msword,839168,04/2010,26,1,false,1,2873,2017-03-17
-2875,T35,"Notice of appeal (Nitrate vulnerable zone)",t035-eng.doc,application/msword,105472,05/2012,8,1,false,1,2875,2017-03-17
-2876,HQ2,"Hearing Questionnaire 2",hq002-eng.doc,application/msword,65536,05/2014,8,1,false,1,2876,2017-03-17
-2877,Application for Anonymity,"Application for anonymity (IAT)",anonymity-form-iat-eng.doc,application/msword,38912,08/2012,8,1,false,1,2877,2017-03-17
-2878,IAFT-1,"Appeal to the First-Tier Tribunal (Immigration and Asylum Chamber) against an in country (Asylum/Immigration) decision",iaft001-eng.pdf,application/pdf,199316,10/2016,8,1,false,1,2878,2017-03-17
-2879,IAFT-2,"Appeal to the First-Tier Tribunal (Immigration and Asylum Chamber) against a decision of an Entry Clearance Officer",iaft002-eng.pdf,application/pdf,159807,10/2016,8,1,false,1,2879,2017-03-17
-2880,IAFT-3,"Appeal to the First-Tier Tribunal (Immigration and Asylum Chamber) against your Home Office (Asylum/Immigration) decision",iaft003-eng.pdf,application/pdf,186281,10/2016,8,1,false,1,2880,2017-03-17
-2882,T38,"Cover sheet for Nitrate Vulnerable Zone appeal",t38-eng.pdf,application/pdf,74472,12/2016,8,1,false,1,2882,2017-03-17
-2884,IAFT-4,"First-Tier Tribunal application for permission to appeal to Upper Tribunal",iaft004-eng.pdf,application/pdf,77747,10/2015,8,1,false,1,2884,2017-03-17
-2889,SEND4A,"Disability discrimination claim by a parent",send004a-eng.pdf,application/pdf,159883,09/2015,8,1,false,1,2889,2017-03-17
-2890,SEND15A,"Expenses claim form - parents",send015a-eng.pdf,application/pdf,123821,09/2014,8,1,false,1,2890,2017-03-17
-2891,SEND16A,"Expenses claim form - witnesses",send016a-eng.pdf,application/pdf,163218,09/2014,8,1,false,1,2891,2017-03-17
-2892,SEND17,"Explanation for missing travel tickets/receipts",send017-eng.pdf,application/pdf,147452,09/2012,8,1,false,1,2892,2017-03-17
-2893,SEND15AYP,"Expenses claim form - young person",send15ayp-eng.pdf,application/pdf,164654,08/2016,8,1,false,1,2893,2017-03-17
-2894,N210C,"Acknowledgment of Service (Part 81, Section 4 - Certification, or application under section 336 of the Charities Act 2011, in relation to conduct alleged to constitute contempt of court (CPR Part 81, Section 4))",n210c-eng.pdf,application/pdf,98505,10/2012,8,1,false,1,2894,2017-03-17
-2896,T450,"Standard application for a Gender Recognition Certificate",t450-eng.pdf,application/pdf,194303,11/2016,8,1,false,1,2896,2017-03-17
-2900,CAPSBACS1,"Payment of Attachment of Earnings Orders by BACS",capsbacs1-eng-2016.02.24.pdf,application/pdf,103361,02/2016,8,2,false,1,2900,2017-03-17
-2904,CAPSBACS2,"Payment details",capsbacs2-eng-2016.02.24.pdf,application/pdf,114180,02/2016,8,1,false,1,2904,2017-03-17
-2908,CAPSBACS3,"BACS registration form",capsbacs3-eng-2016.02.24.pdf,application/pdf,116848,02/2016,8,1,false,1,2908,2017-03-17
-2912,CAPSBACS4,"BACS schedule - payments to CAPS",cpasbacs4-eng-2016.02.24.pdf,application/pdf,126480,02/2016,8,1,false,1,2912,2017-03-17
-2980,IAFT-5,"Appeal to the First-Tier Tribunal (Immigration and Asylum Chamber) - Complete this form if you are appealing from inside the United Kingdom and you have the right to do so",iaft5-eng.pdf,application/pdf,195232,11/2016,8,1,false,1,2980,2017-03-17
-2982,IAFT-6,"Appeal to the First-Tier Tribunal (Immigration and Asylum Chamber) against a decision of an Entry Clearance Officer (ECO)",iaft6-eng.pdf,application/pdf,161869,11/2016,8,1,false,1,2982,2017-03-17
-2983,IAFT-7,"Appeal to the First-Tier Tribunal (Immigration and Asylum Chamber) - Complete this form if your right of appeal can only be exercised after having left the United Kingdom or you have chosen to leave the United Kingdom before exercising your right of appeal",iaft7-eng.pdf,application/pdf,181182,11/2016,8,1,false,1,2983,2017-03-17
-2990,T144,"Victim's representations to the Tribunal",t144-eng.pdf,application/pdf,756938,03/2017,8,1,false,1,2990,2017-03-17
-3000,Fee Account Application form,"Fee account - Customer application form",fee-account-application-eng.pdf,application/pdf,1260443,05/2015,8,1,false,1,3000,2017-03-17
-3001,N1SDT,"Claim form (MCOL secure data transfer)",n001sdt-eng.pdf,application/pdf,236752,09/2015,8,1,false,1,3001,2017-03-17
-3006,Ffurflen 6.27 | Form 6.27,"Deiseb Methdaliad Dyledwr | Debtor's Bankruptcy Petition",form-627-bil.doc,application/msword,84480,10/2012,26,1,false,1,3006,2017-03-17
-3007,QBD OHA,"Out of hours application ? Queen's Bench Division",qbd-oha-eng.doc,application/msword,71168,06/2013,8,1,false,1,3007,2017-03-17
-3008,N16,"General form of injunction for interim application or originating application",n016-eng.pdf,application/pdf,1283981,10/2012,8,1,false,1,3008,2017-03-17
-3009,N16(1),"General form of injunction for interim application or originating application (Formal parts - See complete N16 for wording of operating clauses)",n016(1)-eng.pdf,application/pdf,27840,10/2012,8,1,false,1,3009,2017-03-17
-3010,N110A,"Power of arrest attached to injunction",n110a-eng.pdf,application/pdf,374902,06/2015,8,1,false,1,3010,2017-03-17
-3015,T240,"Notice of Appeal",t240-eng.pdf,application/pdf,560625,03/2015,8,1,false,1,3015,2017-03-17
-3019,T245,"Application to Close Enquiry",t245-eng.pdf,application/pdf,532715,03/2015,8,1,false,1,3019,2017-03-17
-3020,IAUT1,"Application for permission to appeal from First-Tier Tribunal (Immigration and Asylum Chamber)",iaut001-eng.pdf,application/pdf,120979,07/2015,8,1,false,1,3020,2017-03-17
-3025,N253A,"Notice of provisional assessment (general form)",n253a-eng.pdf,application/pdf,45325,04/2013,8,1,false,1,3025,2017-03-17
-3027,N261,"Provisional assessment hearing notice",n261-eng.pdf,application/pdf,19315,04/2013,8,1,false,1,3027,2017-03-17
-3030,N149A,"Notice of proposed allocation to the small claims track",n149a-eng.pdf,application/pdf,95302,04/2013,8,1,false,1,3030,2017-03-17
-3031,N149B,"Notice of proposed allocation to the fast track",n149b-eng.pdf,application/pdf,95532,04/2013,8,1,false,1,3031,2017-03-17
-3032,N149C,"Notice of proposed allocation to the multi-track",n149c-eng.pdf,application/pdf,132637,04/2016,8,1,false,1,3032,2017-03-17
-3033,N263,"Disclosure report",n263-eng.pdf,application/pdf,107237,04/2013,8,1,false,1,3033,2017-03-17
-3034,N180,"Directions questionnaire (Small claims track)",n180-eng.pdf,application/pdf,157332,04/2014,8,1,false,1,3034,2017-03-17
-3035,N181,"Directions questionnaire (Fast track and multi-track)",n181-eng.pdf,application/pdf,153042,04/2014,8,1,false,1,3035,2017-03-17
-3036,N180,"Holiadur Cyfarwyddiadau (Trac Hawliadau Bychain) | Directions questionnaire (Small claims track)",n180-bil.pdf,application/pdf,126699,04/2014,26,1,false,1,3036,2017-03-17
-3037,N181,"Holiadau Cyfarwyddiadau (Y trac cyflym a'r Amldrac) | Directions questionnaire (Fast track and multi-track)",n181-bil.pdf,application/pdf,183797,04/2014,26,1,false,1,3037,2017-03-17
-3038,SSCS1,"Notice of Appeal Against a Decision of the Department for Work and Pensions",sscs001-eng.pdf,application/pdf,135263,09/2013,8,1,false,1,3038,2017-03-17
-3039,Precedent H,"Form Precedent H",precedent(h)-eng.xls,application/vnd.ms-excel,93696,10/2016,8,1,false,1,3039,2017-03-17
-3041,FTC1,"Application for Permission to Appeal and Notice of Appeal From First-tier Tribunal Including Notes for Applicants and Appellants (Tax and Chancery Chamber)",ftc001-eng.pdf,application/pdf,553886,11/2014,8,1,false,1,3041,2017-03-17
-3042,FTC2,"Form FTC2 Application for Costs or Expenses",ftc002-eng.pdf,application/pdf,503564,11/2014,8,1,false,1,3042,2017-03-17
-3043,FTC3,"Reference notice (Financial Services)",ftc003-eng.pdf,application/pdf,543726,11/2014,8,1,false,1,3043,2017-03-17
-3044,SEND7,"Request for change",send7-eng.pdf,application/pdf,87792,11/2016,8,1,false,1,3044,2017-03-17
-3045,SEND8,"Withdrawal of appeal or claim",send008-eng.pdf,application/pdf,68677,10/2015,8,1,false,1,3045,2017-03-17
-3053,Form EDMO,"Applications relating to Empty Dwelling Management Orders (EDMOs)",edmo-eng.doc,application/msword,272896,01/2017,8,1,false,1,3053,2017-03-17
-3054,Form HHSRS,"Applications relating to Improvement Notices, Prohibition Orders, Demolition Orders and Emergency Measures",hhsrs-eng.doc,application/msword,265728,01/2017,8,1,false,1,3054,2017-03-17
-3055,Form HMO,"Applications relating to licensing of Houses in Multiple Occupation (HMOs) and selective licensing",hmo-eng.doc,application/msword,222720,01/2017,8,1,false,1,3055,2017-03-17
-3056,Form MO,"Applications relating to interim and final Management Orders (MOs)",mo-eng.doc,application/msword,236032,01/2017,8,1,false,1,3056,2017-03-17
-3060,Form OCN,"Applications relating to Overcrowding Notice",ocn-eng.doc,application/msword,227840,01/2017,8,1,false,1,3060,2017-03-17
-3071,T385,"Notice of appeal against a decision of a Valuation Tribunal",t385-eng.pdf,application/pdf,130853,01/2016,8,1,false,1,3071,2017-03-17
-3074,Form RP PTA,"Application for permission to appeal a decision to the Upper Tribunal (Lands Chamber)",rp-pta-eng.doc,application/msword,128512,01/2017,8,1,false,1,3074,2017-03-17
-3075,Form RRO1,"Application by a local housing authority for a Rent Repayment Order (Housing Act 2004)",rro1-eng.doc,application/msword,147456,01/2017,8,1,false,1,3075,2017-03-17
-3076,Form RRO2,"Application by occupier for a Rent Repayment Order (Housing Act 2004)",rro2-eng.doc,application/msword,158208,01/2017,8,1,false,1,3076,2017-03-17
-3077,Form RTB1,"Application for a determination as to whether a dwelling house is suitable for occupation by elderly persons",rtb1-eng.doc,application/msword,165376,01/2017,8,1,false,1,3077,2017-03-17
-3078,Form RTM,"Application relating to (No fault) right to manage",rtm-eng.doc,application/msword,178688,01/2017,8,1,false,1,3078,2017-03-17
-3079,Form TA,"Application for recognition of a Tenants' Association",ta-eng.doc,application/msword,224768,01/2017,8,1,false,1,3079,2017-03-17
-3080,Leasehold 1,"Application for a determination as to liability to pay an administration charge or for the variation of a fixed administration charge",leasehold1-eng.doc,application/msword,212480,01/2017,8,1,false,1,3080,2017-03-17
-3081,Leasehold 2,"Application by a tenant for the appointment of a manager or for the variation or discharge of an order appointing a manager",leasehold2-eng.doc,application/msword,228864,01/2017,8,1,false,1,3081,2017-03-17
-3082,Leasehold 3,"Application for a determination of liability to pay and reasonableness of service charges",leasehold3-eng.doc,application/msword,243712,01/2017,8,1,false,1,3082,2017-03-17
-3083,Leasehold 4,"Application for the variation of a lease or leases",leasehold4-eng.doc,application/msword,206336,01/2017,8,1,false,1,3083,2017-03-17
-3084,Leasehold 5,"Application for the dispensation of all or any of the consultation requirements provided for by Section 20 of the Landlord and Tenant Act 1985",leasehold5-eng.doc,application/msword,216064,01/2017,8,1,false,1,3084,2017-03-17
-3085,Leasehold 6,"Application for an order that a breach of covenant or a condition in the lease has occurred",leasehold6-eng.doc,application/msword,178688,01/2017,8,1,false,1,3085,2017-03-17
-3086,Leasehold 7,"Application for an order under Section 20C of the Landlord and Tenant Act 1985",leasehold7-eng.doc,application/msword,201728,01/2017,8,1,false,1,3086,2017-03-17
-3087,Leasehold 8,"Application for determination of reasonable costs - Flats and Premises (Section 91(2)(d) of the Leasehold Reform, Housing and Urban Development Act 1993)",leasehold8-eng.doc,application/msword,252416,01/2017,8,1,false,1,3087,2017-03-17
-3088,Leasehold 9,"Application form: Flats and premises leasehold enfranchisement (Missing landlord lease terms and/or premium)",leasehold9-eng.doc,application/msword,214528,01/2017,8,1,false,1,3088,2017-03-17
-3089,Leasehold 10,"Application for determination of the terms of acquisition remaining in dispute. Flats and premises (Collective enfranchisement)",leasehold10-eng.doc,application/msword,261632,01/2017,8,1,false,1,3089,2017-03-17
-3090,Leasehold 11,"Application for determination of premium or other terms of acquisition remaining in dispute. Flats and premises (Lease renewal)",leasehold11-eng.doc,application/msword,301056,01/2017,8,1,false,1,3090,2017-03-17
-3091,Leasehold 12,"Application for determination of price payable. houses and premises (Leasehold enfranchisement)",leasehold12-eng.doc,application/msword,352256,01/2017,8,1,false,1,3091,2017-03-17
-3092,Leasehold 13,"Applications for determination of price payable, provisions in the conveyance, apportionment of rent and determination of sub-tenant's share. Houses and premises - Leasehold enfranchisement (Missing landlord)",leasehold13-eng.doc,application/msword,297984,01/2017,8,1,false,1,3092,2017-03-17
-3093,Leasehold 14,"Application for a Reasonable Costs Order",leasehold14-eng.doc,application/msword,326656,01/2017,8,1,false,1,3093,2017-03-17
-3094,Rents 1,"Application referring a notice proposing a new rent under an Assured Periodic Tenancy or Agricultural Occupancy, to the Tribunal",rents1-eng.doc,application/msword,159232,01/2017,8,1,false,1,3094,2017-03-17
-3095,Rents 2,"Application to the Tribunal for Determination of a Rent under an Assured Shorthold Tenancy",rents2-eng.doc,application/msword,178176,01/2017,8,1,false,1,3095,2017-03-17
-3096,Rents 3,"Application referring a notice proposing different terms for a Statutory Periodic Tenancy to the Tribunal",rents3-eng.doc,application/msword,159232,01/2017,8,1,false,1,3096,2017-03-17
-3097,T410,"Application to Rectify or Set Aside Documents",t410-eng.doc,application/msword,103936,07/2013,8,1,false,1,3097,2017-03-17
-3098,T411,"Land Registration Objection to an Application to the Tribunal to Rectify or Set Aside Document(s)",t411-eng.doc,application/msword,83968,07/2013,8,1,false,1,3098,2017-03-17
-3100,Leasehold 15,"Application form: Flats and premises collective enfranchisement (Missing landlord)",leasehold15-eng.doc,application/msword,215040,01/2017,8,1,false,1,3100,2017-03-17
-3103,TAHB511,"Notice of Application for Certificate of Bad Husbandry",tahb511-eng.doc,application/msword,260608,02/2015,8,1,false,1,3103,2017-03-17
-3104,TAHB521,"Response to application for certificate of bad husbandry",tahb521-eng.doc,application/msword,226304,02/2015,8,1,false,1,3104,2017-03-17
-3105,TALD711,"Notice of Application for an Order under the Land Drainage Act 1991",tald711-eng.doc,application/msword,573952,02/2015,8,1,false,1,3105,2017-03-17
-3106,TALD721,"Response to an Application for an Order under the Land Drainage Act 1991",tald721-eng.doc,application/msword,244736,02/2015,8,1,false,1,3106,2017-03-17
-3107,TALG911,"Notice of Application.  For use where there is no other dedicated form",talg911-eng.doc,application/msword,299008,02/2015,8,1,false,1,3107,2017-03-17
-3108,TALG921,"Response to Notice of Application on Form TALG911.  For use where there is no other dedicated form",talg921-eng.doc,application/msword,246272,02/2015,8,1,false,1,3108,2017-03-17
-3111,TASD111,"Notice of Application for Direction for Succession Tenancy on Death",tasd111-eng.doc,application/msword,730624,08/2015,8,1,false,1,3111,2017-03-17
-3112,TASD121,"Response to application for direction for succession tenancy on death",tasd121-eng.doc,application/msword,445952,02/2015,8,1,false,1,3112,2017-03-17
-3113,TASR211,"Notice of Application for Direction for Succession Tenancy on Retirement",tasr211-eng.doc,application/msword,483840,02/2015,8,1,false,1,3113,2017-03-17
-3114,TASR221,"Response to application for direction for succession tenancy on retirement",tasr221-eng-20151223.doc,application/msword,388096,12/2015,8,1,false,1,3114,2017-03-17
-3115,C110A,"Application for a care or supervision order and other orders under Part 4 of the Children Act 1989 or an Emergency Protection Order under section 44 of the Children Act 1989",c110a-eng.pdf,application/pdf,371388,09/2016,8,1,false,1,3115,2017-03-17
-3117,TANQ411,"Notice of Application for Consent to the Operation of a Notice to Quit",tanq411-eng.doc,application/msword,468992,02/2015,8,1,false,1,3117,2017-03-17
-3118,TANQ421,"Response to application for consent to the operation of a notice to quit",tanq421-eng.doc,application/msword,260608,02/2015,8,1,false,1,3118,2017-03-17
-3119,EL1,"Claim Notification Form (EL1): Low Value Personal Injury Claims in Employers' Liability - Accident Only (£1,000 - £25,000)",el01-eng.pdf,application/pdf,266613,04/2013,8,1,false,1,3119,2017-03-17
-3120,EL2,"Claim Notification Form (EL2): Low Value Personal Injury Claims in Employers' Liability - Accident Only (£1,000 - £25,000).  Defendant Only",el02-eng.pdf,application/pdf,191880,04/2013,8,1,false,1,3120,2017-03-17
-3121,ELD1,"Claim Notification Form (ELD1): Low Value Personal Injury Claims in Employers' Liability - Disease (£1,000 - £25,000)",eld01-eng.pdf,application/pdf,153247,04/2013,8,1,false,1,3121,2017-03-17
-3122,ELD2,"Claim Notification Form (ELD2): Low Value Personal Injury Claims in Employers' Liability - Disease (£1,000 - £25,000).  Defendant Only",eld02-eng.pdf,application/pdf,138620,04/2013,8,1,false,1,3122,2017-03-17
-3123,EPL3,"Medical Report Form (EPL3): Low Value Personal Injury Claims in Employers' Liability and Public Liability (£1,000 - £25,000)",epl03-eng.pdf,application/pdf,86764,04/2013,8,1,false,1,3123,2017-03-17
-3124,EPL4,"Interim Settlement Pack and Response to Interim Settlement Pack (EPL4): Low Value Personal Injury Claims in Employers' Liability and Public Liability (£1,000 - £25,000)",epl04-eng.pdf,application/pdf,137019,04/2013,8,1,false,1,3124,2017-03-17
-3125,EPL5,"Stage 2 Settlement Pack and Response to Settlement Pack (EPL5): Low Value Personal Injury Claims in Employers' Liability and Public Liability (£1,000 - £25,000)",epl05-eng.pdf,application/pdf,113034,04/2013,8,1,false,1,3125,2017-03-17
-3126,EPL6 and EPL7,"Court Proceedings Pack (Part A) (EPL6) and (Part B) (EPL7): Low Value Personal Injury Claims in Employers' Liability and Public Liability (£1,000 - £25,000)",epl06-and-07-eng.pdf,application/pdf,112933,04/2013,8,1,false,1,3126,2017-03-17
-3127,PL1,"Claim Notification Form (PL1): Low Value Personal Injury Claims in Public Liability Accidents (£1,000 - £25,000)",pl01-eng.pdf,application/pdf,176585,04/2013,8,1,false,1,3127,2017-03-17
-3128,PL2,"Claim Notification Form (PL2): Low Value Personal Injury Claims in Public Liability Accidents (£1,000 - £25,000).  Defendant Only",pl02-eng.pdf,application/pdf,172314,04/2013,8,1,false,1,3128,2017-03-17
-3130,ET1A,"Employment Tribunal claim form for multiple claimants",et1a-eng.pdf,application/pdf,502061,02/2017,8,1,false,1,3130,2017-03-17
-3131,ET1,"Employment Tribunal claim form for single claimants",et1-eng.pdf,application/pdf,398167,02/2017,8,1,false,1,3131,2017-03-17
-3133,ET3,"Employment Tribunal response form",et003-eng.pdf,application/pdf,104081,04/2014,8,1,false,1,3133,2017-03-17
-3135,T443,"Form 8 Appeal From Decision of Employment Tribunal - Appellant's Reply to Cross Appeal",t443-eng.pdf,application/pdf,9355,07/2013,8,1,false,1,3135,2017-03-17
-3136,T444,"Form 1 Notice of Appeal From Decision of Employment Tribunal",t444-eng.pdf,application/pdf,9923,07/2013,8,1,false,1,3136,2017-03-17
-3137,T445,"Form 3 Appeal From Decision of Employment Tribunal/Certification Officer - Respondent's Answer",t445-eng.pdf,application/pdf,8565,07/2013,8,1,false,1,3137,2017-03-17
-3138,TSF4,"Party/witness claim for attending an Employment Tribunal",tsf4-eng.pdf,application/pdf,198375,08/2013,8,1,false,1,3138,2017-03-17
-3139,T439,"Declaration from a party/witness who is self employed and claiming loss of earnings",t439-eng.pdf,application/pdf,61706,08/2013,8,1,false,1,3139,2017-03-17
-3202,T362,"Absent owner application form",t362-eng.pdf,application/pdf,105196,12/2016,8,1,false,1,3202,2017-03-17
-3362,T370,"Notice of reference by an authority",t370-eng.pdf,application/pdf,172588,01/2016,8,1,false,1,3362,2017-03-17
-3371,T371,"Notice of reference by a claimant",t371-eng.pdf,application/pdf,153774,01/2016,8,1,false,1,3371,2017-03-17
-3373,T372,"Response by an authority to a notice of reference",t372-eng.pdf,application/pdf,119488,01/2016,8,1,false,1,3373,2017-03-17
-3375,T373,"Response by a claimant to a notice of reference",t373-eng.pdf,application/pdf,111261,01/2016,8,1,false,1,3375,2017-03-17
-3380,T374,"Form BNO - Notice of Reference relating to the validity of a Blight or Purchase Counter Notice",t374-eng.pdf,application/pdf,128037,01/2016,8,1,false,1,3380,2017-03-17
-3382,T375,"Response to a notice of reference BNO",t375-eng.pdf,application/pdf,109135,01/2016,8,1,false,1,3382,2017-03-17
-4362,T379,"Application under Section 84 of the Law of Property Act 1925 to discharge or modify a restrictive covenant",t379-eng.pdf,application/pdf,160229,01/2016,8,1,false,1,4362,2017-03-17
-4371,T380,"Form LPB - Restrictive Covenant Application: Publicity Notice",t380-eng.doc,application/msword,42496,08/2015,8,1,false,1,4371,2017-03-17
-4373,T381,"Form LPD - Notice of Objection to a Restrictive Covenant Application",t381-eng.pdf,application/pdf,573550,10/2014,8,1,false,1,4373,2017-03-17
-4374,T382,"Form LPCoC - Certificate of Compliance",t382-eng.doc,application/msword,91136,12/2010,8,1,false,1,4374,2017-03-17
-4375,T382,"Form LPCoC - Certificate of Compliance",t382-eng.pdf,application/pdf,62676,12/2010,8,1,false,1,4375,2017-03-17
-4379,T383,"Form 1 - Application for a Certificate of the Tribunal - Rights of Light Act 1959",t383-eng.doc,application/msword,31232,12/2010,8,1,false,1,4379,2017-03-17
-4380,T383,"Form 1 - Application for a Certificate of the Tribunal - Rights of Light Act 1959",t383-eng.pdf,application/pdf,22842,12/2010,8,1,false,1,4380,2017-03-17
-4381,T384,"Form A - Light Obstruction Notice - Rights of Light Act 1959",t384-eng.doc,application/msword,29696,12/2010,8,1,false,1,4381,2017-03-17
-4382,T384,"Form A - Light Obstruction Notice - Rights of Light Act 1959",t384-eng.pdf,application/pdf,19996,12/2010,8,1,false,1,4382,2017-03-17
-4383,T601,"Notice of appeal against a decision of the First-tier Tribunal (Property Chamber) in England, or a Leasehold Valuation or Residential Property Tribunal in Wales",t601-eng.pdf,application/pdf,606168,01/2016,8,1,false,1,4383,2017-03-17
-4384,T602,"Application for permission to appeal against a decision of the First-tier Tribunal (Property Chamber) in England, or a Leasehold Valuation or Residential Property Tribunal in Wales",t602-eng.pdf,application/pdf,616465,01/2016,8,1,false,1,4384,2017-03-17
-4385,N226,"Notice of admission (Unspecified amount)",n226-eng.pdf,application/pdf,256739,04/2006,8,1,false,1,4385,2017-03-17
-4387,T603,"Respondent's notice to an appeal against a decision of the first-tier tribunal (Property Chamber) in England, or a Leasehold Valuation or Residential Property Tribunal in Wales",t603-eng.pdf,application/pdf,533020,01/2016,8,1,false,1,4387,2017-03-17
-4388,N39,"Order to attend court for questioning",n039-eng.pdf,application/pdf,599230,03/2002,8,1,false,1,4388,2017-03-17
-4389,T453,"Application for a Gender Recognition Certificate (Overseas legal recognition application) (Gender Recognition Act 2004)",t453-eng.pdf,application/pdf,293871,11/2016,8,1,false,1,4389,2017-03-17
-4390,Enquiry Form,"Enquiry Form (Appellant)",appellant-enquiry-form-eng.pdf,application/pdf,31222,10/2013,8,1,false,1,4390,2017-03-17
-4391,Enquiry Form,"Enquiry Form (Other Party)",other-party-enquiry-form-eng.pdf,application/pdf,30435,10/2013,8,1,false,1,4391,2017-03-17
-4392,SSCS1,"Notice of Appeal Against a Decision of the Department for Work and Pensions (Large Print)",sscs001-large-eng.pdf,application/pdf,125042,09/2013,8,1,false,1,4392,2017-03-17
-4393,SSCS2,"Notice of Appeal Against a Decision of the Department for Work and Pensions - Child Maintenance Group",sscs002-eng.pdf,application/pdf,209299,08/2013,8,1,false,1,4393,2017-03-17
-4394,SSCS2,"Notice of Appeal Against a Decision of the Department for Work and Pensions - Child Maintenance Group (Large Print)",sscs002-large-eng.pdf,application/pdf,126178,08/2013,8,1,false,1,4394,2017-03-17
-4395,SSCS3,"Notice of Appeal Against a Decision of the Department for Work and Pensions - Compensation Recovery Unit",sscs003-eng.pdf,application/pdf,149052,01/2014,8,1,false,1,4395,2017-03-17
-4397,EX160,"Apply for help with fees",ex160-eng.pdf,application/pdf,127032,02/2017,8,1,false,1,4397,2017-03-17
-4398,EX160,"Gwneud cais am help i dalu ffioedd | Apply for help with fees",ex160-bil.pdf,application/pdf,258000,02/2017,26,1,false,1,4398,2017-03-17
-4403,T480,"Judicial review claim form",t480-eng.pdf,application/pdf,157206,08/2016,8,1,false,1,4403,2017-03-17
-4404,T482,"Judicial review, acknowledgment of service",t482-eng.pdf,application/pdf,80055,08/2016,8,1,false,1,4404,2017-03-17
-4405,T483,"UTIAC Judicial Review. Application for urgent consideration",t483-eng.pdf,application/pdf,102207,11/2013,8,1,false,1,4405,2017-03-17
-4406,T484,"Application notice (Upper Tribunal Immigration and Asylum Chamber)",t484-eng.pdf,application/pdf,99910,06/2016,8,1,false,1,4406,2017-03-17
-4407,T485,"Statement under Upper Tribunal Rule 28A (2)(b)",t485-eng.pdf,application/pdf,76015,08/2016,8,1,false,1,4407,2017-03-17
-4408,T486,"Notice of Change of Solicitor",t486-from-november-eng.pdf,application/pdf,89500,08/2013,8,1,false,1,4408,2017-03-17
-4409,JR1,"Judicial Review Claim Form, England and Wales (Upper Tribunal - Tax & Chancery Chamber)",jr001(tcc)-eng.pdf,application/pdf,583623,11/2014,8,1,false,1,4409,2017-03-17
-4410,JR2,"Judicial Review - Acknowledgment of Service Form  (Upper Tribunal - Tax & Chancery Chamber)",jr002(tcc)-eng.pdf,application/pdf,590551,11/2014,8,1,false,1,4410,2017-03-17
-4411,Application for Anonymity,"Application for Anonymity (UTIAC)",anonymity-form-utiac-eng.pdf,application/pdf,32438,12/2010,8,1,false,1,4411,2017-03-17
-4412,Application for Anonymity,"Application for Anonymity (UTIAC)",anonymity-form-utiac-eng.doc,application/msword,35328,12/2010,8,1,false,1,4412,2017-03-17
-4413,IAUT3,"Application of Renewal (UTIAC)",iaut003-utiac-eng.doc,application/msword,348672,11/2013,8,1,false,1,4413,2017-03-17
-4414,IAUT3,"Application of Renewal (UTIAC)",iaut003-utiac-eng.pdf,application/pdf,31836,11/2013,8,1,false,1,4414,2017-03-17
-4415,Notice of intention to pursue an appeal,"Notice of Intention to Pursue an Appeal (UTIAC)",appeal-notice-utiac-eng.pdf,application/pdf,48229,11/2013,8,1,false,1,4415,2017-03-17
-4416,SSCS4,"Notice of appeal against a decision of the Department for Work and Pensions - Recovery of NHS Charges",sscs004-eng.pdf,application/pdf,106162,01/2014,8,1,false,1,4416,2017-03-17
-4417,TALG975,"Application for Permission to Appeal a Decision to the Upper Tribunal (Lands Chamber). Applications for Stay, Suspension and Postponement Pending Appeal",talg975-eng.doc,application/msword,257024,02/2015,8,1,false,1,4417,2017-03-17
-4418,T359,"Immigration guidance for unrepresented appellants",t359-eng.pdf,application/pdf,148331,11/2014,8,4,false,1,4418,2017-03-17
-4423,EX370,"Your First Time at Court? What You Can Expect",ex370-eng.pdf,application/pdf,148877,03/2014,8,2,false,1,4423,2017-03-17
-4424,T412,"A Short Guide for Users",t412-eng.pdf,application/pdf,148706,07/2013,8,4,false,1,4424,2017-03-17
-4425,Claim Information Form,"Claim Information Form",claim-info-eng.xls,application/vnd.ms-excel,99840,04/2014,8,1,false,1,4425,2017-03-17
-4426,EX108,"Tape transcription",ex108-eng.pdf,application/pdf,73667,07/2014,8,1,false,1,4426,2017-03-17
-4427,N182,"Mediation settlement agreement",n182-eng.doc,application/msword,83456,04/2014,8,1,false,1,4427,2017-03-17
-4430,N208PC,"Planning statutory review claim",n208pc-eng-20151222.pdf,application/pdf,129000,12/2015,8,1,false,1,4430,2017-03-17
-4439,N215PC,"Certificate of Service (Planning Court)",n215pc-eng.pdf,application/pdf,295667,09/2011,8,1,false,1,4439,2017-03-17
-4440,EAC1,"Application for Certificate to Act as an Enforcement Agent",eac001-eng.pdf,application/pdf,152820,04/2014,8,1,false,1,4440,2017-03-17
-4442,EAC2,"Complaint Against a Certificated Person",eac002-eng.pdf,application/pdf,75533,04/2014,8,1,false,1,4442,2017-03-17
-4444,N331,"Notice of withdrawal from possession or payment over of moneys, on notice of receiving or winding-Up order",n331-eng.doc,application/msword,33792,04/2014,8,1,false,1,4444,2017-03-17
-4445,EX381,"Court of Appeal frequently asked questions",ex381-eng.pdf,application/pdf,132158,12/2016,8,2,false,1,4445,2017-03-17
-4450,N461PC,"Judicial Review Claim Form",n461pc-eng.pdf,application/pdf,356767,04/2014,8,1,false,1,4450,2017-03-17
-4451,N462PC,"Judicial Review Acknowledgment of service",n462pc-eng.pdf,application/pdf,192018,07/2015,8,1,false,1,4451,2017-03-17
-4452,N463PC,"Judicial Review Application for Urgent Consideration",n463pc-eng.pdf,application/pdf,80235,04/2014,8,1,false,1,4452,2017-03-17
-4453,N464PC,"Application for Directions as to Venue for Administration and Determination",n464pc-eng.pdf,application/pdf,331432,04/2014,8,1,false,1,4453,2017-03-17
-4454,EX730,"Would You like to Settle Your Case without Going to a Court Hearing?",ex730-eng.pdf,application/pdf,398854,04/2014,8,2,false,1,4454,2017-03-17
-4455,PC001,"Request for an Adjournment (Birmingham)",pc001-birmingham-eng.pdf,application/pdf,19261,09/2008,8,1,false,1,4455,2017-03-17
-4456,PC001,"Request for an Adjournment (Cardiff)",pc001-cardiff-eng.pdf,application/pdf,18960,09/2008,8,1,false,1,4456,2017-03-17
-4457,County Court Business Centre Code of Practice,"County Court Business Centre Code of Practice",ccbc-cop-eng-20160216.pdf,application/pdf,605598,12/2015,8,2,false,1,4457,2017-03-17
-4458,PC001,"Request for an Adjournment (London)",pc001-london-eng.pdf,application/pdf,19622,09/2008,8,1,false,1,4458,2017-03-17
-4459,PC001,"Request for an Adjournment (Manchester)",pc001-manchester-eng.pdf,application/pdf,19073,09/2008,8,1,false,1,4459,2017-03-17
-4460,PCPF244,"Application Notice (Part 23) in the High Court of Justice, Queens Bench Division, the Planning Court",pcpf244-eng.pdf,application/pdf,70848,04/2014,8,1,false,1,4460,2017-03-17
-4461,SSCS5,"Notice of appeal against a decision of HM Revenue and Customs",sscs005-eng.pdf,application/pdf,154548,07/2014,8,1,false,1,4461,2017-03-17
-4462,GMappeal1,"Notice of Appeal Form",gm-appeal001-eng.pdf,application/pdf,38781,06/2014,8,1,false,1,4462,2017-03-17
-4463,GMappeal2,"Application to Extend Time",gm-appeal002-eng.pdf,application/pdf,38748,06/2014,8,1,false,1,4463,2017-03-17
-4464,POAC1,"Notice of Appeal to the Proscribed Organisations Appeals Commission (POAC)",poac001-eng.pdf,application/pdf,117350,07/2014,8,1,false,1,4464,2017-03-17
-4471,SEND11,"Attendance form - parents",send011-eng.pdf,application/pdf,56086,07/2014,8,1,false,1,4471,2017-03-17
-4472,SEND11YP,"Attendance form - young person",send11yp-eng.pdf,application/pdf,145940,09/2016,8,1,false,1,4472,2017-03-17
-4473,SEND12,"Attendance form - local authority",send012-eng.pdf,application/pdf,55797,07/2014,8,1,false,1,4473,2017-03-17
-4475,SEND1A,"Appeal form - statement of educational needs",send01a-eng-2016.03.01.pdf,application/pdf,174366,02/2016,8,1,false,1,4475,2017-03-17
-4476,SEND20A,"Application for permission to appeal",send020a-eng.pdf,application/pdf,170939,08/2014,8,1,false,1,4476,2017-03-17
-4477,SEND20B,"Application for review",send020b-eng.pdf,application/pdf,173691,08/2014,8,1,false,1,4477,2017-03-17
-4478,SEND20C,"Application to set aside final decision",send020c-eng.pdf,application/pdf,199735,08/2014,8,1,false,1,4478,2017-03-17
-4480,N142,"Guardianship Order",n142-eng.pdf,application/pdf,136581,07/2015,8,1,false,1,4480,2017-03-17
-4485,N143,"[Interim] Hospital Order",n143-eng.pdf,application/pdf,153687,07/2015,8,1,false,1,4485,2017-03-17
-4495,T609,"Appeals From Decisions Made by the First-Tier Tribunal (Property Chamber) in Residential Property and Agricultural Land and Drainage Cases",t609-eng.pdf,application/pdf,162744,09/2014,8,2,false,1,4495,2017-03-17
-4496,CIC Guide 1996,"Guide to the Criminal Injuries Compensation Scheme 1996",cic-guide-1996-eng.pdf,application/pdf,114461,04/1999,8,4,false,1,4496,2017-03-17
-4497,CIC Guide 2001,"Guide to the Criminal Injuries Compensation Scheme 2001",cic-guide-2001-eng.pdf,application/pdf,712752,12/2007,8,4,false,1,4497,2017-03-17
-4498,CIC Guide 2008,"Guide to the Criminal Injuries Compensation Scheme 2008",cic-guide-2008-eng.pdf,application/pdf,114461,07/2014,8,4,false,1,4498,2017-03-17
-4499,CIC Guide 2012,"Guide to the Criminal Injuries Compensation Scheme 2012",cic-guide-2012-eng.pdf,application/pdf,506438,07/2014,8,4,false,1,4499,2017-03-17
-4500,Criminal Injuries Compensation Scheme 1996,"The Criminal Injuries Compensation Scheme 1996",cic-scheme-1996-eng.pdf,application/pdf,57168,04/1999,8,2,false,1,4500,2017-03-17
-4501,Criminal Injuries Compensation Scheme 2001,"The Criminal Injuries Compensation Scheme 2001",cic-scheme-2001-eng.pdf,application/pdf,136973,04/2001,8,2,false,1,4501,2017-03-17
-4502,Criminal Injuries Compensation Scheme 2008,"The Criminal Injuries Compensation Scheme 2008",cic-scheme-2008-eng.pdf,application/pdf,1098260,07/2014,8,2,false,1,4502,2017-03-17
-4503,Criminal Injuries Compensation Scheme 2012,"The Criminal Injuries Compensation Scheme 2012",cic-scheme-2012-eng.pdf,application/pdf,721490,07/2014,8,2,false,1,4503,2017-03-17
-4504,CS01,"Memorandum of understanding between Ofsted and the First-Tier Tribunal of the Health, Education and Social Care Chamber",cs001-eng.pdf,application/pdf,73971,04/2014,8,2,false,1,4504,2017-03-17
-4505,CS02,"Memorandum of Understanding Between Department for Education (Independent Education and Boarding Team) and HM Courts & Tribunals Service (First-tier Tribunal Health, Education and Social Care Chamber)",cs002-eng.pdf,application/pdf,56234,08/2015,8,2,false,1,4505,2017-03-17
-4506,CS03,"Memorandum of Understanding between Care Quality Commission and HM Courts & Tribunals Service regrading expedited appeals to the First-tier Tribunal (Care Standards)",cs003-eng.pdf,application/pdf,50217,07/2014,8,2,false,1,4506,2017-03-17
-4507,CS04,"Memorandum of Understanding Between the Welsh Ministers and Tribunals Service in Respect of Expedited Appeals",cs004-eng.pdf,application/pdf,82624,07/2014,8,2,false,1,4507,2017-03-17
-4508,PHL Guide,"A guide to Making an Appeal to Primary Health Lists",phl-guide-eng.pdf,application/pdf,297645,10/2014,8,4,false,1,4508,2017-03-17
-4509,REMO 11,"Annex C - Application for Establishment of a Decision",remo-011-eng.doc,application/msword,65024,08/2014,8,1,false,1,4509,2017-03-17
-4510,REMO 12,"Annex D - Application for Modification of a Decision",remo-012-eng.doc,application/msword,76288,08/2014,8,1,false,1,4510,2017-03-17
-4511,REMO 13,"Annex E - Financial Circumstances Form",remo-013-eng.doc,application/msword,242176,08/2014,8,1,false,1,4511,2017-03-17
-4512,SEND21,"Mediation Certificate",send021-eng.pdf,application/pdf,70595,09/2014,8,2,false,1,4512,2017-03-17
-4513,SEND22,"Answering a Claim - A Guide to Responsible Bodies",send022-eng.pdf,application/pdf,189501,08/2014,8,4,false,1,4513,2017-03-17
-4514,SEND3,"Information About Schools",send003-eng.pdf,application/pdf,67136,07/2014,8,2,false,1,4514,2017-03-17
-4515,SEND6,"Information for Children and Young People",send006-eng.pdf,application/pdf,463723,07/2014,8,2,false,1,4515,2017-03-17
-4516,T243,"At Your Hearing",t243-eng.pdf,application/pdf,541665,03/2015,8,2,false,1,4516,2017-03-17
-4517,T244,"Further Appeal Notes",t244-eng.pdf,application/pdf,531592,03/2015,8,3,false,1,4517,2017-03-17
-4518,Application for Anonymity,"Application for anonymity guidance notes (IAT)",anonymity-guide-iat-eng.pdf,application/pdf,54910,08/2012,8,4,false,1,4518,2017-03-17
-4519,IAFT-1 Guide,"A guide to completing IAFT-1 appeal form",iaft001-guide-eng.pdf,application/pdf,378615,09/2015,8,4,false,1,4519,2017-03-17
-4520,T490,"Gender Recognition Panel Application Process Flowchart",t490-eng.pdf,application/pdf,2193,07/2014,8,2,false,1,4520,2017-03-17
-4521,T491,"Table of Gender Recognition Schemes in Countries and Territories",t491-eng.pdf,application/pdf,159883,06/2011,8,2,false,1,4521,2017-03-17
-4522,T492,"Additonal Guidance Issued by the President on the GRA's Medical Requirements",t492-eng.pdf,application/pdf,29787,12/2005,8,4,false,1,4522,2017-03-17
-4523,T493,"List of specialists in the field of gender dysphoria",t493-eng.pdf,application/pdf,110828,01/2017,8,2,false,1,4523,2017-03-17
-4524,T494,"Expenses and Allowances Payable to Parties and Witnesses Attending an Employment Tribunal",t494-eng.pdf,application/pdf,31709,10/2006,8,2,false,1,4524,2017-03-17
-4525,T622,"Bail Variation Request Form (SIAC B2)",t622-eng.pdf,application/pdf,470083,07/2015,8,1,false,1,4525,2017-03-17
-4526,T496,"Guide to loss of earnings and special expenses",t496-eng.pdf,application/pdf,36233,08/2010,8,4,false,1,4526,2017-03-17
-4527,T497,"Criminal Injuries Compensation (Your appeal)",t497-eng.pdf,application/pdf,147809,07/2014,8,2,false,1,4527,2017-03-17
-4529,IAFT-3 Guide,"A guide to completing IAFT-3 appeal form",iaft003-guide-eng.pdf,application/pdf,361337,09/2015,8,4,false,1,4529,2017-03-17
-4530,IAFT-4 Guide,"A guide to completing IAFT-4 application form",iaft004-guide-eng.pdf,application/pdf,165208,09/2015,8,4,false,1,4530,2017-03-17
-4531,T611,"Judicial Mediation - Scotland",t611-eng.pdf,application/pdf,15405,07/2014,8,2,false,1,4531,2017-03-17
-4532,T612,"Judicial Mediation - England and Wales",t612-eng.pdf,application/pdf,15040,07/2014,8,2,false,1,4532,2017-03-17
-4533,IAFT-5 Guide,"A guide to completing IAFT-5 appeal form - Information on fee payment. Notice of appeal to the First-tier Tribunal (Immigration and Asylum Chamber) in country",iaft5-guide-eng.pdf,application/pdf,198723,12/2016,8,4,false,1,4533,2017-03-17
-4534,T614,"Procedure flowchart for appeals from The First-tier Tribunal (Property Chamber) in England and the Leasehold Valuation and Residential Property Tribunals in Wales",t614-eng.pdf,application/pdf,397255,01/2016,8,2,false,1,4534,2017-03-17
-4535,T615,"Procedure flowchart for rating appeals",t615-eng.pdf,application/pdf,381077,01/2016,8,2,false,1,4535,2017-03-17
-4536,T616,"Procedure flowchart for claims for compensation for the compulsory purchase of land and other claims for land compensation",t616-eng.pdf,application/pdf,388115,01/2016,8,2,false,1,4536,2017-03-17
-4537,T617,"Procedure flowchart for applications to discharge or modify restrictive covenants affecting land",t617-eng.pdf,application/pdf,202926,01/2016,8,2,false,1,4537,2017-03-17
-4538,T618,"Upper Tribunal Lands Chamber Flowchart - Detailed Assessment of Costs",t618-eng.pdf,application/pdf,52655,11/2010,8,2,false,1,4538,2017-03-17
-4539,T619A,"Guidance Notes for Completion of SIAC Appeal Form",t619a-eng.pdf,application/pdf,574728,07/2015,8,4,false,1,4539,2017-03-17
-4540,T98A,"Rights of appeal",t098a-eng.pdf,application/pdf,27588,11/2014,8,2,false,1,4540,2017-03-17
-4542,FL701,"Forced Marriage Protection Orders - How can they protect me? (Arabic)",fl701-ara.pdf,application/pdf,554028,02/2015,2,2,false,1,4542,2017-03-17
-4543,FL701,"Forced Marriage Protection Orders - How can they protect me? (Bengali)",fl701-ben.pdf,application/pdf,401170,02/2015,3,2,false,1,4543,2017-03-17
-4544,FL701,"Forced Marriage Protection Orders - How can they protect me? (Farsi)",fl701-far.pdf,application/pdf,299571,02/2015,9,2,false,1,4544,2017-03-17
-4545,FL701,"Forced Marriage Protection Orders - How can they protect me? (Punjabi)",fl701-pun.pdf,application/pdf,655057,02/2015,17,2,false,1,4545,2017-03-17
-4546,FL701,"Forced Marriage Protection Orders - How can they protect me? (Urdu)",fl701-urd.pdf,application/pdf,233762,02/2015,24,2,false,1,4546,2017-03-17
-4547,SEND23,"Working document guidance",send23-eng-2016.03.01.pdf,application/pdf,141804,01/2015,8,4,false,1,4547,2017-03-17
-4549,IAFT-6 Guide,"A guide to completing IAFT-6 appeal form - Information on fee payment - Notice of appeal to the First-Tier Tribunal (Immigration and Asylum Chamber) overseas entry clearance",iaft6-guide-eng.pdf,application/pdf,192098,11/2016,8,4,false,1,4549,2017-03-17
-4550,T94,"Appealing to the First-tier Tribunal (Transport)",t094-eng.pdf,application/pdf,203924,08/2014,8,2,false,1,4550,2017-03-17
-4551,SEND25,"How to Appeal a Special Educational Needs and Disability (SEND) Decision",send025-eng.pdf,application/pdf,248991,09/2014,8,2,false,1,4551,2017-03-17
-4552,T499,"The War Pensions and Armed Forces Compensation Chamber Short Guide",t499-eng.pdf,application/pdf,106430,04/2011,8,4,false,1,4552,2017-03-17
-4553,T610,"The War Pensions and Armed Forces Compensation FAQ",t610-eng.pdf,application/pdf,44172,10/2008,8,2,false,1,4553,2017-03-17
-4554,IAFT-7 Guide,"A guide to completing IAFT-7 appeal form - Information on fee payment - Notice of appeal to the First-Tier Tribunal (Immigration and Asylum Chamber) overseas appeal against a decision made inside the UK",iaft7-guide-eng.pdf,application/pdf,240760,11/2016,8,4,false,1,4554,2017-03-17
-4555,SEND14,"Information About Schools",send014-eng.pdf,application/pdf,240015,08/2014,8,2,false,1,4555,2017-03-17
-4556,REMO 7 Notes,"Guidance Notes for Completing an Application for Recognition, Declaration of Enforceability or Enforcement of a Decision Relating to Maintenance Obligations",remo007-notes-eng.pdf,application/pdf,229511,09/2014,8,4,false,1,4556,2017-03-17
-4557,REMO 8 Notes,"Guidance Notes for Completing an Application to Obtain a Maintenance Decision or to Have a Decision Relating to Maintenance Modified",remo008-notes-eng.pdf,application/pdf,147884,08/2014,8,4,false,1,4557,2017-03-17
-4558,IAUT1 Guide,"A guide to completing IAUT-1 application form",iaut001-guide-eng.pdf,application/pdf,171511,07/2015,8,4,false,1,4558,2017-03-17
-4577,REMO 20,"A guide to Reciprocal Enforcement of Maintenance Orders",remo020-eng.pdf,application/pdf,540718,06/2015,8,4,false,1,4577,2017-03-17
-4592,COP42,"Making an application to the Court of Protection",cop42-eng.pdf,application/pdf,251489,12/2013,8,2,false,1,4592,2017-03-17
-4600,COP44,"Court of Protection fees",cop044-eng.pdf,application/pdf,74743,11/2015,8,2,false,1,4600,2017-03-17
-4601,PH1,"Application by occupier of a park home on a protected site (other than a transit pitch on a local authority gypsy and traveller site) for an order that the site owner give the occupier a written statement as to the terms of their agreement",ph1-eng.doc,application/msword,131072,01/2017,8,1,false,1,4601,2017-03-17
-4602,COP44B,"Guide - Applying for help with Court of Protection fees",cop44b-eng.pdf,application/pdf,454231,04/2016,8,4,false,1,4602,2017-03-17
-4603,PH3,"Application by occupier of a park home or a park home site owner for a determination of any question arising under the Mobile Homes Act 1983 or agreement to which it applies",ph3-eng.doc,application/msword,158720,01/2017,8,1,false,1,4603,2017-03-17
-4604,PH4,"Application by site owner for a determination that having regard to its condition a park home is having a detrimental effect on the amenity of the site",ph4-eng.doc,application/msword,141824,01/2017,8,1,false,1,4604,2017-03-17
-4605,PH5,"Application by owner of a park home site for a refusal order preventing the occupier from selling the park home and assigning the agreement to the proposed occupier",ph5-eng.doc,application/msword,160768,01/2017,8,1,false,1,4605,2017-03-17
-4606,PH6,"Application by owner of a park home site for a refusal order preventing the occupier from giving the park home and assigning the agreement to a member of the occupier's family",ph6-eng.doc,application/msword,159744,01/2017,8,1,false,1,4606,2017-03-17
-4607,PH7,"Application by site owner for a determination that the owner may require an occupier to re-site the occupier's home temporarily to another pitch on the protected site",ph7-eng.doc,application/msword,138752,01/2017,8,1,false,1,4607,2017-03-17
-4608,PH8,"Application by the occupier for an order that the site owner secure that a temporarily re-sited home is returned to the original pitch",ph8-eng.doc,application/msword,129536,01/2017,8,1,false,1,4608,2017-03-17
-4609,PH9,"Application by site owner or occupier for determination of new level of pitch fee",ph9-eng.doc,application/msword,163840,01/2017,8,1,false,1,4609,2017-03-17
-4610,PH10,"Application by a protected site owner for a determination that improvements should be taken into account when the pitch fee is reviewed",ph10-eng.doc,application/msword,134144,01/2017,8,1,false,1,4610,2017-03-17
-4611,PH11,"Application to the tribunal by a park homes site residents' association for an order recognising the applicant as a qualifying association",ph11-eng.doc,application/msword,137728,01/2017,8,1,false,1,4611,2017-03-17
-4612,PH12,"Application by site owner for a determination as to the applicant's entitlement to terminate the agreement",ph12-eng.doc,application/msword,145408,01/2017,8,1,false,1,4612,2017-03-17
-4613,PH13,"Application by a local authority site owner for determination of new level of pitch fee",ph13-eng.doc,application/msword,167936,01/2017,8,1,false,1,4613,2017-03-17
-4614,PH14,"Application under regulation 17 of the Mobile Homes (Site Rules) (England) Regulations 2014",ph14-eng.doc,application/msword,130560,01/2017,8,1,false,1,4614,2017-03-17
-4615,PH15,"Application under regulation 10 of the Mobile Homes (Site Rules) (England) Regulations 2014 ('the 2014 regulations') with regard to the proposed making, varying or deletion of a site rule or rules",ph15-eng.doc,application/msword,147968,01/2017,8,1,false,1,4615,2017-03-17
-4616,PH16,"Application under regulation 6 of the Mobile Homes (Site Licensing) (England) Regulations 2014 ('the 2014 regulations') with regard to the local authority's refusal to issue, or consent to the transfer of, a site licence",ph16-eng.doc,application/msword,132608,01/2017,8,1,false,1,4616,2017-03-17
-4617,PH17,"Application by a local authority under Section 5A(3) of the Caravan Sites and Control of Development Act 1960 (as amended) ('the Act') for an order as to payment of the annual site licence fee by the licence holder ('a payment order') OR an order for revocation of the site licence on the ground of non-compliance with a payment order",ph17-eng.doc,application/msword,133632,01/2017,8,1,false,1,4617,2017-03-17
-4618,PH18,"Appeal under Section 7 or 8 of the Caravan Sites and Control of Development Act 1960 (as amended) ('the Act') (1) with regard to conditions attached to a site licence or (2) to an alteration by the local authority of conditions attached to a licence",ph18-eng.doc,application/msword,142336,01/2017,8,1,false,1,4618,2017-03-17
-4619,PH19,"Appeal under the Caravan Sites and Control of Development Act 1960 (as amended) ('the Act') against: (1) a compliance notice served by a local authority under Section 9A of the Act with regard to an alleged breach of condition(s) attached to a site licence, or (2) the taking of emergency action by the local authority under Section 9E of the Act, or (3) the demand by a local authority for a charge under Section 9F of the Act in respect of action in default or emergency action",ph19-eng.doc,application/msword,144384,01/2017,8,1,false,1,4619,2017-03-17
-4630,Form 200,"Civil Appeals Office fees (from 18 April 2016)",form-200-eng.pdf,application/pdf,89134,04/2016,8,1,false,1,4630,2017-03-17
-4635,LOC014,"Court fees for bankrupts",loc014-eng.pdf,application/pdf,144500,12/2008,8,1,false,1,4635,2017-03-17
-4640,Form 56C,"Court of Appeal Mediation Scheme - Fees Schedule",form-056c-eng.pdf,application/pdf,13988,10/2012,8,1,false,1,4640,2017-03-17
-4645,Gambling - Application for fee remission for companies,"Application for fee remission for companies",gambling-fee-exemption(company)-eng.pdf,application/pdf,20968,01/2010,8,1,false,1,4645,2017-03-17
-4650,EX504,"Graduated Fees Reference to a Judge",ex504-eng.pdf,application/pdf,383396,08/2009,8,1,false,1,4650,2017-03-17
-4660,UTLC Fees,"Upper Tribunal (Lands Chamber) fees table (from 18 April 2016)",utlc-fees-eng.pdf,application/pdf,73795,11/2016,8,2,false,1,4660,2017-03-17
-4724,SEND24,"EHC appeal form - child of or under statutory school age",send24-eng-2016.03.30.pdf,application/pdf,599191,02/2016,8,1,false,1,4724,2017-03-17
-4725,SEND24A,"EHC appeal form - young person over statutory school age",send024a-eng.pdf,application/pdf,223063,06/2015,8,1,false,1,4725,2017-03-17
-4726,SEND4B,"Disability Discrimination Claim by Young Person",send004b-eng.pdf,application/pdf,166358,09/2015,8,1,false,1,4726,2017-03-17
-4727,SEND26A,"Disability discrimination claim after permanent exclusion - parent",send026a-eng.pdf,application/pdf,199651,09/2015,8,1,false,1,4727,2017-03-17
-4728,SEND26B,"Disability discrimination claim after permanent exclusion - young person",send026b-eng.pdf,application/pdf,177797,09/2015,8,1,false,1,4728,2017-03-17
-4729,SEND28,"Appeal form - child detained in youth accommodation",send28-eng-2016.03.01.pdf,application/pdf,130042,02/2016,8,1,false,1,4729,2017-03-17
-4730,SEND28A,"Appeal form - young person under 18 detained in youth accommodation",send28a-eng-2016.03.01.pdf,application/pdf,221712,02/2016,8,1,false,1,4730,2017-03-17
-4733,SEND 30,"Request for a Witness Summons",send030-eng.pdf,application/pdf,77852,07/2015,8,1,false,1,4733,2017-03-17
-4734,EXN161,"Appellant's notice - Application for Permission to Appeal Under Sections 26, 28, 103, 105, 108 and 110 of the Extradition Act 2003",exn161-eng.doc,application/msword,62464,10/2014,8,1,false,1,4734,2017-03-17
-4735,EXN162,"Respondent's notice - To an Application for Permission to Appeal Under Sections 26, 28, 103, 105, 108 and 110 of the Extradition Act 2003",exn162-eng.doc,application/msword,55808,10/2014,8,1,false,1,4735,2017-03-17
-4736,EX244,"Application Notice - (Pursuant to the Extradition Act 2003)",ex244-eng.doc,application/msword,36864,10/2014,8,1,false,1,4736,2017-03-17
-4737,SEND24B,"Appeal form - refusal to secure an EHC assessment - child of or under statutory school age",send24b-eng.pdf,application/pdf,235511,08/2016,8,1,false,1,4737,2017-03-17
-4738,EX160A,"Sut i wneud cais am help i dalu ffioedd | How to apply for help with fees",ex160a-bil.pdf,application/pdf,193900,02/2017,26,2,false,1,4738,2017-03-17
-4750,REMO 7,"Application Form With a View to the Recognition, Declaration of Enforceability or Enforcement of a Decision in Matters Relating to Maintenance Obligations",remo007-eng.pdf,application/pdf,119793,10/2014,8,1,false,1,4750,2017-03-17
-4751,REMO 8,"Application Form to Obtain or Have Modified a Decision in Matters Relating to Maintenance Obligations",remo008-eng.pdf,application/pdf,132901,10/2014,8,1,false,1,4751,2017-03-17
-4752,UT3 Notes,"Notes for Appellants Form UT3 (Mental Health)",ut003-notes-eng.pdf,application/pdf,39430,11/2009,8,3,false,1,4752,2017-03-17
-4753,UT3 Leaflet,"Appealing Against a Decision of the Health, Education and Social Care Chamber of the First-tier Tribunal (Mental Health) (Appeals from Decisions of the First-tier Tribunal)",ut003-leaflet-eng.pdf,application/pdf,111679,04/2013,8,2,false,1,4753,2017-03-17
-4754,UT3 Leaflet,"Appealing Against a Decision of the Health, Education and Social Care Chamber of the First-tier Tribunal (Mental Health) (Appeals from Decisions of the First-tier Tribunal)",ut003-leaflet-eng.doc,application/msword,1787904,03/2013,8,2,false,1,4754,2017-03-17
-4755,UT4 Notes,"Notes for Appellants Form UT4 (Special Educational Needs and Disability Discrimination in Schools)",ut004-notes-eng.pdf,application/pdf,34204,10/2011,8,3,false,1,4755,2017-03-17
-4756,UT4 Leaflet,"Appealing Against a Decision of the Health, Education and Social Care Chamber of the First-tier Tribunal (Special Educational Needs) (Appeals from Decisions of the First-tier Tribunal)",ut004-leaflet-eng.pdf,application/pdf,67454,04/2014,8,2,false,1,4756,2017-03-17
-4757,UT5 Notes,"Notes for Applicants and Appellants Form UT5 (Health Education & Social Care Chamber Care Standards and NHS (Performers) List)",ut005-notes-eng.pdf,application/pdf,87807,05/2013,8,3,false,1,4757,2017-03-17
-4758,UT5 Leaflet,"Appealing to the Upper Tribunal Administrative Appeals Chamber from the First-tier Tribunal. Care Standards and NHS (Performers) List Decisions",ut005-leaflet-eng.pdf,application/pdf,117591,05/2013,8,2,false,1,4758,2017-03-17
-4759,UT6 Notes,"Notes for Appellants Form UT6 (War Pensions and Armed Forces Compensation)",ut006-notes-eng.pdf,application/pdf,30866,07/2012,8,3,false,1,4759,2017-03-17
-4760,UT6 Notes,"Notes for Appellants Form UT6 (War Pensions and Armed Forces Compensation)",ut006-notes-eng.doc,application/msword,54272,07/2012,8,3,false,1,4760,2017-03-17
-4761,UT6 Leaflet,"Appealing Against a Decision of the War Pensions and Armed Forces Compensation Chamber of the First-tier Tribunal (Appeals from Decisions of the First-tier Tribunal)",ut006-leaflet-eng.pdf,application/pdf,85785,07/2012,8,2,false,1,4761,2017-03-17
-4762,UT6 Leaflet,"Appealing Against a Decision of the War Pensions and Armed Forces Compensation Chamber of the First-tier Tribunal (Appeals from Decisions of the First-tier Tribunal)",ut006-leaflet-eng.doc,application/msword,1807360,04/2013,8,2,false,1,4762,2017-03-17
-4763,UT8 Notes,"Notes for Applicants and Appellants form UT8 (Mental Health Wales)",ut008-notes-eng.pdf,application/pdf,320445,04/2012,8,3,false,1,4763,2017-03-17
-4765,UT8 Leaflet,"Appealing Against a Decision of the Health, Education and Social Care Chamber of the First-tier Tribunal (Mental Health Wales) (Appeals from Decisions of the First-tier Tribunal)",ut008-leaflet-eng.pdf,application/pdf,64029,03/2014,8,2,false,1,4765,2017-03-17
-4766,UT9 Notes,"Notes for Applicants and Appellants Form UT9 (Appeals from Special Educational Needs Tribunal for Wales)",ut009-notes-eng.pdf,application/pdf,309844,04/2012,8,3,false,1,4766,2017-03-17
-4767,UT9 Leaflet,"Appealing Against a Decision of the Health, Education and Social Care Chamber of the First-tier Tribunal (Special Educational Needs Wales) (Appeals from Decisions of the First-tier Tribunal)",ut009-leaflet-eng.pdf,application/pdf,107267,05/2009,8,2,false,1,4767,2017-03-17
-4768,UT10 Leaflet,"Appeals against decisions of the Disclosure and Barring Service (Appeals direct to the Upper Tribunal)",ut10-leaflet-eng.pdf,application/pdf,185000,09/2016,8,2,false,1,4768,2017-03-17
-4770,UT11 Notes,"Notes for Applicants and Appellants Form UT11 (General Regulatory Chamber)",ut011-notes-eng.pdf,application/pdf,551704,11/2014,8,3,false,1,4770,2017-03-17
-4771,UT11 Leaflet,"All General Regulatory Chamber Cases Except Information Rights (Appeals from Decisions of the First-tier Tribunal)",ut011-leaflet-eng.pdf,application/pdf,419962,09/2015,8,2,false,1,4771,2017-03-17
-4772,UT12 Notes,"Notes for appellants form UT12 (Traffic Commissioner) appeals",ut12-notes-eng.pdf,application/pdf,404635,12/2016,8,3,false,1,4772,2017-03-17
-4773,UT12 Leaflet,"Appeals Against Decisions of the Traffic Commissioner (Appeals Direct to the Upper Tribunal)",ut012-leaflet-eng.pdf,application/pdf,167343,08/2009,8,2,false,1,4773,2017-03-17
-4774,UT13 Leaflet,"Appealing to the Administrative Appeals Chamber of the Upper Tribunal - Against Decisions of the First-Tier Tribunal in Information Rights Cases (General Regulatory Chamber)",ut013-leaflet-eng.pdf,application/pdf,245431,09/2014,8,2,false,1,4774,2017-03-17
-4780,Fee Account,"Fee Account - The Easy Way to Pay Fees",fee-account-eng.pdf,application/pdf,113727,06/2015,8,2,false,1,4780,2017-03-17
-4781,Secure Data Transfer,"Secure Data Transfer (SDT) - Using SDT to improve the service we offer",secure-data-transfer-eng.pdf,application/pdf,168835,04/2016,8,2,false,1,4781,2017-03-17
-4782,Fee Account FAQs,"Fee Account - Frequently Asked Questions",fee-account-faq-eng.pdf,application/pdf,548281,09/2016,8,2,false,1,4782,2017-03-17
-4783,Fee Account T&Cs,"Fee Account terms and conditions",fee-account-tc-eng-20160203.pdf,application/pdf,553525,01/2016,8,2,false,1,4783,2017-03-17
-4784,MCOL Guide,"Money Claim Online (MCOL) - User guide for claimants",mcol-guide-eng.pdf,application/pdf,378241,07/2016,8,4,false,1,4784,2017-03-17
-4800,CS A1,"Appeal application form - Child Care Providers and Children's Homes",csa001-eng.pdf,application/pdf,119605,07/2014,8,1,false,1,4800,2017-03-17
-4801,CS R1,"Response to appeal application - for Justice of the Peace, Ofsted, Care quality commission (CGC), Care and Social Services Inspectorate Wales (CCSIW), Health Inspectorate Wales or a Child Minder Agency (CMA) cases",csr001-eng.pdf,application/pdf,84808,07/2014,8,1,false,1,4801,2017-03-17
-4802,CS A2,"Appeal Application Form - Establishment Agencies",csa002-eng.pdf,application/pdf,125534,07/2014,8,1,false,1,4802,2017-03-17
-4803,CS R2,"Response to appeal application - for all Welsh Ministers, Secretary of State - Department of Education cases",csr002-eng.pdf,application/pdf,79192,11/2015,8,1,false,1,4803,2017-03-17
-4804,CS A3,"Appeal application form - Independent Schools/Non-maintained Special Schools",csa003-eng.pdf,application/pdf,117738,11/2015,8,1,false,1,4804,2017-03-17
-4805,CS R3,"Response to appeal application - Secretary of State for All Inclusion on the Protection of Children (PoCA) or on the Protection of Vulnerable Adults (PoVA) List and Monitor",csr003-eng.pdf,application/pdf,80865,07/2014,8,1,false,1,4805,2017-03-17
-4806,CS A4,"Appeal Application Form - Monitor",csa004-eng.pdf,application/pdf,109840,07/2014,8,1,false,1,4806,2017-03-17
-4807,CS A90,"Appeal Application Form - Inclusion on the Protection of Children (PoCA) List",csa090-eng.pdf,application/pdf,122825,07/2014,8,1,false,1,4807,2017-03-17
-4808,CS A91,"Appeal Application Form - Prohibition or Restriction From Participating in the Management of an Independent School Under Section 142 of the Education Act",csa091-eng.pdf,application/pdf,105243,07/2014,8,1,false,1,4808,2017-03-17
-4809,CS R91,"Response to appeal application - Prohibition or Restriction from participating in the management of an independent school under Section 142 of the Education Act",csr091-eng.pdf,application/pdf,83582,07/2014,8,1,false,1,4809,2017-03-17
-4810,CS P1,"Application for permission to appeal a decision of the First-tier Tribunal (Care Standards)",csp001-eng.pdf,application/pdf,89659,07/2014,8,1,false,1,4810,2017-03-17
-4811,CS S1,"Application to set aside a decision of the First-tier Tribunal (Care Standards)",css001-eng.pdf,application/pdf,94644,07/2014,8,1,false,1,4811,2017-03-17
-4812,CS WD,"Withdrawal Form (Except for PoCA and PoVA Cases)",cswd-eng.pdf,application/pdf,69738,07/2014,8,1,false,1,4812,2017-03-17
-4827,SEND27,"Guidance for the Local Authority producing the hearing bundle",send27-eng.pdf,application/pdf,360004,04/2016,8,4,false,1,4827,2017-03-17
-4828,SEND28B,"Detained Children and Young People With SEN",send028b-eng.pdf,application/pdf,137251,05/2015,8,2,false,1,4828,2017-03-17
-4850,Crown Court Preliminary Hearing form,"Crown Court Preliminary Hearing Form (Section 28)",preliminary-hearing-eng.doc,application/msword,219136,09/2014,8,1,false,1,4850,2017-03-17
-4851,Ground Rules Hearing Form,"Defence Ground Rules Hearing Form (Section 28)",ground-rules-hearing-eng.doc,application/msword,104448,10/2014,8,1,false,1,4851,2017-03-17
-4852,T386,"Respondent's notice (Valuation Tribunal Appeal)",t386-eng.pdf,application/pdf,546967,01/2016,8,1,false,1,4852,2017-03-17
-4853,SSCS6,"Notice of Appeal Against a Decision by the Scheme Administrator for the Diffuse Mesothelioma Payment Scheme",sscs006-eng.pdf,application/pdf,184551,10/2014,8,1,false,1,4853,2017-03-17
-4900,T464,"Cais Amgen am Dystysgrif Cydnabod Rhyw",t464-cym.pdf,application/pdf,664728,06/2016,25,1,false,1,4900,2017-03-17
-4901,T466,"Statutory Declaration for Applicants who are married",t466-eng.pdf,application/pdf,333129,10/2014,8,1,false,1,4901,2017-03-17
-4902,T467,"Statutory Declaration for single Applicants",t467-eng.pdf,application/pdf,182470,10/2014,8,1,false,1,4902,2017-03-17
-4903,T468,"Statutory Declaration for Applicants in a Civil Partnership",t468-eng.pdf,application/pdf,301555,10/2014,8,1,false,1,4903,2017-03-17
-4904,T469,"Statutory Declaration for the Spouse of an Applicant for Gender Recognition",t469-eng.pdf,application/pdf,270091,10/2014,8,1,false,1,4904,2017-03-17
-4910,N460,"Reasons for allowing or refusing permission to appeal (including referral to the Court of Appeal (Civil Division)), and information concerning routes of appeal",n460-eng.pdf,application/pdf,80648,10/2016,8,1,false,1,4910,2017-03-17
-4915,N460HC,"Reasons for allowing or refusing permission to appeal and information concerning routes of appeal",n460hc-eng.pdf,application/pdf,73241,10/2016,8,1,false,1,4915,2017-03-17
-4920,N325A,"Request for Warrant for Possession of Land following a Suspended Order for Possession",n325a-eng.pdf,application/pdf,69480,12/2016,8,1,false,1,4920,2017-03-17
-5053,EU Article 53,"Certificate Concerning a Judgment in Civil and Commercial Matters",eu-article-053-eng.pdf,application/pdf,728949,01/2015,8,1,false,1,5053,2017-03-17
-5060,EU Article 60,"Certificate Concerning an Authentic Instrument Court Settlement in Civil and Commercial Matters",eu-article-060-eng.pdf,application/pdf,694967,01/2015,8,1,false,1,5060,2017-03-17
-5100,D89,"Cais am wasanaeth cyflwyno personol gan feili llys",d89-cym.pdf,application/pdf,76164,10/2016,25,1,false,1,5100,2017-03-17
-5105,FP161A,"Nodiadau Canllaw ar Lenwi Ffurflen FP161 - Hysbysiad Apelydd",fp161a-cym.pdf,application/pdf,87715,10/2016,25,2,false,1,5105,2017-03-17
-5110,FP161,"Hysbysiad apelydd",fp161-cym.pdf,application/pdf,139717,10/2016,25,1,false,1,5110,2017-03-17
-5115,FP161B,"Nodiadau i Atebwyr",fp161b-cym.pdf,application/pdf,27827,10/2016,25,2,false,1,5115,2017-03-17
-5120,FP162,"Hysbysiad atebydd",fp162-cym.pdf,application/pdf,121789,10/2016,25,1,false,1,5120,2017-03-17
-5125,FP162A,"Nodiadau canllaw ar lenwi Ffurflen FP162 - Hysbysiad Atebydd",fp162a-cym.pdf,application/pdf,65887,10/2016,25,2,false,1,5125,2017-03-17
-5130,FP244,"Rhybudd Cyflwyno Cais (I'w ddefnyddio mewn ceisiadau a wneir mewn apeliadau i Adran Deulu'r Uchel Lys)",fp244-cym.pdf,application/pdf,64759,10/2016,25,1,false,1,5130,2017-03-17
-5135,FP200,"Ffioedd Achosion Teulu o 18 Ebrill 2016",fp200-cym.pdf,application/pdf,159502,10/2016,25,2,false,1,5135,2017-03-17
-5145,FP201,"Llwybrau Apelio",fp201-cym.pdf,application/pdf,112907,10/2016,25,2,false,1,5145,2017-03-17
-5155,FP202,"Sut i apelio i Adran Deulu'r Uchel Lys",fp202-cym.pdf,application/pdf,135779,10/2016,25,2,false,1,5155,2017-03-17
-5165,FP244A,"Rhybudd Cyflwyno Cais (FP244) - Nodiadau Canllaw",fp244a-cym.pdf,application/pdf,47635,10/2016,25,2,false,1,5165,2017-03-17
-5175,N161D,"Nodiadau canllaw ar lenwi ffurflen N161 - Hysbysiad Apelydd (pob apêl achos teulu yn y Llys Apêl (yr Adran Si l) a'r llys teulu)",n161d-cym.pdf,application/pdf,148313,10/2016,25,2,false,1,5175,2017-03-17
-7000,COP1,"Ffurflen gais",cop001-cym.pdf,application/pdf,273240,08/2015,25,1,false,1,7000,2017-03-17
-7060,COP7,"Cais i wrthwynebu cofrestru Atwrneiaeth Arhosol (LPA)",cop007-cym.pdf,application/pdf,111816,08/2015,25,1,false,1,7060,2017-03-17
-7080,COP9,"Hysbysiad o gais",cop009-cym.pdf,application/pdf,72798,12/2013,25,1,false,1,7080,2017-03-17
-7090,COP10,"Hysbysiad o gais ar gyfer ceisiadau i ymuno fel parti",cop010-cym.pdf,application/pdf,69982,12/2013,25,1,false,1,7090,2017-03-17
-7130,COP14,"Achos yn eich cylch chi yn y Llys Gwarchod",cop014-cym.pdf,application/pdf,37352,12/2013,25,1,false,1,7130,2017-03-17
-7196,COP20B,"Tystysgrif cyflwyno/dim cyflwyno hysbysu/dim hysbysu",cop020b-cym.pdf,application/pdf,121194,12/2013,25,1,false,1,7196,2017-03-17
-7206,COP21B,"Y Llys Gwarchod: Nodiadau Canllaw ar gyfer llenwi ffurflen COP20B - Darllenwch y nodiadau canlynol cyn llenwi ffurflen COP20B",cop021b-cym.pdf,application/pdf,37180,01/2012,25,2,false,1,7206,2017-03-17
-7220,COP23,"Tystysgrif methiant tyst neu wrthodiad gan dyst i fod yn bresennol gerbron archwiliwr",cop023-cym.pdf,application/pdf,62246,12/2013,25,1,false,1,7220,2017-03-17
-7230,COP24,"Datganiad tyst",cop024-cym.pdf,application/pdf,47269,12/2013,25,1,false,1,7230,2017-03-17
-7240,COP25,"Affidafid",cop025-cym.pdf,application/pdf,53760,12/2013,25,1,false,1,7240,2017-03-17
-7270,COP28,"Hysbysiad o wrandawiad",cop028-cym.pdf,application/pdf,30153,01/2012,25,1,false,1,7270,2017-03-17
-7280,COP29,"Hysbysiad o wrandawiad ar gyfer gorchymyn traddodi",cop029-cym.pdf,application/pdf,28314,01/2012,25,1,false,1,7280,2017-03-17
-7290,COP30,"Hysbysiad newid cyfreithiwr",cop030-cym.pdf,application/pdf,63144,12/2013,25,1,false,1,7290,2017-03-17
-7300,COP31,"Hysbysiad o fwriad i ffeilio tystiolaeth drwy ddeponiad",cop031-cym.pdf,application/pdf,45826,12/2013,25,1,false,1,7300,2017-03-17
-7340,COP35,"Hysbysiad apelydd",cop035-cym.pdf,application/pdf,204200,12/2013,25,1,false,1,7340,2017-03-17
-7350,COP36,"Hysbysiad atebydd",cop036-cym.pdf,application/pdf,138644,12/2013,25,1,false,1,7350,2017-03-17
-7360,COP37,"Dadl fframwaith",cop037-cym.pdf,application/pdf,53387,12/2013,25,1,false,1,7360,2017-03-17
-7430,COP44,"Y Llys Gwarchod - ffioedd",cop044-cym.pdf,application/pdf,155579,11/2015,25,2,false,1,7430,2017-03-17
-7460,COP DLB,"Colli Rhyddid Datganiad brys eithriadol",cop-dlb-cym.pdf,application/pdf,98305,12/2013,25,1,false,1,7460,2017-03-17
-7470,COP DLC,"Colli Rhyddid Ffurflen caniatad",cop-dlc-cym.pdf,application/pdf,51462,04/2009,25,1,false,1,7470,2017-03-17
-7480,COP DLD,"Colli Rhyddid - Tystysgrif cyflwyno/dim cyflwyno; Tystysgrif hysbysu/dim hysbysu",cop-dld-cym.pdf,application/pdf,53265,04/2009,25,1,false,1,7480,2017-03-17
-7490,COP DLE,"Colli Rhyddid - Cydnabyddiad cyflwyno/hysbysu",cop-dle-cym.pdf,application/pdf,63976,04/2009,25,1,false,1,7490,2017-03-17
-7500,COP DOL10,"Cais i awdurdodi colli rhyddid (adran 4A(3) a 16(2)(a) o Ddeddf Galluedd Meddyliol 2005)",cop-dol010-cym.pdf,application/pdf,232300,10/2014,25,1,false,1,7500,2017-03-17
-7510,COP GN1,"Ceisiadau am benodi dirprwy ar gyfer eiddo a materion ariannol",cop-gn001-cym.pdf,application/pdf,71565,12/2013,25,2,false,1,7510,2017-03-17
-7520,COP GN2,"Arweiniad ar werthu eiddo y mae mwy nag un yn berchen arno",cop-gn002-cym.pdf,application/pdf,63448,08/2013,25,2,false,1,7520,2017-03-17
-7530,COP GN3,"Nodyn Canllaw - Ceisiadau gan ddirprwyon cyfredol",cop-gn003-cym.pdf,application/pdf,56803,08/2013,25,2,false,1,7530,2017-03-17
-7540,COP GN4,"Gwneud cais lles personol i'r Llys Gwarchod",cop-gn004-cym.pdf,application/pdf,74836,08/2013,25,2,false,1,7540,2017-03-17
-7550,COP GN5,"Dod i Wrandawiad yn y Llys Gwarchod yn Llundain neu yn un o'n llysoedd rhanbarthol",cop-gn005-cym.pdf,application/pdf,37124,12/2013,25,2,false,1,7550,2017-03-17
-7560,COP GN6,"Ceisiadau i'r Llys Gwarchod yng nghyswllt cytundebau tenantiaeth sengl a lluosog",cop-gn006-cym.pdf,application/pdf,45798,08/2013,25,2,false,1,7560,2017-03-17
-7570,COP GN7,"Polisi rhestru - gwybodaeth i ddefnyddwyr y llys",cop-gn007-cym.pdf,application/pdf,56826,08/2013,25,2,false,1,7570,2017-03-17
-7580,COP GN8,"Ceisiadau am Ewyllysiau Statudol, Rhoddion, Setliadau a thrafodion eraill yn ymwneud ag eiddo P",cop-gn008-cym.pdf,application/pdf,57522,08/2013,25,2,false,1,7580,2017-03-17
-10000,COP1,"COP1 - Court of Protection Application Form",cop001-eng.pdf,application/pdf,134441,07/2015,8,1,false,1,10000,2017-03-17
-10001,COP1,"Ffurflen gais | Application form",cop01-bil.pdf,application/pdf,419661,03/2010,26,1,false,1,10001,2017-03-17
-10010,COP1A,"COP1A - Annex A Supporting information for property and affairs applications",cop001a-eng.pdf,application/pdf,183652,07/2015,8,1,false,1,10010,2017-03-17
-10011,COP1A,"Atodiad A: Gwybodaeth ategol ar gyfer ceisiadau ynghylch eiddo a materion ariannol | Annex A: Supporting information for property and affairs applications",cop01a-bil.pdf,application/pdf,455301,03/2010,26,1,false,1,10011,2017-03-17
-10020,COP1B,"COP1B - Annex B - Supporting information for personal welfare applications",cop001b-eng.pdf,application/pdf,117054,07/2015,8,1,false,1,10020,2017-03-17
-10021,COP1B,"Atodiad B: Gwybodaeth ategol ar gyfer ceisiadau lles personol | Annex B: Supporting information for personal welfare applications",cop01b-bil.pdf,application/pdf,233196,03/2010,26,1,false,1,10021,2017-03-17
-10030,COP1C,"Annex C - Supporting information for statutory will, codicil, gift(s), deed of variation or settlement of property",cop001c-eng.pdf,application/pdf,111969,07/2015,8,1,false,1,10030,2017-03-17
-10040,COP1D,"Annex D - Supporting information for applications to appoint or discharge a trustee",cop001d-eng.pdf,application/pdf,104580,07/2015,8,1,false,1,10040,2017-03-17
-10050,COP1E,"Annex E - Supporting information for an application by existing deputy or attorney",cop001e-eng.pdf,application/pdf,100206,07/2015,8,1,false,1,10050,2017-03-17
-10060,COP1F,"Annex F - Supporting information relating to validity or operation of enduring power of attorney (EPA) or lasting power of attorney (LPA)",cop001f-eng.pdf,application/pdf,113175,07/2015,8,1,false,1,10060,2017-03-17
-10070,COP2,"Ffurflen ganiatad",cop002-cym.pdf,application/pdf,93857,10/2013,25,1,false,1,10070,2017-03-17
-10071,COP2,"Ffurflen ganiatâd | Permission form",cop02-bil.pdf,application/pdf,116358,03/2010,26,1,false,1,10071,2017-03-17
-10080,COP3,"Assessment of capacity",cop003-eng.pdf,application/pdf,307714,12/2013,8,1,false,1,10080,2017-03-17
-10081,COP3,"Asesu gallu | Assessment of capacity",cop03-bil.pdf,application/pdf,230413,03/2010,26,1,false,1,10081,2017-03-17
-10090,COP4,"COP4 - Deputy's declaration",cop004-eng.pdf,application/pdf,152658,09/2015,8,1,false,1,10090,2017-03-17
-10091,COP4,"Datganiad dirprwy | Deputy's declaration",cop04-bil.pdf,application/pdf,258800,03/2010,26,1,false,1,10091,2017-03-17
-10100,COP5,"Acknowledgment of Service/Notification",cop005-eng.pdf,application/pdf,107612,07/2015,8,1,false,1,10100,2017-03-17
-10101,COP5,"Cydnabod cyflwyniad/hysbysiad | Acknowledgment of service/notification",cop05-bil.pdf,application/pdf,182207,03/2010,26,1,false,1,10101,2017-03-17
-10120,COP7,"COP7 - Application to object to the registration of a Lasting Power of Attorney",cop007-eng.pdf,application/pdf,326588,07/2015,8,1,false,1,10120,2017-03-17
-10121,COP7,"Cais i wrthwynebu cofrestru Atwrneiaeth Arhosol (AA) | Application to object to the registration of a lasting power of attorney (LPA)",cop07-bil.pdf,application/pdf,219592,03/2010,26,1,false,1,10121,2017-03-17
-10130,COP8,"Application relating to the registration of an enduring power of attorney (EPA)",cop008-eng.pdf,application/pdf,333743,07/2015,8,1,false,1,10130,2017-03-17
-10140,COP9,"COP9 - Application notice",cop009-eng.pdf,application/pdf,284977,07/2015,8,1,false,1,10140,2017-03-17
-10141,COP9,"Hysbysiad o gais | Application notice",cop09-bil.pdf,application/pdf,147748,03/2010,26,1,false,1,10141,2017-03-17
-10150,COP10,"COP10 - Application notice for applications to be joined as a party",cop010-eng.pdf,application/pdf,281804,07/2015,8,1,false,1,10150,2017-03-17
-10151,COP10,"Hysbysiad o gais ar gyfer ceisiadau i ymuno fel parti | Application notice for applications to be joined as a party",cop10-bil.pdf,application/pdf,153905,03/2010,26,1,false,1,10151,2017-03-17
-10170,COP12,"Special undertaking by trustees",cop12-eng-2016.03.08.pdf,application/pdf,239004,01/2012,8,1,false,1,10170,2017-03-17
-10190,COP14,"Proceedings about you in the Court of Protection",cop14-eng-2016.03.08.pdf,application/pdf,241693,12/2013,8,1,false,1,10190,2017-03-17
-10191,COP14,"Achos yn eich cylch yn y Llys Gwarchod | Proceedings about you in the Court of Protection",cop14-bil.pdf,application/pdf,97604,03/2010,26,1,false,1,10191,2017-03-17
-10200,COP15,"Notice that an application form has been issued",cop15-eng-2016.03.08.pdf,application/pdf,243299,12/2013,8,1,false,1,10200,2017-03-17
-10201,COP15,"Hysbysiad bod y ffurflen gais wedi'i chyhoeddi | Notice that an application form has been issued",cop15-bil.pdf,application/pdf,107490,03/2010,26,1,false,1,10201,2017-03-17
-10250,COP20,"Tystysgrif cyflwyno/diffyg cyflwyno Tystysgrif hysbysu/diffyg hysbysu | Certificate of service/non-service Certificate of notification/non-notification",cop20-bil.pdf,application/pdf,281208,03/2010,26,1,false,1,10250,2017-03-17
-10260,COP20A,"Certificate of notification/non-notification of the person to whom the proceedings relate",cop020a-eng.pdf,application/pdf,125358,07/2015,8,1,false,1,10260,2017-03-17
-10270,COP20B,"Certificate of service/non-service notification/non-notification",cop020b-eng.pdf,application/pdf,140797,07/2015,8,1,false,1,10270,2017-03-17
-10290,COP22,"COP22 - Certificate of suitability of litigation friend",cop022-eng.pdf,application/pdf,273929,07/2015,8,1,false,1,10290,2017-03-17
-10291,COP22,"Tystysgrif addasrwydd cyfaill cyfreitha | Certificate of suitability of litigation friend",cop22-bil.pdf,application/pdf,122504,03/2010,26,1,false,1,10291,2017-03-17
-10300,COP23,"Certificate of failure or refusal of witness to attend before an examiner",cop23-eng-2016.03.08.pdf,application/pdf,310501,12/2013,8,1,false,1,10300,2017-03-17
-10301,COP23,"Tystysgrif methiant neu wrthodiad gan dyst i fod yn bresennol gerbron arholwr | Certificate of failure or refusal of witness to attend before an examiner",cop23-bil.pdf,application/pdf,130790,03/2010,26,1,false,1,10301,2017-03-17
-10310,COP24,"COP24 - Witness statement",cop024-eng.pdf,application/pdf,239486,09/2015,8,1,false,1,10310,2017-03-17
-10311,COP24,"Y Llys Gwarchod Datganiad Tyst | Court of Protection Witness statement",cop24-bil.pdf,application/pdf,109900,03/2010,26,1,false,1,10311,2017-03-17
-10320,COP25,"COP25 - Affidavit",cop025-eng.pdf,application/pdf,270700,07/2015,8,1,false,1,10320,2017-03-17
-10321,COP25,"Affidafid | Affidavit",cop25-bil.pdf,application/pdf,117567,03/2010,26,1,false,1,10321,2017-03-17
-10350,COP28,"Notice of hearing",cop28-eng-2016.03.08.pdf,application/pdf,259056,01/2012,8,1,false,1,10350,2017-03-17
-10351,COP28,"Hysbysiad o wrandawiad | Notice of hearing",cop28-bil.pdf,application/pdf,93125,03/2010,26,1,false,1,10351,2017-03-17
-10360,COP29,"Notice of hearing for committal order",cop29-eng-2016.03.08.pdf,application/pdf,47951,01/2012,8,1,false,1,10360,2017-03-17
-10361,COP29,"Hysbysiad o wrandawiad ar gyfer gorchymyn traddodi | Notice of hearing for committal order",cop29-bil.pdf,application/pdf,84724,03/2010,26,1,false,1,10361,2017-03-17
-10370,COP30,"COP30 - Notice of change of solicitor",cop030-eng.pdf,application/pdf,260198,07/2015,8,1,false,1,10370,2017-03-17
-10371,COP30,"Hysbysiad ynghylch newid twrnai | Notice of change of solicitor",cop30-bil.pdf,application/pdf,136203,03/2010,26,1,false,1,10371,2017-03-17
-10380,COP31,"COP31 - Notice of intention to file evidence by deposition",cop031-eng.pdf,application/pdf,325926,07/2015,8,1,false,1,10380,2017-03-17
-10381,COP31,"Hysbysiad o fwriad i ffeilio tystiolaeth drwy ddeponiad | Notice of intention to file evidence by deposition",cop31-bil.pdf,application/pdf,109561,03/2010,26,1,false,1,10381,2017-03-17
-10420,COP35,"Appellant's notice",cop035-eng.pdf,application/pdf,132673,07/2015,8,1,false,1,10420,2017-03-17
-10421,COP35,"Hysbysiad apelydd | Appellant's notice",cop35-bil.pdf,application/pdf,223363,03/2010,26,1,false,1,10421,2017-03-17
-10430,COP36,"Respondent's notice",cop36-eng-2016.03.08.pdf,application/pdf,301436,12/2013,8,1,false,1,10430,2017-03-17
-10431,COP36,"Hysbysiad apelydd | Respondent's notice",cop36-bil.pdf,application/pdf,205201,03/2010,26,1,false,1,10431,2017-03-17
-10440,COP37,"Skeleton argument",cop037-eng.pdf,application/pdf,296375,07/2015,8,1,false,1,10440,2017-03-17
-10450,COP DLA,"Deprivation of Liberty Application Form - For urgent consideration",cop-dla-eng.pdf,application/pdf,420366,07/2015,8,1,false,1,10450,2017-03-17
-10460,COP DLB,"Deprivation of Liberty - Declaration of exceptional urgency",cop-dlb-eng.pdf,application/pdf,357023,07/2015,8,1,false,1,10460,2017-03-17
-10480,COP DLD,"Deprivation of liberty Certificate of service non service Certificate of notification non notification",cop-dld-eng.pdf,application/pdf,351365,07/2015,8,1,false,1,10480,2017-03-17
-10490,COP DLE,"Acknowledgment of service/notification",cop-dle-eng.pdf,application/pdf,356572,07/2015,8,1,false,1,10490,2017-03-17
-10500,COP DOL10,"Application to authorise a deprivation of liberty",cop-dol10-eng.pdf,application/pdf,292098,12/2016,8,1,false,1,10500,2017-03-17
-10510,LPA 008,"Notice to the Office of the Public Guardian of an application to object to registration of a lasting power of attorney made to the Court of Protection",lpa008-eng.pdf,application/pdf,351845,09/2011,8,1,false,1,10510,2017-03-17
-12000,FGM001,"Application for a Female Genital Mutilation (FGM) Protection Order",fgm001-eng.pdf,application/pdf,121840,07/2015,8,1,false,1,12000,2017-03-17
-12010,FGM002,"Rhybudd o achos",fgm002-cym.pdf,application/pdf,28693,07/2015,25,1,false,1,12010,2017-03-17
-12020,FGM003,"Application to vary, extend or discharge a Female Genital Mutilation (FGM) Protection Order",fgm003-eng.pdf,application/pdf,92166,07/2015,8,1,false,1,12020,2017-03-17
-12030,FGM004,"Gorchymyn Amddiffyn rhag Anffurfio Organau Cenhedlu Benywod (FGM)",fgm004-cym.pdf,application/pdf,41887,07/2015,25,1,false,1,12030,2017-03-17
-12040,FGM005,"Application for a Warrant of Arrest - Female Genital Mutilation (FGM) Protection Order",fgm005-eng.pdf,application/pdf,63072,07/2015,8,1,false,1,12040,2017-03-17
-12050,FGM006,"Application for leave to apply for a Female Genital Mutilation (FGM) Protection Order",fgm006-eng.pdf,application/pdf,82874,07/2015,8,1,false,1,12050,2017-03-17
-12060,FGM007,"Application to be joined as, or cease to be, a party to a Female Genital Mutilation (FGM) Protection Order",fgm007-eng.pdf,application/pdf,106716,07/2015,8,1,false,1,12060,2017-03-17
-12065,FGM701,"Gorchmynion Amddiffyn rhag Anffurfio Organau Cenhedlu Benywod (FGM) - Canllawiau interim ar gyfer awdurdodau lleol fel trydydd parti perthnasol a gwybodaeth sy'n berthnasol i waith partneriaeth amlasiataethol",fgm701-cym.pdf,application/pdf,246232,08/2015,25,2,false,1,12065,2017-03-17
-13000,FGM700,"Female Genital Mutilation (FGM) Protection Orders - How can they protect me? (Amharic)",fgm700-amh.pdf,application/pdf,335067,07/2015,1,2,false,1,13000,2017-03-17
-13005,FGM700,"Female Genital Mutilation (FGM) Protection Orders - How can they protect me? (Arabic)",fgm700-ara.pdf,application/pdf,347839,07/2015,2,2,false,1,13005,2017-03-17
-13015,FGM700,"Female Genital Mutilation (FGM) Protection Orders - How can they protect me? (Farsi)",fgm700-far.pdf,application/pdf,488583,07/2015,9,2,false,1,13015,2017-03-17
-13020,FGM700,"Female Genital Mutilation (FGM) Protection Orders - How can they protect me? (French)",fgm700-fre.pdf,application/pdf,399729,07/2015,10,2,false,1,13020,2017-03-17
-13025,FGM700,"Female Genital Mutilation (FGM) Protection Orders - How can they protect me? (Somali)",fgm700-som.pdf,application/pdf,231986,07/2015,19,2,false,1,13025,2017-03-17
-13030,FGM700,"Female Genital Mutilation (FGM) Protection Orders - How can they protect me? (Swahili)",fgm700-swa.pdf,application/pdf,281224,07/2015,21,2,false,1,13030,2017-03-17
-13035,FGM700,"Female Genital Mutilation (FGM) Protection Orders - How can they protect me? (Tigrigina)",fgm700-tir.pdf,application/pdf,409558,07/2015,22,2,false,1,13035,2017-03-17
-13040,FGM700,"Female Genital Mutilation (FGM) Protection Orders - How can they protect me? (Turkish)",fgm700-tur.pdf,application/pdf,158428,07/2015,23,2,false,1,13040,2017-03-17
-13045,FGM700,"Female Genital Mutilation (FGM) Protection Orders - How can they protect me? (Urdu)",fgm700-urd.pdf,application/pdf,297881,07/2015,24,2,false,1,13045,2017-03-17
-14000,N1(CCFL),"Claim form Part 7 - Commercial Court Financial List",n001(ccfl)-eng.pdf,application/pdf,55693,10/2015,8,1,false,1,14000,2017-03-17
-14005,N1(CHFL),"Claim form Part 7- Chancery Division Financial List",n001(chfl)-eng.pdf,application/pdf,55757,10/2015,8,1,false,1,14005,2017-03-17
-14010,Guidance for misc out of court payments,"Guidance for miscellaneous payments out of court",out-of-court-payments(misc)-eng-20160202.pdf,application/pdf,518144,01/2016,8,4,false,1,14010,2017-03-17
-14115,FP161A,"Guidance notes on completing form FP161 - Appellant's notice",fp161a-eng.pdf,application/pdf,92657,10/2016,8,4,false,1,14115,2017-03-17
-14116,FP161B,"Notes for respondent",fp161b-eng.pdf,application/pdf,137000,10/2016,8,3,false,1,14116,2017-03-17
-14117,FP162A,"Guidance notes on completing form FP162 - Respondent's notice",fp162a-eng.pdf,application/pdf,137000,10/2016,8,4,false,1,14117,2017-03-17
-14118,FP200,"Family Proceedings fees from 18 April 2016",fp200-eng.pdf,application/pdf,137000,10/2016,8,2,false,1,14118,2017-03-17
-14119,FP201,"Routes of appeal",fp201-eng.pdf,application/pdf,137000,10/2016,8,2,false,1,14119,2017-03-17
-14120,FP202,"How  to appeal to the Family Division of the High Court",fp202-eng.pdf,application/pdf,137000,10/2016,8,2,false,1,14120,2017-03-17
-14121,FP244A,"Guidance notes on completing form FP244 - Application notice",fp244a-eng.pdf,application/pdf,137000,10/2016,8,4,false,1,14121,2017-03-17
-14122,N161D,"Guidance notes on completing form N161 ? Appellant?s notice (all family proceedings appeals in the court of appeal (Civil Division) and the family court)",n161d-eng.pdf,application/pdf,137000,10/2016,8,4,false,1,14122,2017-03-17
-14123,T495,"Immigration and Appeals Tribunal fees guidance",t495-eng.pdf,application/pdf,187342,11/2016,8,4,false,1,14123,2017-03-17
-14124,IAFT-5(DIA) Guide,"A guide to completing IAFT5(DIA) appeal form",iaft5(dia)-guide-eng.pdf,application/pdf,175735,12/2016,8,4,false,1,14124,2017-03-17
-14800,N9(CCFL),"Acknowledgment of Service - Commercial Court Financial List",n009(ccfl)-eng.pdf,application/pdf,339809,10/2015,8,1,false,1,14800,2017-03-17
-14805,N9(CCCH),"Acknowledgment of Service - Chancery Division Financial List",n009(chfl)-eng.pdf,application/pdf,340062,10/2015,8,1,false,1,14805,2017-03-17
-15700,N208(CCFL),"Claim form - Commercial Court Financial List",n208(ccfl)-eng.pdf,application/pdf,53201,10/2015,8,1,false,1,15700,2017-03-17
-15705,N208(CHFL),"Claim form - Chancery Division Financial List",n208(chfl)-eng.pdf,application/pdf,53303,10/2015,8,1,false,1,15705,2017-03-17
-15720,N210(CCFL),"Acknowledgment of Service - Commercial Court Financial List",n210(ccfl)-eng.pdf,application/pdf,229466,10/2015,8,1,false,1,15720,2017-03-17
-15725,N210(CHFL),"Acknowledgment of Service - Chancery Division Financial List",n210(chfl)-eng.pdf,application/pdf,229648,10/2015,8,1,false,1,15725,2017-03-17
-15730,N211(CCFL),"Claim form Part 20 - Commercial Court Financial List",n211(ccfl)-eng.pdf,application/pdf,72479,10/2015,8,1,false,1,15730,2017-03-17
-15735,N211(CHFL),"Claim form Part 20 - Chancery Division Financial List",n211(chfl)-eng.pdf,application/pdf,54776,10/2015,8,1,false,1,15735,2017-03-17
-15750,N213(CCFL),"Acknowledgment of Service - Commercial Court Financial List",n213(ccfl)-eng.pdf,application/pdf,244418,10/2015,8,1,false,1,15750,2017-03-17
-15755,N213(CHFL),"Acknowledgment of Service - Chancery Division Financial List",n213(chfl)-eng.pdf,application/pdf,244543,10/2015,8,1,false,1,15755,2017-03-17
-16060,N244(CCFL),"Application notice - Commercial Court Financial List",n244(ccfl)-eng.pdf,application/pdf,76388,10/2015,8,1,false,1,16060,2017-03-17
-16065,N244(CHFL),"Application notice - Chancery Division Financial List",n244(chfl)-eng.pdf,application/pdf,76714,10/2015,8,1,false,1,16065,2017-03-17
-16270,N265(CCFL),"List of documents: standard disclosure - Commercial Court Financial List",n265(ccfl)-eng.pdf,application/pdf,220132,10/2015,8,1,false,1,16270,2017-03-17
-16275,N265(CHFL),"List of documents: standard disclosure - Chancery Division Financial List",n265(chfl)-eng.pdf,application/pdf,220782,10/2015,8,1,false,1,16275,2017-03-17
-16300,Precedent R,"Claimant budget discussion report",precedent(r)-eng.xlsx,application/vnd.ms-excel,11458,04/2016,8,1,false,1,16300,2017-03-17
-16303,COA bundle index A2,"Appeal from an Employment Appeal Tribunal",coa-a2-eng.doc,application/msword,30000,09/2016,8,1,false,1,16303,2017-03-17
-16306,COA bundle index B6,"First appeal in divorce financial remedies matters",coa-b6-eng.doc,application/msword,30000,09/2016,8,1,false,1,16306,2017-03-17
-16307,COA bundle index C3,"Appeal from the Competition Appeal Tribunal",coa-c3-eng.doc,application/msword,30000,09/2016,8,1,false,1,16307,2017-03-17
-16308,COA bundle index T2,"Appeal from the Special Immigration Appeal Commission",coa-t2-eng.doc,application/msword,31000,09/2016,8,1,false,1,16308,2017-03-17
-16309,COA bundle index A3/C3,"Appeal from the Upper Tribunal Administrative Appeals Chamber or Tax and Chancery Chamber",coa-a3c3-eng.doc,application/msword,30000,09/2016,8,1,false,1,16309,2017-03-17
-16310,COA bundle index C3,"Appeal from the Upper Tribunal Lands Chamber",coa-utc3-eng.doc,application/msword,30000,09/2016,8,1,false,1,16310,2017-03-17
-16311,COA bundle index B2/B5,"First appeal from the County Court",coa-b2b5-eng.doc,application/msword,29000,09/2016,8,1,false,1,16311,2017-03-17
-16312,COA bundle index A1/A2/A3,"First appeal from the High Court",coa-a1a2a3-eng.doc,application/msword,30000,09/2016,8,1,false,1,16312,2017-03-17
-16313,COA bundle index A2,"First appeal in a bankruptcy or insolvency matter",coa-ba2-eng.doc,application/msword,30000,09/2016,8,1,false,1,16313,2017-03-17
-16314,COA bundle index B3,"First appeal in a personal injury or clinical negligence matter",coa-b3-eng.doc,application/msword,30000,09/2016,8,1,false,1,16314,2017-03-17
-16315,COA bundle index B5,"Homelessness appeal",coa-b5-eng.doc,application/msword,29000,09/2016,8,1,false,1,16315,2017-03-17
-16316,COA bundle index A3a,"Intellectual property first appeal",coa-a3a-eng.doc,application/msword,30000,09/2016,8,1,false,1,16316,2017-03-17
-16317,COA bundle index A3b,"Intellectual property second appeal",coa-a3b-eng.doc,application/msword,30000,09/2016,8,1,false,1,16317,2017-03-17
-16318,COA bundle index C4/C1,"Judicial review appeal from the Administrative Court or Judicial Review of decision of Upper Tribunal",coa-c4c1-eng.doc,application/msword,36000,09/2016,8,1,false,1,16318,2017-03-17
-16319,COA bundle index C1/C4/T3,"Judicial review appeal from the Administrative Court",coa-c1c4t3-eng.doc,application/msword,41000,09/2016,8,1,false,1,16319,2017-03-17
-16320,COA bundle index B4,"First appeal in a child case",coa-b4-eng.doc,application/msword,30000,09/2016,8,1,false,1,16320,2017-03-17
-16321,COA bundle index C2/C3/A3,"Judicial review from the Upper Tribunal",coa-c2c3a3-eng.doc,application/msword,36000,09/2016,8,1,false,1,16321,2017-03-17
-16322,COA bundle index C6,"Judicial review of administrative review decision or appeal from UTIAC",coa-c6-eng.doc,application/msword,31000,09/2016,8,1,false,1,16322,2017-03-17
-16323,COA bundle index B2/B5,"Second appeal from County Court, except homelessness",coa-ccb2b5-eng.doc,application/msword,30000,09/2016,8,1,false,1,16323,2017-03-17
-16324,COA bundle index A1/A2/A3a,"Second appeal from the High Court",coa-a1a2a3a-eng.doc,application/msword,31000,09/2016,8,1,false,1,16324,2017-03-17
-16325,COA bundle index A2,"Second appeal in bankruptcy or insolvency matters",coa-sba2-eng.doc,application/msword,30000,09/2016,8,1,false,1,16325,2017-03-17
-16326,COA bundle index B4,"Second appeal in a child case",coa-sab4-eng.doc,application/msword,31000,09/2016,8,1,false,1,16326,2017-03-17
-16327,COA bundle index B6,"Second appeal in divorce financial remedies matters",coa-sab6-eng.doc,application/msword,33000,09/2016,8,1,false,1,16327,2017-03-17
-16328,COA bundle index B3,"Second appeal in personal injury or clinical negligence matters",coa-sab3-eng.doc,application/msword,30000,09/2016,8,1,false,1,16328,2017-03-17
-16332,FP161,"Appellant's notice (For use in appeals to the Family Division of the High Court)",fp161-eng.pdf,application/pdf,153000,10/2016,8,1,false,1,16332,2017-03-17
-16333,FP162,"Respondent's notice (For use in appeals in the Family Division of the High Court)",fp162-eng.pdf,application/pdf,137000,10/2016,8,1,false,1,16333,2017-03-17
-16334,FP244,"Application notice (For use in applications made within appeals to the Family Division of the High Court)",fp244-eng.pdf,application/pdf,137000,10/2016,8,1,false,1,16334,2017-03-17
-16335,IAFT-5(DIA),"Appeal to the First-tier Tribunal - Information sheet",iaft5(dia)-eng.doc,application/msword,309760,12/2016,8,1,false,1,16335,2017-03-17
-17000,A20,"Mabwysiadu: Canllaw i ddefnyddwyr y llys teulu",a020-cym.pdf,application/pdf,161927,04/2014,25,2,false,1,17000,2017-03-17
-17001,C20,"Atodiad i gais am orchymyn i gadw plentyn mewn Llety Diogel",c20-cym.pdf,application/pdf,25070,08/2016,25,1,false,1,17001,2017-03-17
-17002,CB2,"Gwrandawiadau brys a gwrandawiadau heb rybudd mewn perthynas a threfniadau plant",cb002-cym.pdf,application/pdf,129930,07/2014,25,2,false,1,17002,2017-03-17
-17003,D63,"Judgment summons",d063-eng.pdf,application/pdf,119339,04/2011,8,1,false,1,17003,2017-03-17
-17004,EX20,"Talu fy nyfarniad - Beth ddylwn i wneud? | Paying my judgment, what do I do?",ex020-bil.pdf,application/pdf,251340,04/2006,26,2,false,1,17004,2017-03-17
-17005,EX301,"Yn gwneud hawliad? Ambell gwestiwn i chi ofyn i chi'ch hun | Making a claim? Some questions to ask yourself",ex301-bil.pdf,application/pdf,279782,04/2006,26,2,false,1,17005,2017-03-17
-17006,EX303,"Mae hawliad wedi'i wneud yn fy erbyn - beth ddylwn i ei wneud? | A claim has been made against me, what should I do?",ex303-bil.pdf,application/pdf,267464,04/2006,26,2,false,1,17006,2017-03-17
-17007,EX304,"Dim ateb i fy ffurflen hawliad - Beth ddylwn i wneud? | No reply to my claim form, what should I do?",ex304-bil.pdf,application/pdf,240093,04/2006,26,2,false,1,17007,2017-03-17
-17008,EX350,"Canllawiau i fusnesau bach ar gyfer adennill dyled drwy'r llys sirol | A guide to debt recovery through a county court for small businesses",ex350-bil.pdf,application/pdf,179855,04/2006,26,4,false,1,17008,2017-03-17
-17009,EX550,"Affidafid (gorchymyn i ddod i'r llys ar gyfer holi a gorchymyn traddodi gohiriedig) | Affidavit (order to attend for questioning and suspended committal order)",ex550-bil.pdf,application/pdf,188434,03/2002,26,1,false,1,17009,2017-03-17
-17010,N117,"Ffurflen Gyffredinol Ymgymeriad | General form of undertaking",n117-bil.pdf,application/pdf,54628,10/2012,26,1,false,1,17010,2017-03-17
-17011,N316,"Cais am orchymyn i ddyledwr ddod i'r llys ar gyfer holi",n316-cym.pdf,application/pdf,137656,06/2016,25,1,false,1,17011,2017-03-17
-17012,PA2,"How to obtain probate, a guide for people acting without a solicitor",pa2-eng.pdf,application/pdf,436147,10/2016,8,4,false,1,17012,2017-03-17
-17013,PA4,"Directory of Probate Registries and interview venues",pa4-eng.pdf,application/pdf,261040,03/2017,8,2,false,1,17013,2017-03-17
-17014,Pre-trial Checklist,"Pre-trial Checklist",pretrial-eng.doc,application/msword,19968,04/2005,8,2,false,1,17014,2017-03-17
-17015,EX50A,"Rhestr lawn o ffioedd sy'n gymwys yn y Llysoedd Sifil a Theulu (o 25 mis Gorffennaf 2016)",ex50a-cym.doc,application/msword,928768,07/2016,25,2,false,1,17015,2017-03-17
-17016,EX302,"Sut mae gwneud hawliad yn y llys? I bobl sydd am fynd ag anghydfod i'r llys",ex302-cym.pdf,application/pdf,149047,04/2014,25,2,false,1,17016,2017-03-17
-17017,EX320,"Dyfarniad cofrestredig - Beth mae hynny'n ei olygu?",ex320-cym.pdf,application/pdf,139924,04/2013,25,2,false,1,17017,2017-03-17
-17018,A21,"Mabwysiadu Rhyng-wladol a Chytundeb yr Hag 1993",a021-cym.pdf,application/pdf,177276,04/2014,25,2,false,1,17018,2017-03-17
-17019,A51 Nodiadau | A51 Notes,"Cais i amrywio gorchymyn lleoli (Ffurflen 51) Nodiadau ar lenwi'r ffurflen | Application for variation of a placement order (Form A51) Notes on completing the form",a051-notes-bil.pdf,application/pdf,101066,12/2005,26,3,false,1,17019,2017-03-17
-17020,A57 Nodiadau | A57 Notes,"Cais am orchymyn dychwelyd plentyn (Ffurflen A57) Nodiadau ar lenwi'r ffurflen | Application for a recovery order (Form A57) Notes on completing the form",a057-notes-bil.pdf,application/pdf,113887,12/2005,26,3,false,1,17020,2017-03-17
-17021,AJ20,"Siarter Llysoedd - Y Llysoedd Sifil",aj20-cym.pdf,application/pdf,203710,11/2006,25,2,false,1,17021,2017-03-17
-17022,AJ24,"Siarter Llysoedd - Y Gwasanaeth Profiant",aj24-cym.pdf,application/pdf,162548,11/2007,25,2,false,1,17022,2017-03-17
-17023,AJ25,"Siarter Llysoedd - Llysoedd Teulu",aj25-cym.pdf,application/pdf,209612,12/2006,25,2,false,1,17023,2017-03-17
-17024,AJ26,"Siarter Llysoedd - Y Llys Ynadon",aj26-cym.pdf,application/pdf,184190,11/2006,25,2,false,1,17024,2017-03-17
-17025,5222,"Eich canllaw i Wasanaeth Rheithgor",5222-cym.pdf,application/pdf,216535,02/2015,25,2,false,1,17025,2017-03-17
-17026,AJ22,"Courts Charter - The Royal Courts of Justice",aj22-eng.pdf,application/pdf,195164,10/2008,8,2,false,1,17026,2017-03-17
-17027,AJ24,"Courts Charter - The Probate Service",aj24-eng.pdf,application/pdf,204235,11/2007,8,2,false,1,17027,2017-03-17
-17028,PA1A,"Nodiadau canllaw ar gyfer y Ffurflen Gais am Brofiant PA1 | Guidance Notes for Probate Application Form PA1",pa001a-bil.pdf,application/pdf,193885,12/2008,26,4,false,1,17028,2017-03-17
-17029,N162A,"Nodiadau cyfarwyddiadol ar gyfer llenwi rhybudd yr atebydd | Guidance notes for completing the respondent's notice",n162a-bil.pdf,application/pdf,344677,04/2007,26,4,false,1,17029,2017-03-17
-17030,N461 Nodiadau | N461 Notes,"Nodiadau canllaw ar lenwi'r ffurflen hawlio Adolygiad Barnwrol | Guidance notes on completing the Judicial Review claim form",n461-notes-bil.pdf,application/pdf,196019,05/2009,26,4,false,1,17030,2017-03-17
-17031,MC100,"Make Sure You Can Pay Your Fine (Polish)",mc100-pol.pdf,application/pdf,519635,12/2013,15,2,false,1,17031,2017-03-17
-17032,ADM21,"Declaration as to inability of a defendant to file and serve statement of case under a decree of limitation",adm021-eng.pdf,application/pdf,75284,03/2002,8,1,false,1,17032,2017-03-17
-17033,5222A,"Yn gefn ichi Drwy'ch Gwasanaeth Rheithgor",5222a-cym.pdf,application/pdf,143219,01/2015,25,2,false,1,17033,2017-03-17
-17034,N211C(CC) Nodiadau,"Nodiadau i ddiffynnydd Rhan 20 ar ymateb i ffurflen hawlio Rhan 20 (Y Llys Masnachol)/Notes for Part 20 defendant on replying to the Part 20 claim form (Commercial Court)",n211c(cc)-cym.pdf,application/pdf,180833,10/2008,25,3,false,1,17034,2017-03-17
-17035,LOC002,"I Want to challenge the outcome of an election and how do I apply for relief",loc002-eng.pdf,application/pdf,162915,08/2014,8,2,false,1,17035,2017-03-17
-17036,PA5,"Do I need a Grant of Representation (Probate or Letters of Administration)? A guide for people dealing with the estate when someone has recently died",pa005-eng.pdf,application/pdf,345315,04/2011,8,4,false,1,17036,2017-03-17
-17037,PA5,"A oes angen grant cynrychiolaeth arnaf (profiant neu lythyrau gweinyddu)? Arweiniad i bobl sy'n delio a'r ystad pan fo rhywun wedi marw'n ddiweddar",pa005-cym.pdf,application/pdf,195946,04/2011,25,2,false,1,17037,2017-03-17
-17038,PA7,"How to deposit a will with the Probate Service, a guide for people who want to deposit a will for safekeeping",pa007-eng.pdf,application/pdf,266446,04/2011,8,4,false,1,17038,2017-03-17
-17039,PA7,"Sut i adneuo ewyllys gyda'r Gwasanaeth Profiant. Arweiniad i bobl sydd am adneuo ewyllys i fod dan ofal sicr",pa007-cym.pdf,application/pdf,154300,04/2011,25,2,false,1,17039,2017-03-17
-17040,PA8,"How to enter a caveat, a guide for people who want to challenge an application for grant on an estate",pa008-eng.pdf,application/pdf,236943,04/2011,8,4,false,1,17040,2017-03-17
-17041,PA8,"Sut i gofnodi cafeat. Arweiniad i bobl sydd am herio cais am grant ar ystad",pa008-cym.pdf,application/pdf,173011,04/2011,25,2,false,1,17041,2017-03-17
-17042,PA9,"Sut i gychwyn chwiliad cyffredinol",pa009-cym.pdf,application/pdf,162230,04/2011,25,2,false,1,17042,2017-03-17
-17043,FL701,"Gorchmynion Amddiffyn rhag Priodas dan Orfod - Sut y gallant fy amddiffyn?",fl701-cym.pdf,application/pdf,162454,06/2014,25,2,false,1,17043,2017-03-17
-17044,ADM1C,"Nodiadau I'r diffynnydd ar ymateb i ffurflen hawlio'r Morlys/Notes for defendant on replying to an admiralty claim form",adm001(c)-cym.pdf,application/pdf,201506,10/2008,25,3,false,1,17044,2017-03-17
-17045,CB6,"Canllaw i egluro rhai geiriau ac ymadroddion a ddefnyddir mewn achosion preifat sy'n ymwneud a phlant",cb6-cym.pdf,application/pdf,279872,07/2015,25,2,false,1,17045,2017-03-17
-17046,A61 Nodiadau | A61 Notes,"Cais am orchymyn cyfrifoldeb rhiant cyn mabwysiadu dramor (Ffur en A61). Nodiadau ar lenwi'r ffur en | Application for an order for parental responsibilty prior to adoption abroad (Form A61). Notes on completing the form",a61-notes-bil.pdf,application/pdf,192589,11/2016,26,3,false,1,17046,2017-03-17
-17047,A58 Nodiadau | A58 Notes,"Cais am orchymyn mabwysiadu (Ffur en A58), nodiadau ar lenwi'r ffur en | Application for an adoption order (Form A58). Notes on completing the form",a58-notes-bil.pdf,application/pdf,212673,11/2016,26,3,false,1,17047,2017-03-17
-17048,EX107 Gwybodaeth | EX107 Info,"Canllawiau, Rhestr y Panel Trawsgrifio a Phrisiau | Guidance, transcription panel list and prices",ex107-info-bil-20160128.pdf,application/pdf,153776,01/2016,26,4,false,1,17048,2017-03-17
-17049,D191,"Ynglyn a dirymiad",d191-cym.pdf,application/pdf,187331,04/2014,25,2,false,1,17049,2017-03-17
-17050,UT8 Nodiadau,"Nodiadau i Geiswyr ac Apelyddion Ffurflen UT8",ut008-notes-cym.pdf,application/pdf,236668,04/2012,25,2,false,1,17050,2017-03-17
-17051,5138,"Cais am ymestyn gorchymyn cynrychiolaeth i fwy nag un eiriolwr neu i CF yn unig (Rheoliad 18 o'r Rheoliadau Cymorth Cyfreithiol Troseddol (Penderfyniadau gan Lys a Dewis Cynrychiolydd) 2013 fel y'u diwygiwyd)",5138-cym.doc,application/msword,274944,04/2014,25,1,false,1,17051,2017-03-17
-17052,C19,"Cais am warant cymorth",c019-cym.pdf,application/pdf,950,09/2009,25,1,false,1,17052,2017-03-17
-17053,D8D Nodiadau | D8D Notes,"Nodiadau canllaw ar lenwi deiseb am orchymyn/ddyfarniad rhagdybiaeth o farwolaeth a diddymu'r briodas/bartneriaeth sifil | Supporting notes for guidance on completing a petition for a presumption of death decree/order and dissolution of the marriage/civil partnership",d008d-notes-bil.pdf,application/pdf,182162,01/2014,26,4,false,1,17053,2017-03-17
-17054,D8N Nodiadau | D8N Notes,"Nodiadau canllaw ar gyfer llenwi deiseb dirymu | Supporting notes for guidance on completing a nullity petition",d008n-notes-bil.pdf,application/pdf,172286,04/2014,26,4,false,1,17054,2017-03-17
-17055,Ffurflen E Nodiadau | Form E Notes,"Datganiad ariannol am orchymyn ariannol neu am gymorth ariannol ar ol ysgariad neu ddiddymiad dramor ayb | Financial statement for a financial order or for financial relief after an overseas divorce or dissolution etc",form-e-notes-bil.pdf,application/pdf,172558,01/2014,26,2,false,1,17055,2017-03-17
-17056,Gwys Rheithgor,"Gwys Rheithgor",jury-summons-cym.pdf,application/pdf,247191,05/2011,25,1,false,1,17056,2017-03-17
-17057,FP1A,"Nodiadau ar gyfer ceisydd ar lenwi'r cais (Ffurflen FP1) | Notes for applicant on completing the application (Form FP1)",fp001a-bil.pdf,application/pdf,143703,04/2011,26,3,false,1,17057,2017-03-17
-17058,C110,"Cais am orchymyn gofal neu oruchwylio dan Ddeddf Plant 1989 | Application under the Children Act 1989 for a care or supervision order",c110-bil.pdf,application/pdf,420515,04/2010,26,1,false,1,17058,2017-03-17
-17059,D191,"About Annulment",d191-eng.pdf,application/pdf,215383,04/2014,8,2,false,1,17059,2017-03-17
-17060,MC100,"Gwnewch yn siwr y gallwch dalu eich dirwy",mc100-cym.pdf,application/pdf,214447,12/2013,25,1,false,1,17060,2017-03-17
-17061,C5,"Cais yn ymwneud a chofrestriad gwarchodwr plant neu ddarparwr gofal dydd | Application concerning the registration of a child-minder or provider of day-care",c005-bil.pdf,application/pdf,227581,04/2011,26,1,false,1,17061,2017-03-17
-17062,D258B,"Cais am asesiad manwl (Costau'n daladwy o gronfa ar wahan i Gronfa'r Gwasanaeth Cyfreithiol Cymunedol) | Request for detailed assessment (Costs payable out of a fund other than the Community Legal Service Fund)",d258b-bil.pdf,application/pdf,75436,04/2011,26,1,false,1,17062,2017-03-17
-17063,D258C,"Cais am wrandawiad asesu manwl yn unol a gorchymyn o dan Rhan III Deddf Cyfreithwyr 1974 | Request for detailed assessment hearing pursuant to an order under Part III of the Solicitors Act 1974",d258c-bil.pdf,application/pdf,77696,04/2011,26,1,false,1,17063,2017-03-17
-17064,D50,"Hysbysiad o gais ar sail methu â darparu cynhaliaeth resymol neu ar gyfer newid cytundeb cynhaliaeth yn ystod oes y partion | Notice of application on ground of failure to provide reasonable maintenance or for alteration of maintenance agreement during parties' lifetime",d050-bil.pdf,application/pdf,168485,04/2012,26,1,false,1,17064,2017-03-17
-17065,D50A,"Rhybudd o achos a chydnabyddiad cyflwyno dan adran 17 Deddf Eiddo Gwragedd Priod 1882/adran 66 Deddf Partneriaeth Sifil 2004 | Notice of proceedings and acknowledgement of service under section 17 of the Married Women's Property Act 1882/section 66 of the Civil Partnership Act 2004",d050a-bil.pdf,application/pdf,221235,04/2012,26,1,false,1,17065,2017-03-17
-17066,D50B,"Cais dan adran 17 Deddf Eiddo Gwragedd Priod 1882/adran 66 Deddf Partneriaeth Sifil 2004/Cais i drosglwyddo tenantiaeth dan Ddeddf Cyfraith Teulu 1996 | Application under section 17 of The Married Women's Property Act 1882/section 66 of the Civil Partnership Act 2004/Application to transfer a tenancy under The Family Law Act 1996",d050b-bil.pdf,application/pdf,214763,04/2012,26,1,false,1,17066,2017-03-17
-17067,EX327,"Mae gen i orchymyn cynhaliaeth ond nid ywn cael ei dalu | I've got a maintenance order but its not being paid",ex327-bil.pdf,application/pdf,294306,07/2011,26,2,false,1,17067,2017-03-17
-17068,D50H,"Cais am newid cytundeb cynhaliaeth yn ystod oes y partion | Application for alteration of maintenance agreement during parties lifetime",d050h-bil.pdf,application/pdf,142089,01/2014,26,1,false,1,17068,2017-03-17
-17069,D50J,"Cais am orchymyn yn atal osgoi dan adran 32L Deddf Cynnal Plant 1991 | Application for an order preventing avoidance under section 32L of the Child Support Act 1991",d050j-bil.pdf,application/pdf,218388,04/2011,26,1,false,1,17069,2017-03-17
-17070,D62,"Cais am godi gwys dyfarniad | Request for issue of judgment summons",d062-bil.pdf,application/pdf,185729,04/2011,26,1,false,1,17070,2017-03-17
-17071,D70,"Cais am ddatganiad am statws priodasol/partneriaeth sifil | Application for declaration of marital/civil partnership status",d070-bil.pdf,application/pdf,183433,01/2014,26,1,false,1,17071,2017-03-17
-17072,Ffurflen I | Form I,"Hysbysiad o gais am orchymyn taliadau cyfnodol ar yr un gyfradd a gorchymyn am gynhaliaeth tra disgwylir canlyniad achos | Notice of request for periodical payments order at same rate as order for maintenance pending outcome of proceedings",form-i-bil.pdf,application/pdf,133859,04/2011,26,1,false,1,17072,2017-03-17
-17073,FP1,"Cais dan Ran 19 Rheolau Trefniadaeth Teulu 2010 | Application under Part 19 of the Family Procedure Rules 2010",fp001-bil.pdf,application/pdf,161445,04/2011,26,1,false,1,17073,2017-03-17
-17074,FP5,"Cydnabyddiad cyflwyno Cais dan Ran 19 Rheolau Trefniadaeth Teulu 2010 | Acknowledgment of service Application under Part 19 of the Family Procedure Rules 2010",fp005-bil.pdf,application/pdf,223879,04/2011,26,1,false,1,17074,2017-03-17
-17075,T118,"Information for Victims",t118-eng.pdf,application/pdf,320825,04/2012,8,2,false,1,17075,2017-03-17
-17076,T122,"Information for non-restricted patients detained under the Mental Health Act 1983",t122-eng.pdf,application/pdf,173390,08/2016,8,2,false,1,17076,2017-03-17
-17077,T116 Notes,"Role of the Independent Mental Health Advocate (IMHA) in First-tier Tribunal (Mental Health) Hearings",t116-notes-eng.pdf,application/pdf,225858,07/2012,8,2,false,1,17077,2017-03-17
-17078,T420,"Making a claim to an Employment Tribunal",t420-eng.pdf,application/pdf,429907,03/2017,8,2,false,1,17078,2017-03-17
-17079,T421,"Your claim - what next",t421-eng.pdf,application/pdf,214483,03/2017,8,2,false,1,17079,2017-03-17
-17080,T422,"Responding to a claim to an Employment Tribunal",t422-eng.pdf,application/pdf,277315,03/2017,8,2,false,1,17080,2017-03-17
-17081,T423,"Responding to a claim to an Employment Tribunal (Details of a hearing to be sent)",t423-eng.pdf,application/pdf,274475,03/2017,8,2,false,1,17081,2017-03-17
-17082,T424,"The hearing - guidance for claimants",t424-eng.pdf,application/pdf,253397,03/2017,8,4,false,1,17082,2017-03-17
-17083,C100,"Cais o dan adran 8 Deddf Plant 1989 am orchymyn trefniadau plant, gorchymyn camau gwaharddedig, gorchymyn mater penodol neu i amrywio neu ddiddymu neu ofyn am ganiata&amp;#770;d i roi gorchymyn adran 8 | Application under section 8 of the Children Act 1989 for a child arrangements, prohibited steps, specific issue order or to vary or discharge or ask permission to make a section 8 order",c100-bil.pdf,application/pdf,246617,06/2016,26,1,false,1,17083,2017-03-17
-17084,T426,"The judgment",t426-eng.pdf,application/pdf,279199,03/2017,8,2,false,1,17084,2017-03-17
-17085,SEND4,"How to Claim Against Disability Discrimination in Schools - a Guide for Young People",send004-eng.pdf,application/pdf,356310,11/2014,8,4,false,1,17085,2017-03-17
-17086,T129,"Your Rights to Legal Representation and to See the Tribunal Doctor",t129-eng.pdf,application/pdf,186100,04/2014,8,2,false,1,17086,2017-03-17
-17087,SEND5,"Coming to the Tribunal",send005-eng.pdf,application/pdf,204032,09/2012,8,2,false,1,17087,2017-03-17
-17088,SEND15,"Guidance for Parents Claiming Expenses",send015-eng.pdf,application/pdf,150234,09/2014,8,4,false,1,17088,2017-03-17
-17089,SEND16,"Guidance for Witnesses Claiming Expenses",send016-eng.pdf,application/pdf,219734,09/2014,8,4,false,1,17089,2017-03-17
-17090,Going to a Magistrates' Court,"Going to a Magistrates' Court - Information for People with Learning Disabilities",going-to-magistrates-court-eng.pdf,application/pdf,3043314,05/2012,8,2,false,1,17090,2017-03-17
-17091,N322A Guidance Notes,"Guidance notes for completing form N322A",n322a-notes-eng.pdf,application/pdf,193364,06/2009,8,4,false,1,17091,2017-03-17
-17092,N322B Guidance Notes,"Guidance notes for completing form N322B",n322b-notes-eng.pdf,application/pdf,128921,06/2009,8,4,false,1,17092,2017-03-17
-17093,N322A Nodiadau Canllaw | N322A Guidance Notes,"Nodiadau canllaw ar gyfer llenwi'r ffurflen gais i orfodi penderfyniad neu setliad amodol ACAS (Ffurflen COT3) mae angen caniatâd y llys arno i fynd rhagddo | Notes for guidance on completing the application form to enforce a decision or ACAS conditional settlement (Form COT3) that requires permission of the court to proceed",n322a-notes-bil.pdf,application/pdf,168974,06/2009,26,4,false,1,17093,2017-03-17
-17094,N322B Nodiadau Canllaw | N322B Guidance Notes,"Nodiadau canllaw ar gyfer llenwi'r ffurflen gais i orfodi penderfyniad neu setliad amodol ACAS (Ffurflen COT3) nad oes angen caniatâd y llys arno i fynd rhagddo | Notes for guidance on completing the application form to enforce a decision or ACAS settlement (Form COT3) that does not require permission of the court to proceed",n322b-notes-bil.pdf,application/pdf,168418,06/2009,26,4,false,1,17094,2017-03-17
-17095,A60 Nodiadau | A60 Notes,"Cais am orchymyn mabwysiadu (ac eithrio gorchymyn mabwysiadu dan y Cytundeb) (Ffur en A60). Nodiadau ar lenwi'r ffur en | Application for an adoption order (excluding a Convention adoption order) (Form A60). Notes on completing the form",a60-notes-bil.pdf,application/pdf,186630,11/2016,26,3,false,1,17095,2017-03-17
-17096,ADM15B,"Nodiadau i'r diffynnydd (hawliad cyfyngu'r Morlys) | Notes for defendant (admiralty limitation claim)",adm15(b)-bil.pdf,application/pdf,167893,10/2008,26,3,false,1,17096,2017-03-17
-17097,SEND15YP,"Guidance for a young person claiming expenses",send15yp-eng.pdf,application/pdf,147722,09/2016,8,4,false,1,17097,2017-03-17
-17098,T130,"When can I apply to or be referred to the Tribunal for a hearing?",t130-eng.pdf,application/pdf,553174,06/2015,8,2,false,1,17098,2017-03-17
-17099,N67,"Judgment summons (Debtors Act 1869)",n067-eng.pdf,application/pdf,206133,04/2006,8,1,false,1,17099,2017-03-17
-17100,D50K,"Hysbysiad o Gais am Orfodaeth drwy ddull gorfodi a ystyrir yn briodol gan y llys Rheolau Trefniadaeth Teulu 2010 Rheol 33.3(2)(b) | Notice of Application for Enforcement by such method of enforcement as the court may consider appropriate Family Procedure Rules 2010 Rule 33.3(2)(b)",d50k-bil.pdf,application/pdf,137219,06/2016,26,1,false,1,17100,2017-03-17
-17101,T451,"Canllawiau ynghylch llenwi'r ffurflen gais am Dystysgrif Cydnabod Rhyw",t451-cym.pdf,application/pdf,631152,06/2016,25,2,false,1,17101,2017-03-17
-17102,Ffurflen E Canllawiau,"Ffurflen E Nodiadau",form-e-notes-cym.pdf,application/pdf,224807,04/2013,25,2,false,1,17102,2017-03-17
-17103,T242,"Making an Appeal Explanatory Booklet",t242-eng.pdf,application/pdf,555602,03/2015,8,2,false,1,17103,2017-03-17
-17104,T248,"Guidance Notes on Completing the First-tier Tribunal Application for Permission to Appeal to the Upper Tribunal",t248-eng.pdf,application/pdf,529235,03/2015,8,4,false,1,17104,2017-03-17
-17105,Precedent H Guidance Notes,"Precedent H guidance notes",precedent(h)-notes-eng.doc,application/msword,53248,04/2016,8,4,false,1,17105,2017-03-17
-17106,EX375,"Gorchymyn Gorfodi Ewropeaidd (EEO)",ex375-cym.pdf,application/pdf,75188,04/2014,25,2,false,1,17106,2017-03-17
-17107,Eich apêl - Y Camau Nesaf,"Eich apêl - Y Camau Nesaf",information-leaflet-cym.pdf,application/pdf,71449,10/2013,25,2,false,1,17107,2017-03-17
-17108,SSCS1A,"Sut i apelio yn erbyn penderfyniad a wnaed gan yr Adran Gwaith a Phensiynau",sscs001a-cym.pdf,application/pdf,284632,07/2015,25,2,false,1,17108,2017-03-17
-17109,T481 Nodiadau,"Nodiadau cyfarwyddyd ar gyfer llenwi ffurflen hawlio'r Adolygiad Barnwrol",t481-notes-cym.pdf,application/pdf,237890,08/2013,25,2,false,1,17109,2017-03-17
-17110,T108A,"Guide to Telephone Case Management Hearing, Statements, Bundles and Witness Templates",t108a-eng.pdf,application/pdf,184813,10/2014,8,4,false,1,17110,2017-03-17
-17111,Ffurflen Ymholiadau,"Ffurflen Ymholiadau",appellent-enquiry-form-cym.pdf,application/pdf,42585,10/2013,25,1,false,1,17111,2017-03-17
-17112,T110,"Application to First-tier Tribunal (Mental Health) Mental Health Act 1983 (as amended)",t110-eng.doc,application/msword,68096,05/2015,8,1,false,1,17112,2017-03-17
-17113,D440,"Cais am chwiliad am Ddyfarniad Absoliwt Ysgariad",d440-cym.pdf,application/pdf,357855,08/2014,25,2,false,1,17113,2017-03-17
-17114,Ffurflen Ymholiadau,"Ffurflen Cyswllt (Pleidiau eraill)",other-party-enquiry-form-cym.pdf,application/pdf,41190,10/2013,25,1,false,1,17114,2017-03-17
-17115,T110 Guardianship,"Guardianship - Application to First-Tier Tribunal (Mental Health) Mental Health Act 1983 (As Amended)",t110-guardianship-eng.doc,application/msword,65024,03/2015,8,1,false,1,17115,2017-03-17
-17116,CB5,"Ceisiadau sy'n ymwneud a gorfodi gorchymyn trefniadau plant",cb005-cym.pdf,application/pdf,208998,08/2014,25,2,false,1,17116,2017-03-17
-17117,SSCS1,"Hysbysiad o apêl yn erbyn penderfyniad yr Adran Gwaith a Phensiynau (Nawdd Cymdeithasol a Chynnal Plant)",sscs1-cym.pdf,application/pdf,109586,09/2013,25,1,false,1,17117,2017-03-17
-17118,T111,"Referral to First-tier Tribunal (Mental Health) Mental Health Act 1983 (as amended)",t111-eng.doc,application/msword,72192,11/2011,8,1,false,1,17118,2017-03-17
-17119,SSCS1,"Hysbysiad o apêl yn erbyn penderfyniad yr Adran Gwaith a Phensiynau (Print Bras)",sscs001-large-cym.pdf,application/pdf,173250,04/2013,25,1,false,1,17119,2017-03-17
-17120,SSCS2,"Hysbysiad o apêl yn erbyn penderfyniad yr Adran Gwaith a Phensiynau - y Grwp Cynhaliaeth Plant (Print Bras)",sscs002-large-cym.pdf,application/pdf,187577,08/2013,25,1,false,1,17120,2017-03-17
-17121,CB1,"Gwneud cais (Plant a'r llysoedd teulu)",cb001-cym.pdf,application/pdf,300949,04/2014,25,2,false,1,17121,2017-03-17
-17122,SSCS2,"Hysbysiad o apêl yn erbyn penderfyniad yr Adran Gwaith a Phensiynau - y Grwp Cynhaliaeth Plant",sscs002-cym.pdf,application/pdf,108803,08/2013,25,1,false,1,17122,2017-03-17
-17123,T480,"Adolygiad Barnwrol - Ffurflen Hawlio",t480-cym.pdf,application/pdf,99894,06/2016,25,1,false,1,17123,2017-03-17
-17124,T540,"Guidance on rent cases, general information about the process",t540-eng.pdf,application/pdf,486387,01/2017,8,4,false,1,17124,2017-03-17
-17125,T436,"Ffioedd Tribiwnlys Cyflogaeth ar gyfer grwpiau a mwy nag un hawliad (O'r 29 Gorffennaf 2013 ymlaen)",t436-cym.pdf,application/pdf,229700,03/2015,25,2,false,1,17125,2017-03-17
-17126,T482,"Adolygiad Barnwrol - Cydnabyddiad Cyflwyno",t482-cym.pdf,application/pdf,80929,08/2016,25,1,false,1,17126,2017-03-17
-17127,T437,"Ffioedd y Tribiwnlys Apeliadau Cyflogaeth",t437-cym.pdf,application/pdf,152509,04/2014,25,2,false,1,17127,2017-03-17
-17128,T483,"Adolygiad Barnwrol - Cais am ystyriaeth frys",t483-cym.pdf,application/pdf,138986,08/2013,25,1,false,1,17128,2017-03-17
-17129,T542,"Guidance on enfranchisement. General information about the process",t542-eng.pdf,application/pdf,454339,01/2017,8,4,false,1,17129,2017-03-17
-17130,EX731,"Paratoi ar gyfer cyfryngu dros y ffon",ex731-cym.pdf,application/pdf,146533,04/2014,25,2,false,1,17130,2017-03-17
-17131,T484,"Hysbysiad cyflwyno cais (Uwch Dribiwnlys Y Siambr Mewnfudo a Lloches)",t484-cym.pdf,application/pdf,77709,06/2016,25,1,false,1,17131,2017-03-17
-17132,T543,"Guidance on Housing Act 2004 Cases. General information about the process",t543-eng.pdf,application/pdf,532244,01/2017,8,4,false,1,17132,2017-03-17
-17133,T485,"Datganiad o dan Reol 28A (2)(b) yr Uwch Dribiwnlys",t485-cym.pdf,application/pdf,57645,08/2016,25,1,false,1,17133,2017-03-17
-17134,T544,"Guidance on park homes and sites cases. General information about the process",t544-eng.pdf,application/pdf,466095,01/2017,8,4,false,1,17134,2017-03-17
-17135,T486,"Rhybudd newid cyfreithiwr",t486-cym.pdf,application/pdf,116578,08/2013,25,1,false,1,17135,2017-03-17
-17136,T545,"Guidance on recognition of Tenants' Association. General information about the process",t545-eng.pdf,application/pdf,429412,01/2017,8,4,false,1,17136,2017-03-17
-17137,CB3,"Cyflwyno'r ffurflenni - Deddf Plant 1989",cb003-cym.pdf,application/pdf,136190,04/2014,25,1,false,1,17137,2017-03-17
-17138,T546,"Guidance on right to buy cases. General information about the process",t546-eng.pdf,application/pdf,428482,01/2017,8,4,false,1,17138,2017-03-17
-17139,CB4,"Gwarcheidiaeth Arbennig - Canllaw ar gyfer defnyddwyr y llys teulu",cb004-cym.pdf,application/pdf,156470,04/2014,25,1,false,1,17139,2017-03-17
-17140,PA1S,"Cais am chwiliad profiant (copiau o grantiau ac ewyllysiau) | Application for a probate search (copies of grants and wills)",pa001s-bil.pdf,application/pdf,111668,04/2014,26,1,false,1,17140,2017-03-17
-17141,PPF1,"Cronfa Diogelu Pensiynau (CDP) - Rhannu - Atodiad i Orchymyn Rhannu Iawndal Pensiwn [Adran 24E Deddf Achosion Priodasol 1973] [paragraff 19A Atodlen 5 Deddf Partneriaethau Sifil 2004] | Pension Protection Fund (PPF) Sharing Annex to a Pension Compensation Sharing Order [section 24E of the Matrimonial Causes Act 1973] [paragraph 19A of Schedule 5 to the Civil Partnership Act 2004]",ppf1-bil.pdf,application/pdf,232416,04/2011,26,1,false,1,17141,2017-03-17
-17142,D80B,"Datganiad i gefnogi ysgariad/diddymiad/ymwahaniad (cyfreithiol) - ymddygiad afresymol | Statement in support of divorce/dissolution/(judicial) separation - unreasonable behaviour",d080b-bil.pdf,application/pdf,117807,04/2014,26,1,false,1,17142,2017-03-17
-17143,D80D,"Datganiad i gefnogi ysgariad/diddymiad/ymwahaniad (cyfreithiol) - cydsyniad 2 flynedd | Statement in support of divorce/dissolution/(judicial) separation - 2 years' consent",d080d-bil.pdf,application/pdf,121525,04/2014,26,1,false,1,17143,2017-03-17
-17144,T003,"Notice of appeal/Application for review",t003-eng.pdf,application/pdf,99546,04/2012,8,1,false,1,17144,2017-03-17
-17145,SSCS6,"Hysbysiad o apêl yn erbyn penderfyniad gan Weinyddwr y Cynllun Taliadau Mesothelioma Ymledol",sscs006-cym.pdf,application/pdf,148731,10/2014,25,1,false,1,17145,2017-03-17
-17146,TGRCRef,"References - Some Questions and Answers",tgrcref-eng.pdf,application/pdf,74922,07/2013,8,2,false,1,17146,2017-03-17
-17147,UT1,"Application for permission to appeal to an Upper Tribunal judge and notice of appeal for social security, child support, tax credits, housing benefit and council tax benefit cases",ut001-eng.doc,application/msword,604160,07/2015,8,1,false,1,17147,2017-03-17
-17148,UT2,"Application/appeal form for the Secretary of State, HM Revenue and Customs and local authorities for social security, child support, tax credits and housing benefit and council tax benefit cases",ut002-eng.pdf,application/pdf,62844,07/2012,8,1,false,1,17148,2017-03-17
-17149,UT2,"Application/appeal form for the Secretary of State, HM Revenue and Customs and local authorities for social security, child support, tax credits and housing benefit and council tax benefit cases",ut002-eng.doc,application/msword,215552,07/2012,8,1,false,1,17149,2017-03-17
-17150,UT5,"Application for permission to appeal to an Upper Tribunal judge and notice of appeal form for care standards and primary health lists cases",ut005-eng.pdf,application/pdf,117065,10/2011,8,1,false,1,17150,2017-03-17
-17151,UT7,"Application/appeal form for the Secretary of State for war pensions and armed forces compensation cases",ut007-eng.pdf,application/pdf,76465,10/2011,8,1,false,1,17151,2017-03-17
-17152,UT13,"Application for permission to appeal and notice of appeal from an information rights decision of the First-tier Tribunal (General Regulatory Chamber)",ut013-eng.pdf,application/pdf,134022,09/2015,8,1,false,1,17152,2017-03-17
-17153,JRC1,"Judicial review claim form - criminal injuries compensation cases, England and Wales",jrc1-eng.doc,application/msword,234496,03/2013,8,1,false,1,17153,2017-03-17
-17154,JRC1,"Judicial review claim form - criminal injuries compensation cases, England and Wales",jrc1-eng.pdf,application/pdf,59623,01/2012,8,1,false,1,17154,2017-03-17
-17155,REMO20,"Canllaw i Gydorfodi Gorchmynion Cynhaliaeth",remo020-cym.pdf,application/pdf,170367,06/2015,25,2,false,1,17155,2017-03-17
-17156,A101A,"Cytundeb i wneud gorchymyn rhieni yng nghyswllt fy mhlentyn | Agreement to the making of a parental order in respect of my child",a101a-bil.doc,application/msword,73216,04/2010,26,1,false,1,17156,2017-03-17
-17157,C52,"Cydnabyddiaeth Adran 54 o Ddeddf Ffrwythloni Dynol ac Embryoleg 2008 | Acknowledgment Section 54 Human Fertilisation and Embryology Act 2008",c052-bil.pdf,application/pdf,116807,10/2012,26,1,false,1,17157,2017-03-17
-17158,C63,"Cais am ddatganiad ynghylch pwy yw rhiant person dan adran 55A Deddf Cyfraith Teulu 1986 | Application for declaration of parentage under section 55A of the Family Law Act 1986",c63-bil.pdf,application/pdf,139163,06/2016,26,1,false,1,17158,2017-03-17
-17159,C7,"Cydnabyddiad | Acknowledgement",c007-bil.pdf,application/pdf,385827,12/2008,26,1,false,1,17159,2017-03-17
-17160,C79,"Cais yn ymwneud a gorfodi gorchymyn trefniadau plant | Application related to enforcement of a child arrangement order",c79-bil.pdf,application/pdf,188623,06/2016,26,1,false,1,17160,2017-03-17
-17161,T454,"Canllawiau ynghylch llenwi'r ffurflen gais Dramor am Dystysgrif Cydnabod Rhyw",t454-cym.pdf,application/pdf,615083,06/2016,25,2,false,1,17161,2017-03-17
-17162,Ffurflen 6.28 | Form 6.28,"Datganiad Amgylchiadau Ariannol (Deiseb Dyledwr)Deddf Ansolfedd 1986 | Statement of Affairs (Debtor's Petition)Insolvency Act 1986",form-628-bil.pdf,application/pdf,167697,10/2012,26,1,false,1,17162,2017-03-17
-17163,FL407A,"Cais am Warant Arestio. Gorchymyn Amddiffyn Priodi Dan Orfod Rhan 4A Deddf Cyfraith Teulu 1996 | Application for a Warrant of Arrest. Forced Marriage Protection Order Part 4A Family Law Act 1996",fl407a-bil.pdf,application/pdf,77478,11/2008,26,1,false,1,17163,2017-03-17
-17164,T450,"Cais am Dystysgrif Cydnabod Rhyw",t450-cym.pdf,application/pdf,581548,06/2016,25,1,false,1,17164,2017-03-17
-17165,N110A,"Pwer i arestio wedi'i atodi i'r waharddeb",n110a-cym.pdf,application/pdf,37321,06/2015,25,1,false,1,17165,2017-03-17
-17166,C110A,"Cais am orchymyn gofal neu orchymyn goruchwylio a gorchmynion eraill dan Ran 4 Deddf Plant 1989, neu Orchymyn Amddiffyn Brys dan adran 44 Deddf Plant 1989",c110a-cym.pdf,application/pdf,269102,11/2014,25,1,false,1,17166,2017-03-17
-17167,T453,"Cais am Dystysgrif Cydnabod Rhyw (Cais am Gydnabyddiaeth Gyfreithiol Dramor)",t453-cym.pdf,application/pdf,622974,06/2016,25,1,false,1,17167,2017-03-17
-17168,FL404B,"Gorchymyn Amddiffyn rhag Priodas dan Orfod",fl404b-cym.pdf,application/pdf,153268,06/2014,25,1,false,1,17168,2017-03-17
-17169,Undertaking to Issue Form,"Request for an Urgent Application (High Court Family Division)",undertaking-to-issue-eng.doc,application/msword,37376,04/2014,8,1,false,1,17169,2017-03-17
-17170,T415,"Information on Challenging Decisions in Land Registration Cases",t415-eng.pdf,application/pdf,70384,03/2014,8,2,false,1,17170,2017-03-17
-17171,EX380,"Information about appeals for victims of crime",ex380-eng.pdf,application/pdf,305154,04/2016,8,2,false,1,17171,2017-03-17
-17172,N358,"Notice of Claim to Goods Taken Under Control",n358-eng.doc,application/msword,39424,04/2014,8,1,false,1,17172,2017-03-17
-17173,N465PC,"Response to application as to venue for administration and determination",n465pc-eng.pdf,application/pdf,315565,04/2014,8,1,false,1,17173,2017-03-17
-17174,SSCS5A,"How to appeal against a decision made by HM Customs and Revenue",sscs005a-eng.pdf,application/pdf,244418,07/2014,8,2,false,1,17174,2017-03-17
-17175,T04,"General Regulatory Chamber - Guidance Note for Respondents",t004-eng.pdf,application/pdf,83520,02/2014,8,4,false,1,17175,2017-03-17
-17176,PC001,"Request for an Adjournment (Leeds)",pc001-leeds-eng.pdf,application/pdf,19015,09/2008,8,1,false,1,17176,2017-03-17
-17177,T470,"Gangmasters Licensing Appeals - a guide to making an appeal",t470-eng.pdf,application/pdf,170668,10/2014,8,4,false,1,17177,2017-03-17
-17178,T170,"Appeal/Applicatiion Form (A)",t170-eng.pdf,application/pdf,562377,10/2014,8,1,false,1,17178,2017-03-17
-17179,T171,"Application to Set Aside a Decision of Primary Health Lists (SA)",t171-eng.pdf,application/pdf,548097,10/2014,8,1,false,1,17179,2017-03-17
-17180,T172,"Application for Permission to Appeal Decision of Primary Health Lists (AA)",t172-eng.pdf,application/pdf,539591,10/2014,8,1,false,1,17180,2017-03-17
-17181,T200,"Notice of Appeal (Form EO9)",t200-eng.pdf,application/pdf,114104,04/2016,8,1,false,1,17181,2017-03-17
-17182,T210,"Appeal form",t210-eng.doc,application/msword,183558,07/2015,8,1,false,1,17182,2017-03-17
-17183,T211,"Rhybudd Apel yn erbyn penderfyniad gan yr Awdurdod Iawndal am Anafiadau Troseddol | Notice of appeal against a decision of the Criminal Injuries Compensation Authority",t211-bil.pdf,application/pdf,93042,09/2014,26,1,false,1,17183,2017-03-17
-17184,T173,"Response to appeal application Form",t173-eng.pdf,application/pdf,536883,10/2014,8,1,false,1,17184,2017-03-17
-17185,T247,"Application for Permission to Appeal Decision of the Tax Tribunal",t247-eng.pdf,application/pdf,506237,03/2015,8,1,false,1,17185,2017-03-17
-17186,T619,"Notice of Appeal to the Special Immigration Appeal Commission",t619-eng.doc,application/msword,213504,03/2015,8,1,false,1,17186,2017-03-17
-17187,REMO 9,"Annex A - Application for Recognition or Recognition and Enforcement",remo-009-eng.doc,application/msword,71680,08/2014,8,1,false,1,17187,2017-03-17
-17188,REMO 10,"Annex B - Application for Enforcement of a Decision Made or Recognised in the Requested State",remo-010-eng.doc,application/msword,56320,08/2014,8,1,false,1,17188,2017-03-17
-17189,SEND1,"How to Appeal Against a SEN decision",send001-eng.pdf,application/pdf,256566,01/2015,8,2,false,1,17189,2017-03-17
-17190,SEND2,"Preparing the Local Authority's Case",send002-eng.pdf,application/pdf,62468,07/2014,8,2,false,1,17190,2017-03-17
-17191,SEND20,"Guidance Notes - Applying to the First-tier Tribunal (Special Educational Needs and Disability)",send020-eng.pdf,application/pdf,178483,09/2014,8,4,false,1,17191,2017-03-17
-17192,T621,"Application to be released on SIAC bail (SIAC B1)",t621-eng.pdf,application/pdf,570235,07/2015,8,1,false,1,17192,2017-03-17
-17193,COP42,"Gwneud cais i'r Llys Gwarchod",cop42-cym.pdf,application/pdf,183592,12/2013,25,2,false,1,17193,2017-03-17
-17194,COP44A,"Apply for help with Court of Protection fees",cop44a-eng.pdf,application/pdf,127118,02/2016,8,1,false,1,17194,2017-03-17
-17195,PH2,"Application by an occupier of a park home on a protected site, or a park home site owner, for: (1) an order (under section 2(2) implying a term or terms concerning the matters mentioned in Part 2 of Schedule 1 to the 1983 Act (see below) into an agreement for occupation or (2) an order (under Section 2(3)(a)) varying or deleting any express term (other than a site rule) of an agreement for occupation or (3) an order (under Section 2(3)(b)) that an unenforceable express term have full effect, or to have such effect subject to any variation specified in the order",ph2-eng.doc,application/msword,156160,01/2017,8,1,false,1,17195,2017-03-17
-17196,T435,"Employment Tribunal fees for individuals (from 29 July 2013)",t435-eng.pdf,application/pdf,210188,02/2017,8,2,false,1,17196,2017-03-17
-17197,T436,"Employment Tribunal fees for groups and multiples (from 29 July 2013)",t436-eng.pdf,application/pdf,226140,02/2017,8,2,false,1,17197,2017-03-17
-17198,T437,"Employment Appeal Tribunal fees (from 29 July 2013)",t437-eng-20151230.pdf,application/pdf,177790,12/2015,8,2,false,1,17198,2017-03-17
-17199,PA3,"Probate fees (from April 2014)",pa003-eng.pdf,application/pdf,172000,02/2017,8,2,false,1,17199,2017-03-17
-17200,T613,"UTIAC fees (from 22 April 2014)",t613-eng.pdf,application/pdf,39604,04/2014,8,2,false,1,17200,2017-03-17
-17201,Gambling - Guidance on fee remission for companies,"Guidance on fee remission for companies",gambling-fee-exemption-notes(company)-eng.pdf,application/pdf,30556,05/2011,8,4,false,1,17201,2017-03-17
-17202,T547,"A guide to what costs fees and expenses may be recoverable in the First-Tier Tribunal (Property Chamber) (Residential Property)",t547-eng.pdf,application/pdf,530167,03/2015,8,4,false,1,17202,2017-03-17
-17203,SSCS6A,"How to Appeal Against a Decision Made By the Scheme Administrator for the Diffuse Mesothelioma Payment Scheme",sscs006a-eng.pdf,application/pdf,412451,10/2014,8,2,false,1,17203,2017-03-17
-17204,EX370,"Eich tro cyntaf yn y llys? Beth y gallwch ei ddisgwyl | Your First Time At Court? What You Can Expect",ex370-bil.pdf,application/pdf,184060,03/2014,26,2,false,1,17204,2017-03-17
-17205,UT1 Leaflet,"UT1 Social Entitlement Leaflet - Appealing to the Administrative Appeals Chamber of the Upper Tribunal England and Wales",ut001-leaflet-eng.pdf,application/pdf,139584,07/2015,8,2,false,1,17205,2017-03-17
-17206,T465,"Guidance on Completing the Alternative Application Form for a Gender Recognition Certificate",t465-eng.pdf,application/pdf,593286,06/2016,8,4,false,1,17206,2017-03-17
-17207,T465,"Canllawiau ynghylch Llenwi'r Ffurflen Gais Amgen am Dystysgrif Cydnabod Rhyw",t465-cym.pdf,application/pdf,624591,06/2016,25,2,false,1,17207,2017-03-17
-17208,COP3,"Asesu galluedd",cop003-cym.pdf,application/pdf,183339,12/2013,25,1,false,1,17208,2017-03-17
-17209,COP4,"Datganiad y dirprwy",cop004-cym.pdf,application/pdf,255385,10/2013,25,1,false,1,17209,2017-03-17
-17210,COP8,"Cais yn ymwneud a chofrestru atwrneiaeth barhaus (EPA)",cop008-cym.pdf,application/pdf,149980,12/2013,25,1,false,1,17210,2017-03-17
-17211,COP12,"Ymgymeriad arbennig gan ymddiriedolwyr",cop012-cym.pdf,application/pdf,55203,01/2012,25,1,false,1,17211,2017-03-17
-17212,COP15,"Hysbysiad bod ffurflen gais wedi'i chyhoeddi",cop015-cym.pdf,application/pdf,38182,12/2013,25,1,false,1,17212,2017-03-17
-17213,COP44A,"Gwneud cais am gymorth gyda ffioedd y Llys Gwarchod",cop044a-cym.pdf,application/pdf,94220,11/2015,25,1,false,1,17213,2017-03-17
-17214,COP DLA,"Ffurflen gais Colli Rhyddid I'w hystyried ar frys",cop-dla-cym.pdf,application/pdf,159055,01/2012,25,1,false,1,17214,2017-03-17
-17215,FGM001,"Cais am Orchymyn Amddiffyn rhag Anffurfio Organau Cenhedlu Benywod (FGM)",fgm001-cym.pdf,application/pdf,84890,07/2015,25,1,false,1,17215,2017-03-17
-17216,FGM003,"Cais i amrywio, ymestyn neu ryddhau Gorchymyn Amddiffyn rhag Anffurfio Organau Cenhedlu Benywod (FGM)",fgm003-cym.pdf,application/pdf,47235,07/2015,25,1,false,1,17216,2017-03-17
-17217,FGM005,"Cais am Warant Arestio",fgm005-cym.pdf,application/pdf,26088,07/2015,25,1,false,1,17217,2017-03-17
-17218,FGM006,"Cais am ganiatâd i wneud cais am Orchymyn Amddiffyn rhag Anffurfio Organau Cenhedlu Benywod (FGM)",fgm006-cym.pdf,application/pdf,33513,07/2015,25,1,false,1,17218,2017-03-17
-17219,FGM700,"Female Genital Mutilation (FGM) Protection Orders - How can they protect me?",fgm700-eng.pdf,application/pdf,213251,07/2015,8,2,false,1,17219,2017-03-17
-17220,FGM701,"Female Genital Mutilation (FGM) Protection Orders - Interim guidance for local authorities as a relevant third party and information relevant to multi-agency partnership working",fgm701-eng.pdf,application/pdf,129121,08/2015,8,4,false,1,17220,2017-03-17
-17221,FGM700,"Gorchmynion Amddiffyn rhag Anffurfio Organau Cenhedlu Benywod (FGM)",fgm700-cym.pdf,application/pdf,199659,07/2015,25,1,false,1,17221,2017-03-17
-17222,N1C(CCCHFL),"Notes for defendant on replying to the Part 7 claim form - Chancery Division/Commercial Court Financial List",n001c(ccchfl)-eng.pdf,application/pdf,140180,05/2015,8,3,false,1,17222,2017-03-17
-17223,A60,"Cais am orchymyn mabwysiadu (ac eithrio gorchymyn mabwysiadu dan y Cytundeb) | Application for an adoption order (excluding a Convention adoption order)",a60-bil.pdf,application/pdf,444197,11/2016,26,1,false,1,17223,2017-03-17
-17224,MPs Expenses - Notice of Appeal,"Notice of Appeal",mp-expenses-noa-eng.pdf,application/pdf,520561,03/2015,8,1,false,1,17224,2017-03-17
-17225,T464,"Alternative application for a Gender Recognition Certificate",t464-eng.pdf,application/pdf,312633,11/2016,8,1,false,1,17225,2017-03-17
-17226,FGM007,"Cais i ymuno fel parti neu roi'r gorau i fod yn barti i Orchymyn Amddiffyn rhag Anffurfio Organau Cenhedlu Benywod (FGM)",fgm007-cym.pdf,application/pdf,55245,07/2015,25,1,false,1,17226,2017-03-17
+id,code,title,attachment_file_name,attachment_content_type,attachment_file_size,content_date,language_id,doc_attachment_type_id,inactive,creator_id,published_date,original_url,original_id
+1,N30,"Judgment for claimant (in default)",n30-eng.pdf,application/pdf,248517,04/2006,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1
+4,N30(CH),"Judgment for claimant (in default)",n30(hc)-eng.pdf,application/pdf,247657,04/2006,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4
+14,A/E,"Your Guide to the Attachment of Earnings Act 1971",ae-eng.pdf,application/pdf,180866,11/2014,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,14
+15,Attachment Orders - A guide for employers,"Attachment Orders - A guide for employers",ao-employers-guide-eng.pdf,application/pdf,643856,08/2008,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,15
+18,A20,"Adoption - A guide for family court users",a20-eng.pdf,application/pdf,449748,11/2016,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,18
+19,A20,"Mabwysiadu:  Arweiniad i Ddefnyddwyr y Llysoedd | Adoption:  A Guide for Court Users",a020-bil.pdf,application/pdf,77228,10/2003,26,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,19
+20,A20(1),"President's Intercountry Supplement",a020(1)-eng.pdf,application/pdf,49056,11/2008,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,20
+21,A20(1),"Canolfannau Mabwysiadu Rhyngwladol - Arweiniad a gyhoeddwyd gan Lywydd yr Adran Deulu",a020(1)-cym.pdf,application/pdf,63777,11/2008,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,21
+26,A4,"Application For Revocation Of An Order Freeing A Child For Adoption",a004-eng.pdf,application/pdf,34125,06/2001,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,26
+27,A5,"Application For Substitution Of One Adoption Agency For Another",a005-eng.pdf,application/pdf,76647,05/2002,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,27
+32,AE Faq,"Gorchmynion Atafaelu enillion gogyfer a dirwyon troseddol Peilot Cenedlaethol mis Ebrill 2004",ae-faq-cym.pdf,application/pdf,109948,07/2004,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,32
+33,AE Canllaw,"Canllawiau i GyFLogwyr i Ddeddf Atafaelu Enillion 1971",ae-guide-cym.pdf,application/pdf,213589,07/2004,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,33
+46,Attachment of Earnings Orders for criminal fines National Pilot April 2004,"Attachment of Earnings Orders for criminal fines national pilot (April 2004)",attachment-earnings-mags-faq-eng.pdf,application/pdf,98351,06/2004,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,46
+48,C(PRA1),"Parental Responsibility Agreement",c(pra001)-eng.pdf,application/pdf,360750,08/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,48
+49,C1,"Cais am orchymyn (Deddf Plant 1989)",c1-cym.pdf,application/pdf,265983,06/2016,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,49
+50,C1,"Application for an order",c1-eng.pdf,application/pdf,328888,06/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,50
+56,C11,"Atodiad i gais am Orchymyn Diogelu Brys | Supplement for an application for an Emergency Protection Order",c011-bil.pdf,application/pdf,171681,08/2004,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,56
+57,C12,"Atodiad i gais am warant i helpu person a awdurdodir gan Orchymyn Amddiffyn Brys | Supplement for an application for a warrant to assist a person authorised by an Emergency Protection Order",c012-bil.pdf,application/pdf,129706,08/2004,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,57
+58,C12,"Supplement for an application for a Warrant to assist a person authorised by an Emergency Protection Order",c012-eng.pdf,application/pdf,122025,08/2004,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,58
+59,C13,"Supplement for an application for a Care or Supervision Order",c013-eng.pdf,application/pdf,14738,09/1999,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,59
+60,C14,"Supplement for an application for authority to refuse contact with a child in care",c014-eng.pdf,application/pdf,12241,09/1999,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,60
+61,C14,"Atodiad i gais am awdurdod i wrthod cyswllt â phlentyn mewn gofal | Supplement for an application for authority to refuse contact with a child in care",c014-bil.pdf,application/pdf,110190,09/1999,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,61
+62,C15,"Supplement for an application for contact with a child in care",c015-eng.pdf,application/pdf,11195,09/1999,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,62
+63,C15,"Atodiad i gais am gyswllt gyda phlentyn sydd mewn gofal | Supplement for an application for contact with a child in care",c015-bil.pdf,application/pdf,105555,09/1999,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,63
+64,C16,"Supplement for an application for a Child Assessment Order",c016-eng.pdf,application/pdf,12628,09/1999,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,64
+65,C16,"Atodiad i gais am Orchymyn Asesu Plentyn | Supplement for an application for a Child Assessment Order",c016-bil.pdf,application/pdf,116449,09/1999,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,65
+66,C17,"Supplement for an application for an Education Supervision Order",c017-eng.pdf,application/pdf,149870,07/2010,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,66
+68,C17A,"Supplement for an application for an extension of an Education Supervision Order",c017(a)-eng.pdf,application/pdf,10892,09/1999,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,68
+69,C17A,"Atodiad i gais am estyniad i Orchymyn Goruchwylio Addysg | Supplement for an application for an extention of an Education Supervision Order",c017(a)-bil.pdf,application/pdf,110869,09/1999,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,69
+70,C18,"Atodiad i gais am Orchymyn Adfer | Supplement for an application for a Recovery Order",c018-bil.pdf,application/pdf,145150,09/1999,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,70
+71,C18,"Supplement for an application for a Recovery Order",c018-eng.pdf,application/pdf,19040,09/1999,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,71
+72,C19,"Application for a warrant of assistance",c019-eng.pdf,application/pdf,364127,11/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,72
+74,C1A,"Allegations of harm and domestic violence (Supplemental information form)",c001a-eng.pdf,application/pdf,357564,01/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,74
+75,C1A,"Honiadau o niwed a thrais yn y cartref (Ffurflen gwybodaeth ategol) | Allegations of harm and domestic violence (Supplemental information form)",c001a-bil.pdf,application/pdf,212087,04/2011,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,75
+76,C1A Nodiadau | C1A Notes,"Nodiadau Canllaw ar gyfer Ffurflen Gwybodaeth Ychwanegol C1A | Notes for Guidance for Supplemental Information Form C1A",c001a-notes-bil.pdf,application/pdf,213141,01/2005,26,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,76
+77,C1A Notes,"Notes for Guidance for Supplemental Information Form C1A",c001a-notes-eng.pdf,application/pdf,238981,01/2005,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,77
+78,C2,"Application: For permission to start proceedings; For an order or directions in existing proceedings; To be joined as, or cease to be, a party in existing family proceedings under the Children Act 1989",c2-eng.pdf,application/pdf,606202,06/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,78
+79,C2,"Cais: Am ganiatad i gychwyn achos; Am orchymyn neu gyfarwyddiadau mewn achos sydd eisoes ar waith; I ymuno fel parti, neu i roi'r gorau i fod yn barti, mewn achos teulu sydd eisoes ar waith o dan Ddeddf Plant 1989 | Application: For permission to start proceedings; For an order or directions in existing proceedings; To be joined as, or cease to be, a party in existing family proceedings under the Children Act 1989",c2-bil.pdf,application/pdf,118135,06/2016,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,79
+80,C20,"Supplement for an application for an order to hold a child in Secure Accommodation",c20-eng.pdf,application/pdf,65271,08/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,80
+82,C3,"Application for an order authorising search for taking charge of and delivery of a child",c003-eng.pdf,application/pdf,12661,09/1999,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,82
+83,C3,"Cais am orchymyn i awdurdodi chwilio am blentyn, cymryd cyfrifoldeb drosto/drosti a throsglwyddo'r plentyn i fan penodol | Application for an order authorising search for, taking charge of, and delivery of, a child",c003-bil.pdf,application/pdf,128333,09/1999,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,83
+84,C4,"Application for an order for disclosure of a child's whereabouts",c004-eng.pdf,application/pdf,13201,09/1999,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,84
+85,C4,"Cais am orchymyn i ddatgelu ble mae plentyn | Application for an order for disclosure of a child's whereabouts",c004-bil.pdf,application/pdf,118653,09/1999,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,85
+86,C60,"Tystysgrif y cyfeirir ati yn Erthygl 33 Rheoliad y Cyngor (CE) Rhif 1347/2000 29 Mai 2000 sy'n ymwneud â dyfarniadau ynghylch cyfrifoldeb rhieni | Certificate referred to in Article 33 of Council Regulation (EC) No. 1347/2000 of 29 May 2000 concerning judgments on parental responsibility",c060-bil.pdf,application/pdf,140319,09/2001,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,86
+87,C60,"Concerning Judgements on parental responsibility",c060-eng.pdf,application/pdf,278155,03/2005,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,87
+88,C7,"Acknowledgement",c007-eng.pdf,application/pdf,201509,11/2013,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,88
+89,C9,"Statement of service",c009-eng.pdf,application/pdf,28940,10/2004,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,89
+90,C9,"Datganiad Cyflwyno | Statement of Service",c009-bil.pdf,application/pdf,122072,12/2004,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,90
+91,Case Management Information Sheet,"Case Management Information Sheet",cmis-eng.doc,application/msword,24576,04/2005,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,91
+93,CB1,"Making an Application - Children and the Family Courts",cb001-eng.pdf,application/pdf,286318,02/2015,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,93
+94,CB2,"Urgent Hearings and Those Without Notice in Relation to Child Arrangements",cb002-eng.pdf,application/pdf,158078,11/2014,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,94
+97,CB3,"Serving the Forms",cb003-eng.pdf,application/pdf,433687,04/2014,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,97
+98,D11,"Application notice",d11-eng.pdf,application/pdf,201034,06/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,98
+99,D11,"Rhybudd o gais | Application notice",d11-bil.pdf,application/pdf,155917,06/2016,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,99
+100,D13B,"Affidafid i gefnogi cais i hepgor cyflwyno'r ddeiseb ysgaru/diddymu/dirymu/ymwahaniad (cyfreithiol) i'r Atebydd | Affidavit in support of a request to dispense with service of the divorce/dissolution/nullity/(judicial) separation petition on the Respondent",d013b-bil.pdf,application/pdf,250827,04/2012,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,100
+103,D180,"Tystysgrif y cyfeirir ati yn Erthygl 33 Rheoliad y Cyngor (CE) Rhif 1347/2000 29 Mai 2000 sy'n ymwneud â dyfarniadau mewn materion priodasol | Certificate referred to in Article 33 of Council Regulation (EC) NO. 1347/2000 of 29 May 2000 concerning judgments in matrimonial matters",d180-bil.pdf,application/pdf,261499,09/2001,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,103
+104,D180,"Concerning judgments in matrimonial matters",d180-eng.pdf,application/pdf,251725,03/2005,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,104
+105,D183,"Ynglyn ag ysgariad/diddymiad",d183-cym.pdf,application/pdf,142258,04/2014,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,105
+106,D183,"About Divorce/Dissolution",d183-eng.pdf,application/pdf,168484,04/2014,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,106
+108,D184,"Rydw i eisiau ysgariad/diddymiad - beth ddylwn i ei wneud?",d184-cym.pdf,application/pdf,140770,04/2014,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,108
+109,D184,"I Want to Get a Divorce/Dissolution",d184-eng.pdf,application/pdf,168240,04/2014,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,109
+111,D185,"Children and Divorce and Dissolution",d185-eng.pdf,application/pdf,156385,04/2014,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,111
+112,D185,"Plant ac ysgariad a diddymiad",d185-cym.pdf,application/pdf,143891,04/2014,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,112
+114,D186,"Mae'r atebydd wedi ateb fy neiseb",d186-cym.pdf,application/pdf,137439,04/2014,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,114
+115,D186,"The respondent has replied to my petition. What must I do?",d186-eng.pdf,application/pdf,347722,04/2016,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,115
+117,D187,"Mae gen i ddyfarniad nisi/gorchymyn amodol. Beth sydd rhaid i mi ei wneud nesaf?",d187-cym.pdf,application/pdf,151883,04/2014,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,117
+119,D187,"I Have a Decree Nisi/Conditional Order.  What Must I do Next?",d187-eng.pdf,application/pdf,155595,11/2015,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,119
+120,D190,"I Want to Apply for a Financial Order",d190-eng.pdf,application/pdf,145929,08/2015,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,120
+121,D190,"Rwyf eisiau gwneud cais am orchymyn ariannol",d190-cym.pdf,application/pdf,158638,08/2015,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,121
+122,D252,"Notice of commencement of assessment of bill of costs",d252-eng.pdf,application/pdf,32009,04/2011,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,122
+123,D252,"Hysbysiad cychwyn asesu bil costau | Notice of commencement of assessment of bill of costs",d252-bil.pdf,application/pdf,67650,04/2011,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,123
+124,D254,"Request for a Default Costs Certificate",d254-eng.pdf,application/pdf,26245,04/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,124
+125,D254,"Cais am Dystysgrif Costau Diffygdalu | Request for a Default Costs Certificate",d254-bil.pdf,application/pdf,57221,04/2011,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,125
+126,D258,"Request for detailed assessment hearing (general form)",d258-eng.pdf,application/pdf,245134,04/2011,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,126
+127,D258,"Cais am wrandawiad asesiad manwl (ffurflen gyffredinol) | Request for detailed assessment hearing (general form)",d258-bil.pdf,application/pdf,82981,04/2011,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,127
+128,D258A,"Request for detailed assessment (Legal aid/Legal Services Commission only)",d258a-eng.pdf,application/pdf,251422,11/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,128
+129,D258A,"Cais am asesiad manwl (Y Comisiwn Gwasanaethau Cyfreithiol/Cymorth Cyfreithiol yn unig) | Request for detailed assessment (Legal aid/Legal Services Commission only)",d258a-bil.pdf,application/pdf,78386,04/2011,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,129
+130,D259,"Notice of Appeal against a detailed assessment",d259-eng.pdf,application/pdf,44871,11/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,130
+131,D259,"Hysbysiad o Apel yn erbyn asesiad manwl | Notice of Appeal against a detailed assessment",d259-bil.pdf,application/pdf,75615,04/2011,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,131
+133,D36,"Hysbysiad o gais i wneud dyfarniad nisi yn absoliwt neu i wneud gorchymyn amodol yn derfynol | Notice of application for decree nisi to be made absolute or conditional order to be made final",d036-bil.pdf,application/pdf,100493,11/2014,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,133
+134,D440,"Request for Search for Divorce Decree Absolute",d440-eng.pdf,application/pdf,567472,11/2014,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,134
+135,D63,"Gwys Dyfarniad Rheolau Achosion Teulu 7.4(5) | Judgement Summons Family Proceedings Rules 7.4(5)",d063-bil.pdf,application/pdf,209473,01/2003,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,135
+138,D8,"Deiseb ysgaru/diddymu/ymwahanu (cyfreithiol) | Divorce/dissolution/(judicial) separation petition",d8-bil.pdf,application/pdf,174151,06/2016,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,138
+140,D8 Notes,"Supporting Notes for Guidance on Completing a Divorce/Dissolution/(Judicial) Separation Petition",d008-notes-eng.pdf,application/pdf,185581,04/2014,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,140
+141,D8 Nodiadau | D8 Notes,"Nodiadau canllaw ar gyfer llenwi deiseb ysgaru/diddymu/ymwahanu (cyfreithiol) | Supporting notes for guidance on completing a divorce/dissolution/(judicial) separation petition",d008-notes-bil.pdf,application/pdf,172287,04/2014,26,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,141
+142,D80A,"Statement in Support of Divorce/(Judicial) Separation - Adultery",d080a-eng.pdf,application/pdf,596713,04/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,142
+143,D80A,"Datganiad i gefnogi ysgariad/ymwahaniad (cyfreithiol) - godineb | Statement in support of divorce/(judicial) separation - adultery",d080a-bil.pdf,application/pdf,497406,04/2014,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,143
+144,D80B,"Statement in Support of Divorce/Dissolution/(Judicial) Separation - Unreasonable Behaviour",d080b-eng.pdf,application/pdf,603453,04/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,144
+145,D8B,"Ateb i ddeiseb ysgaru/diddymu/ymwahanu (cyfreithiol) neu ddirymu | Answer to a divorce/dissolution/(judicial) separation or nullity petition",d008b-bil.pdf,application/pdf,235389,04/2012,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,145
+146,D80C,"Statement in Support of Divorce/Dissolution/(Judicial) Separation - Desertion",d080c-eng.pdf,application/pdf,380452,04/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,146
+147,D80C,"Datganiad i gefnogi ysgariad/diddymiad/ymwahaniad (cyfreithiol) - gadael | Statement in support of divorce/dissolution/(judicial) separation - desertion",d080c-bil.pdf,application/pdf,123719,04/2014,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,147
+148,D8D,"Deiseb am orchymyn/ddyfarniad rhagdybio marwolaeth a diddymu priodas/partneriaeth sifil | Petition for a presumption of death decree/order and the dissolution of a marriage/civil partnership",d008d-bil.pdf,application/pdf,170140,01/2014,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,148
+149,D80D,"Statement in Support of Divorce/Dissolution/(Judicial) Separation - 2 Years' Consent",d080d-eng.pdf,application/pdf,609037,01/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,149
+150,D80E,"Statement in Support of Divorce/Dissolution/(Judicial) Separation - 5 Years' Consent",d080e-eng.pdf,application/pdf,592661,04/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,150
+151,D80E,"Datganiad i gefnogi ysgariad/diddymiad/ymwahaniad (cyfreithiol) - ymwahaniad 5 mlynedd | Statement in support of divorce/dissolution/(judicial) separation - 5 years' separation",d080e-bil.pdf,application/pdf,117553,04/2014,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,151
+153,D81,"Datganiad gwybodaeth am orchymyn cydsynio yng nghyswllt rhwymedi ariannol | Statement of information for a consent order in relation to a financial remedy",d081-bil.pdf,application/pdf,293184,04/2012,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,153
+154,D84,"Application for a decree nisi conditional order or (judicial) separation decreeorder",d084-eng.pdf,application/pdf,327965,04/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,154
+155,D84,"Cais am ddyfarniad nisi/gorchymyn amodol neu orchymyn/dyfarniad ymwahanu (cyfreithiol) | Application for a decree nisi/conditional order or (judicial) separation decree/order",d084-bil.pdf,application/pdf,158001,04/2012,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,155
+156,D89,"Request for personal service by a court bailiff",d89-eng.pdf,application/pdf,111472,10/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,156
+157,D89,"Cais am gyflwyno personol gan feili llys | Request for personal service by a court bailiff",d089-bil.pdf,application/pdf,180199,04/2011,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,157
+159,D8A,"Datganiad trefniadau ar gyfer plant | Statement of arrangements for children",d008a-bil.pdf,application/pdf,292368,04/2011,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,159
+160,D151,"Application for registration of a maintenance order in the family court",d151-eng.pdf,application/pdf,145212,11/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,160
+161,EX107,"Tape transcription request",ex107-eng.pdf,application/pdf,358619,04/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,161
+162,EX107,"Cais am Drawsgrifio Tâp | Tape transcription request",ex107-bil.pdf,application/pdf,279747,01/2007,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,162
+164,EX140,"Cofnod archwiliad (Unigolyn) | Record of examination (Individual)",ex140-bil.pdf,application/pdf,1128608,04/2003,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,164
+165,EX140,"Record of evidence (Individual debtor)",ex140-eng.pdf,application/pdf,377873,04/2003,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,165
+166,EX141,"Cofnod archwiliad (swyddog mewn cwmni neu gorfforaeth) | Record of examination (Officer of company or corporation)",ex141-bil.pdf,application/pdf,667221,04/2003,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,166
+167,EX141,"Record of evidence (Officer of a company)",ex141-eng.pdf,application/pdf,267534,04/2003,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,167
+170,EX97A,"Bailiff risk assessment questionnaire",ex97a-eng.pdf,application/pdf,87919,03/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,170
+175,EX20,"Paying your Judgment, what do I do?",ex020-eng.pdf,application/pdf,169328,04/2013,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,175
+177,EX20,"Talu fy nyfarniad - Beth ddylwn i wneud?",ex020-cym.pdf,application/pdf,170336,04/2006,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,177
+178,N1A,"Notes for claimant on completing a claim form",n001a-eng.pdf,application/pdf,51124,07/2014,8,3,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,178
+179,EX301,"I'm in a dispute, what can I do?",ex301-eng.pdf,application/pdf,227014,06/2014,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,179
+181,EX301,"Rwyf mewn anghydfod - beth alla i ei wneud?",ex301-cym.pdf,application/pdf,868803,03/2012,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,181
+183,EX302,"How do I make a court claim? For people who want to take a dispute to court",ex302-eng.pdf,application/pdf,175970,04/2014,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,183
+185,EX302,"Sut mae gwneud hawliad | How to make a claim",ex302-bil.pdf,application/pdf,254951,04/2006,26,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,185
+187,EX303,"A court claim has been made against me, what Should I Do? For people whose dispute has been taken to court",ex303-eng.pdf,application/pdf,222127,06/2014,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,187
+189,EX303,"Mae hawliad wedi'i wneud yn fy erbyn yn y llys - beth ddylwn i ei wneud?",ex303-cym.pdf,application/pdf,873947,11/2011,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,189
+191,EX304,"I've started a claim in court, what happens next?",ex304-eng.pdf,application/pdf,212385,06/2014,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,191
+193,EX304,"Rwyf wedi cychwyn hawliad yn y llys - beth sy'n digwydd nesaf?",ex304-cym.pdf,application/pdf,855927,10/2011,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,193
+196,EX305,"The fast track and the multi-track in the civil courts",ex305-eng.pdf,application/pdf,467974,03/2017,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,196
+197,EX305,"Y Trac Cyflym a'r Amldrac mewn llysoedd sifil",ex305-cym.pdf,application/pdf,147266,03/2017,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,197
+199,EX306,"The small claims track in the civil courts (If your dispute has gone to court)",ex306-eng.pdf,application/pdf,478395,03/2017,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,199
+201,EX306,"Y trac hawliadau bychain yn y llysoedd sifil (Os yw eich anghydfod wedi mynd ymlaen i'r llys)",ex306-cym.pdf,application/pdf,151418,03/2017,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,201
+215,EX320,"Registered judgments, what does it mean?",ex320-eng.pdf,application/pdf,157668,06/2014,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,215
+217,EX320,"Dyfarniad cofrestredig - Beth mae hynny'n ei olygu? | Registered judgments, what does it mean?",ex320-bil.pdf,application/pdf,232137,04/2006,26,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,217
+219,EX321,"I have a judgment but the defendant hasn't paid, what do I do?",ex321-eng.pdf,application/pdf,180597,04/2016,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,219
+221,EX321,"Mae gennyf ddyfarniad ond nid yw'r diffynnydd wedi talu - Beth ddylwn ei wneud?",ex321-cym.pdf,application/pdf,151478,04/2016,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,221
+224,EX322,"How do I ask for a warrant of control?",ex322-eng.pdf,application/pdf,223093,04/2016,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,224
+225,EX322,"Gwarantau Rheolaeth - Sut mae gofyn am warant reolaeth?",ex322-cym.pdf,application/pdf,597200,04/2016,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,225
+227,EX323,"How do I ask for an attachment of earnings order?",ex323-eng.pdf,application/pdf,229604,04/2016,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,227
+229,EX323,"Atafaelu enillion - Sut mae gofyn am orchymyn atafaelu enillion?",ex323-cym.pdf,application/pdf,410593,04/2016,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,229
+231,EX324,"How do I apply for an order? Order to obtain information from a person who owes you money",ex324-eng.pdf,application/pdf,163670,04/2014,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,231
+233,EX324,"Sut mae gwneud cais am orchymyn? Gorchymyn i gael gwybodaeth gan rywun sydd mewn dyled i chi",ex324-cym.pdf,application/pdf,153815,04/2014,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,233
+234,EX325,"Third party debt orders and charging orders. How do I apply for an order? How do I respond to an order?",ex325-eng.pdf,application/pdf,204095,05/2016,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,234
+236,EX325,"Gorchmynion dyled trydydd parti a gorchmynion arwystlo. Sut mae gwneud cais am orchymyn? Sut mae ymateb i orchymyn?",ex325-cym.pdf,application/pdf,195843,05/2016,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,236
+237,EX326,"I cannot pay my judgment, what do I do?",ex326-eng.pdf,application/pdf,189007,04/2014,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,237
+239,EX326,"Alla'i ddim talu fy nyfarniad - beth ddylwn i wneud?",ex326-cym.pdf,application/pdf,210281,04/2005,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,239
+240,EX326,"Alla'i ddim talu fy nyfarniad - beth ddylwn i wneud? (PDF Print Bras)",ex326-large-cym.pdf,application/pdf,156540,04/2003,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,240
+241,EX327,"I've got a maintenance order but it's not being paid",ex327-eng-20160107.pdf,application/pdf,174899,01/2016,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,241
+244,EX327,"Mae gen i orchymyn cynhaliaeth ond nid yw'n cael ei dalu",ex327-cym.pdf,application/pdf,159743,08/2015,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,244
+245,EX332,"Squatters - A quicker procedure",ex332-eng.pdf,application/pdf,175497,07/2014,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,245
+246,EX332,"Sgwatwyr - Gorchymyn meddiannu dros dro trefn gyflymach - Gwydobaeth i berchnogion a thenantiaid",ex332-cym.pdf,application/pdf,153020,04/2005,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,246
+247,EX333,"Squatters - Illegal occupation of premises",ex333-eng.pdf,application/pdf,192474,04/2005,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,247
+248,EX333,"Sgwatwyr - Gorchymyn meddiannu interim - Dal eiddo yn anghyfreithlon - Gwybodaeth i ddeiliaid",ex333-cym.pdf,application/pdf,125089,04/2005,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,248
+249,EX340,"I want to appeal, what should I do? For people who want to appeal against a court decision",ex340-eng.pdf,application/pdf,550282,11/2016,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,249
+250,EX340,"Rwyf am apelio - beth ddylwn i ei wneud?",ex340-cym.pdf,application/pdf,166891,04/2014,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,250
+251,EX341,"I Have Been Asked to Be a Witness - What Do I Do?",ex341-eng.pdf,application/pdf,161613,04/2014,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,251
+252,EX341,"Gofynnwyd i mi fod yn dyst - beth ddylwn ei wneud? Bod yn dyst yn yr Uchel Lys a'r Llysoedd Sirol",ex341-cym.pdf,application/pdf,154444,04/2014,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,252
+253,EX342,"Coming to a Court Hearing?  Some Things You Should Know.  Court Hearings in the High Court and County Courts",ex342-eng.pdf,application/pdf,176458,07/2014,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,253
+254,EX343,"Unhappy With Our Service - What Can You Do?",ex343-eng.pdf,application/pdf,157575,10/2015,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,254
+255,EX343,"Yn anfodlon gyda'n gwasanaeth - beth allwch chi ei wneud? Canllaw ar gyfer ein holl ddefnyddwyr",ex343-cym.pdf,application/pdf,143538,10/2015,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,255
+256,EX343A,"Complaint form",ex343a-eng.pdf,application/pdf,117532,10/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,256
+257,EX343A,"Ffurflen gwyno",ex343a-cym.pdf,application/pdf,149594,04/2010,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,257
+261,EX345,"About Bailiffs, Enforcement Officers and Enforcement Agents",ex345-eng.pdf,application/pdf,181739,04/2014,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,261
+262,EX350,"A guide to debt recovery through the county courts for small businesses",ex350-eng.pdf,application/pdf,195407,05/2014,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,262
+263,EX350,"Canllaw i fusnesau bach ynghylch adennill dyled drwy'r Llys Sirol",ex350-cym.pdf,application/pdf,174010,05/2014,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,263
+264,EX50,"Civil and Family Court Fees (from 6th March 2017)",ex50-eng.pdf,application/pdf,741564,03/2017,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,264
+266,EX501,"Mae'r hysbysiad hwn yn egluro ein gwasanaeth Welsh | This notice explains our Welsh language service",ex501-bil.pdf,application/pdf,112438,04/2012,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,266
+267,EX503,"Human Rights Act",ex503-eng.pdf,application/pdf,166899,08/2014,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,267
+269,EX550,"Affidavit of service",ex550-eng.pdf,application/pdf,33379,04/2005,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,269
+270,EX50,"Ffioedd y Llys Sifil a'r Llys Teulu (O 6 Mawrth 2017)",ex50-cym.pdf,application/pdf,140559,03/2017,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,270
+271,EX670,"Disclosure orders against the Inland Revenue",ex670-eng.doc,application/msword,47616,11/2003,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,271
+272,EX670,"Gorchmynion dadleniad yn erbyn Cyllid y Wlad",ex670-cym.doc,application/msword,46080,11/2003,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,272
+273,EX670 Notes,"Disclosure Orders Against the Inland Revenue Guidance from the Presidents Office",ex670-notes-eng.pdf,application/pdf,19914,12/2003,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,273
+274,EX80A,"Legal Aid/Legal Aid Agency Assessment Certificate",ex080a-eng.pdf,application/pdf,85194,04/2013,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,274
+275,EX80A,"Tystysgrif asesu Cymorth Cyfreithiol/Comisiwn Gwasanaethau Cyfreithiol | Legal aid/Legal Services Commission assessment certificate",ex080a-bil.pdf,application/pdf,166467,01/2005,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,275
+280,Ffurflen B,"Hysbysiad o gais i ystyried sefyllfa ariannol yr Atebydd ar ol ysgariad/diddymiad",form-b-cym.pdf,application/pdf,57497,10/2016,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,280
+285,Ffurflen P2 | Form P2,"Atodiad Atafaelu Pensiwn dan Adran 25B neu 25C Deddf Achosion Priodasol 1973 | Pension Attachment Annex under Section 25B or 25C of the Matrimonial Causes Act 1973",p02-bil.pdf,application/pdf,106447,02/2003,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,285
+286,Fixing Sheet,"Fixing Sheet",fixing-sheet-eng.doc,application/msword,44544,09/2012,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,286
+289,FL403,"Application to vary, extend or discharge an order in existing proceedings",fl403-eng.pdf,application/pdf,147332,01/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,289
+290,FL403,"Cais i amrywio, ymestyn neu ddiddymu gorchymyn mewn achos cyfredol | Application to vary, extend or discharge an order in existing proceedings",fl403-bil.pdf,application/pdf,186645,11/2014,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,290
+291,FL407,"Cais am Warant Arestio | Application for a warrant of arrest",fl407-bil.pdf,application/pdf,113802,10/1997,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,291
+292,FL410,"Ymrwymiad atebydd | Recognizance of respondent",fl410-bil.pdf,application/pdf,137200,10/1997,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,292
+293,FL411,"Ymrwymiad ernes atebydd | Recognizance of respondent's surety",fl411-bil.pdf,application/pdf,164276,10/1997,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,293
+294,FL415,"Statement of service",fl415-eng.pdf,application/pdf,593445,10/1997,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,294
+295,FL415,"Datganiad Cyflwyno | Statement of Service",fl415-bil.pdf,application/pdf,124180,10/1997,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,295
+296,FL700,"Domestic violence injunctions under the Family Law Act - How can it help me?",fl700-eng.pdf,application/pdf,277169,07/2016,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,296
+297,Form 110,"Certificate for enforcement in a foreign country under [s.10 of the Administration of Justice Act 1920] [s.10 of the Foreign Judgments (Reciprocal Enforcement) Act 1933] [s.12 of the Civil Jurisdiction and Judgments Act 1982] (CPR 74.12 and PD 74A para.7)",form110-eng.doc,application/msword,33792,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,297
+298,Form 111,"Certificate of the enforcement in Scotland or Northern Ireland of a money judgment of the High Court or of the County Court (s.18 of and Schedule 6 to the Civil Jurisdiction and Judgments Act 1982) (CPR 74.17 and PD 74A para.8.2)",form111-eng.doc,application/msword,31744,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,298
+299,Form 112,"Certificate annexed to a sealed copy of judgment of the High Court or of the County Court for enforcement of non-money provisions in Scotland or Northern Ireland (s.18 of and Schedule 7 to the Civil Jurisdiction and Judgments Act 1982) (CPR 74.18 and PD 74A para.8.3)",form112-eng.doc,application/msword,31744,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,299
+328,Getting the best out of the court system,"Getting the best out of the court system. Information for local authorities and other social landlords",possession-claims-eng.pdf,application/pdf,308425,08/2003,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,328
+335,Jury Summons Form,"Jury Summons Form",jury-summons-eng.pdf,application/pdf,98839,07/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,335
+336,Jury Summons Guide,"Guide to Jury Summons",jury-summons-guide-eng.pdf,application/pdf,82601,07/2014,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,336
+337,N1,"Ffurflen hawlio (RTS rhan 7) | Claim form (CPR part 7)",n1-bil.pdf,application/pdf,85103,06/2016,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,337
+338,N1,"Claim form (CPR Part 7)",n1-eng.pdf,application/pdf,83171,06/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,338
+340,N1(CC),"Claim Form",n001(cc)-eng.pdf,application/pdf,39271,04/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,340
+342,N11,"Ffuflen amddiffyniad | Defence form",n011-bil.pdf,application/pdf,152962,04/2006,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,342
+343,N11,"Defence form",n011-eng.pdf,application/pdf,356407,12/2007,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,343
+345,N117,"General form of undertaking",n117-eng.pdf,application/pdf,38589,10/2012,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,345
+346,N117,"Ffurflen Gyffredinol Ymgymeriad",n117-cym.pdf,application/pdf,64359,04/1999,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,346
+347,N119,"Particulars of claim for possession",n119-eng.pdf,application/pdf,256464,04/2010,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,347
+350,N119,"Manylion hawliad i feddiannu (adeilad preswyl ar rent) | Particulars of claim for possession (Rented residential premises)",n119-bil.pdf,application/pdf,337635,08/2005,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,350
+351,N119A,"Notes for guidance to complete particulars of claim",n119a-eng.pdf,application/pdf,154523,04/2010,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,351
+355,N11B,"Defence form (Accelerated possession procedure) (Assured shorthold tenancy)",n011b-eng.pdf,application/pdf,318019,08/2011,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,355
+358,N11B,"Ffurflen Amddiffyn (trefn meddiannu gyflymedig) (tenantiaeth fyrddaliadol sicr) | Defence form (Accelerated possession procedure) (Assured shorthold tenancy)",n011b-bil.pdf,application/pdf,111954,08/2011,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,358
+359,N11D,"Defence form (Demotion of tenancy) (Suspension of right to buy)",n011d-eng.pdf,application/pdf,130288,08/2005,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,359
+361,N11D,"Ffurflen amddiffyn (israddio tenantiaeth) | Defence form (Demotion of tenancy)",n011d-bil.pdf,application/pdf,738800,08/2005,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,361
+362,N11M,"Ffurflen Amddiffyniad (eiddo preswyl dan forgais) | Defence form (Mortgaged residential premises)",n011m-bil.pdf,application/pdf,453986,04/2006,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,362
+363,N11M,"Defence form (Mortgaged residential premises)",n011m-eng.pdf,application/pdf,521714,04/2006,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,363
+366,N11R,"Ffurflen Amddiffyniad (adeilad preswyl ar rent) | Defence form (Rented residential premises)",n011r-bil.pdf,application/pdf,463710,04/2006,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,366
+367,N11R,"Defence form",n011r-eng.pdf,application/pdf,490064,04/2006,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,367
+369,N120,"Manylion hawliad i feddiannu (eiddo preswyl dan forgais) | Particulars of claim for possession (Mortgaged residential premises)",n120-bil.pdf,application/pdf,248763,10/2005,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,369
+371,N120,"Particulars of claim (Mortgaged residential premises)",n120-eng.pdf,application/pdf,171091,08/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,371
+372,N121,"Manylion hawliad i feddiannu (tresmaswyr) | Particulars of claim for possession (Trespassers)",n121-bil.pdf,application/pdf,88368,10/2001,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,372
+373,N121,"Particulars of claim (Trespassers)",n121-eng.pdf,application/pdf,41660,10/2001,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,373
+375,N122,"Particulars of claim for demotion order/suspension of right to buy",n122-eng.pdf,application/pdf,123349,04/2010,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,375
+377,N122,"Manylion hawliad gorchymyn israddio | Particulars of claim for demotion order",n122-bil.pdf,application/pdf,203751,08/2005,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,377
+378,N130,"Cais am orchymyn meddiannu interim | Application for an interim possession order",n130-bil.pdf,application/pdf,221790,12/2002,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,378
+379,N130,"Application for possession including application for interim possession order",n130-eng.pdf,application/pdf,166548,05/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,379
+380,N133,"Datganiad tyst y diffynnydd i wrthwynebu gwneud gorchymyn meddiannu interim | Witness statement of the defendant to oppose the making of an interim possession order",n133-bil.pdf,application/pdf,143597,12/2002,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,380
+381,N133,"Witness statement of the defendant to oppose the making of an interim possession order",n133-eng.pdf,application/pdf,59327,12/2002,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,381
+382,N15,"Acknowledgment of service (Arbitration claim)",n015-eng.pdf,application/pdf,404783,03/2002,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,382
+383,N15,"Cydnabyddiad Cyflwyno (hawliad cyflafareddu) | Acknowledgment of service (Arbitration claim)",n015-bil.pdf,application/pdf,155311,03/2002,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,383
+386,N150,"Holiadur Dyrannu | Allocation questionnaire",n150-bil.pdf,application/pdf,341751,11/2011,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,386
+387,N151,"Holiadur Dyrannu (swm i'w benderfynu gan y llys) | Allocation questionnaire (Amount to be decided by the court)",n151-bil.pdf,application/pdf,351898,04/2008,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,387
+388,N161,"Appellant's notice (all appeals except small claims track appeals and appeals to the Family Division of the High Court)",n161-eng.pdf,application/pdf,588066,10/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,388
+391,N161,"Hysbysiad apelydd (Pob apel ac eithrio apeliadau ar y trac hawliadau bychain) | Appellant's notice (All appeals except small claims track appeals)",n161-bil.pdf,application/pdf,139380,06/2016,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,391
+392,N161A,"Guidance notes on completing form N161 - Appellant's notice (all appeals except small claims track appeals or appeals to the Family Division of the High Court)",n161a-eng.pdf,application/pdf,316437,10/2016,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,392
+393,N161A,"Nodiadau cyfarwyddiadol ar gyfer llenwi rhybudd yr apelydd",n161a-cym.pdf,application/pdf,40443,10/2001,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,393
+394,N161B,"Important Notes for Respondent",n161b-eng.pdf,application/pdf,24597,04/2000,8,3,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,394
+396,N162,"Respondent's notice (For all appeals except appeals to the Family Division of the High Court)",n162-eng.pdf,application/pdf,97038,10/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,396
+398,N162A,"Guidance notes on completing the respondent's notice",n162a-eng.pdf,application/pdf,292215,04/2007,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,398
+400,N163,"Skeleton arguments",n163-eng.pdf,application/pdf,63470,04/2000,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,400
+401,N163,"Dadl fframwaith | Skeleton argument",n163-bil.pdf,application/pdf,140460,12/2004,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,401
+402,N16A,"Application for injunction (General form)",n016a-eng.pdf,application/pdf,400112,05/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,402
+405,N16A,"Cais am Waharddeb (Ffurflen Gyffredinol) | Application for injunction (General form)",n016a-bil.pdf,application/pdf,298728,04/2007,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,405
+406,N170,"Listing questionnaire (Pre-trial checklist)",n170-eng.pdf,application/pdf,111054,05/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,406
+408,N170,"Holiadur rhestru (Rhestr wirio cyn-treial) | Listing questionnaire (Pre-trial checklist)",n170-bil.pdf,application/pdf,419313,12/2002,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,408
+409,N1A,"Nodiadau i'r hawlydd ar lenwi ffurflen hawlio | Notes for claimant on completing a claim form",n1a-bil.pdf,application/pdf,147823,07/2014,26,3,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,409
+416,N1FD,"Notes for defendant (Consumer Credit Act cases)",n001(fd)-eng.pdf,application/pdf,40824,06/2014,8,3,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,416
+417,N205A,"Notice of issue (Specified amount)",n205a-eng.pdf,application/pdf,329706,04/2006,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,417
+418,N2,"Claim Form (Probate)",n002-eng.pdf,application/pdf,242688,05/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,418
+419,N2,"Ffurflen Hawliad (Hawliad Profiant) | Claim Form (probate claim)",n002-bil.pdf,application/pdf,140815,10/2001,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,419
+420,N20,"Gwys Tyst | Witness summons",n020-bil.pdf,application/pdf,156452,09/2002,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,420
+421,N20,"Witness summons",n020-eng.pdf,application/pdf,50705,05/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,421
+422,N205D,"Notice of issue(Probate claim)",n205d-eng.pdf,application/pdf,26509,10/2001,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,422
+423,N208,"Ffurflen hawlio (RTS Rhan 8) | Claim form (CPR Part 8)",n208-bil.pdf,application/pdf,31765,06/2016,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,423
+424,N208,"Claim form (CPR Part 8)",n208-eng.pdf,application/pdf,75915,06/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,424
+428,N208(CC),"Claim form (Part 8)",n208(cc)-eng.pdf,application/pdf,37680,04/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,428
+429,N208A,"Nodiadau i'r hawlydd ar lenwi ffurflen hawlio Rhan 8 | Notes for claimant (Part 8 claim form)",n208a-bil.pdf,application/pdf,137471,04/1999,26,3,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,429
+431,N208A,"Notes for claimant  (Part 8 claim form)",n208a-eng.pdf,application/pdf,47310,06/2014,8,3,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,431
+432,N208C,"Nodiadau i'r diffynnydd (ffurflen hawlio Rhan 8.) | Notes for defendant (Part 8 claim form)",n208c-bil.pdf,application/pdf,268616,08/2008,26,3,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,432
+434,N208C,"Notes for defendant (Part 8 claim form)",n208c-eng.pdf,application/pdf,82124,06/2009,8,3,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,434
+435,N208C(CC),"Notes for Defendant on Replying to the Part 8 Claim Form",n208c(cc)-eng.pdf,application/pdf,202539,10/2008,8,3,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,435
+436,N210,"Cydnabyddiad Cyflwyno (Hawliadau rhan 8) | Acknowledgment of service (Part 8 claim)",n210-bil.pdf,application/pdf,893151,05/2007,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,436
+437,N210,"Acknowledgment of service (CPR Part 8)",n210-eng.pdf,application/pdf,55891,03/2001,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,437
+439,N210(CC),"Acknowledgment of service (Part 8)",n210(cc)-eng.pdf,application/pdf,37383,04/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,439
+440,N210A,"Cydnabyddiad Cyflwyno (Rhan 8 - Hawliad costau'n unig) | Acknowledgment of service (Part 8 costs - only claim)",n210a-bil.pdf,application/pdf,104258,12/2002,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,440
+441,N210A,"Acknowledgment of service (Part 8 costs - only claim)",n210a-eng.pdf,application/pdf,146344,12/2002,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,441
+442,N211,"Ffurflen hawlio (Hawliadau ychwanegol - RTS Rhan 20) | Claim form (Additional claims - CPR Part 20)",n211-bil.pdf,application/pdf,115887,06/2016,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,442
+443,N211,"Claim form (Additional claims - CPR Part 20)",n211-eng.pdf,application/pdf,74098,06/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,443
+445,N211(CC),"Claim Form (Part 20)",n211(cc)-eng.pdf,application/pdf,58075,04/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,445
+446,N211A,"Notes for claimant (Part 20 claim form)",n211a-eng.pdf,application/pdf,54123,04/2013,8,3,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,446
+449,N211C,"Nodiadau i'r diffynnydd ar ateb y ffurflen hawlio Rhan 20 | Notes for defendant (Part 20 claim form)",n211c-bil.pdf,application/pdf,159559,01/2003,26,3,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,449
+451,N211C,"Notes for defendant (Part 20 claim form)",n211c-eng.pdf,application/pdf,31769,10/2002,8,3,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,451
+452,N211C(CC),"Notes for Part 20 Defendant on Replying to the Part 20 Claim Form",n211c(cc)-eng.pdf,application/pdf,163243,04/2011,8,3,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,452
+453,N213,"Cydnabyddiad Cyflwyno (Hawliad Rhan 20) | Acknowledgment of Service (Part 20 claim)",n213-bil.pdf,application/pdf,207121,04/2006,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,453
+454,N213,"Acknowledgment of Service(Part 20 claim)",n213-eng.pdf,application/pdf,383427,10/2008,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,454
+456,N213(CC),"Acknowledgment of service (Part 20 claim) - Commercial Court",n213(cc)-eng.pdf,application/pdf,37698,04/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,456
+459,N215,"Certificate of service",n215-eng.pdf,application/pdf,273887,10/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,459
+460,N215,"Tystysgrif cyflwyno | Certificate of service",n215-bil.pdf,application/pdf,82864,09/2011,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,460
+461,N218,"Rhybudd cyflwyno i bartner | Notice of service on partner",n218-bil.pdf,application/pdf,62388,04/1999,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,461
+462,N218,"Notice of service on a partner",n218-eng.pdf,application/pdf,14052,04/1999,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,462
+463,N224,"Request for service out of England and Wales through the court",n224-eng.pdf,application/pdf,46532,04/1999,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,463
+464,N224,"Cais i gyflwyno'r tu allan i Gymru a Lloegr drwy'r llys | Request for service out of England and Wales through the court",n224-bil.pdf,application/pdf,120379,10/2008,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,464
+465,N225,"Request for judgment and reply to admission (Specified amount)",n225-eng.pdf,application/pdf,261025,04/2013,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,465
+467,N225,"Cais am Ddyfarniad ac ateb i addefiad (swm penodol) | Request for judgment and reply to admission (specified amount)",n225-bil.pdf,application/pdf,583876,04/2006,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,467
+468,N227,"Cais am Ddyfarniad trwy ddiffyg (y swm i'w benderfynu gan y llys) | Request for judgment by default (Amount to be decided by the court)",n227-bil.pdf,application/pdf,160433,04/2006,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,468
+469,N227,"Request for judgment by default (Amount to be decided by the court)",n227-eng.pdf,application/pdf,266564,04/2006,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,469
+471,N228,"Notice of admission - return of goods (Hire-purchase or conditional sale)",n228-eng.pdf,application/pdf,377549,04/2006,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,471
+472,N235,"Tystysgrif addasrwydd cyfaill cyfreitha | Certificate of suitability of litigation friend",n235-bil.pdf,application/pdf,111916,03/2003,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,472
+473,N235,"Certificate of suitability of litigation friend",n235-eng.pdf,application/pdf,705661,10/2007,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,473
+475,N24,"General form of Judgment or order",n024-eng.pdf,application/pdf,392894,04/1999,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,475
+476,N242,"Hysbysiad talu i'r llys (dan orchymyn - Rhan 37) | Notice of payment into court (Under order - Part 37)",n242-bil.pdf,application/pdf,88642,04/2003,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,476
+477,N242,"Notice of payment into court (Under order - part 37)",n242-eng.pdf,application/pdf,117412,05/2012,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,477
+478,N242A,"Notice of offer to settle (Section 1 - Part 36)",n242a-eng.pdf,application/pdf,108847,06/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,478
+479,N242A,"Hysbysiad o gynnig i setlo (Adran 1 - Rhan 36) | Notice of offer to settle (Section 1 - Part 36)",n242a-bil.pdf,application/pdf,101206,08/2011,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,479
+483,N244,"Rhybudd cyflwyno cais | Application notice",n244-bil.pdf,application/pdf,125609,06/2016,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,483
+484,N244,"Application notice",n244-eng.pdf,application/pdf,75180,06/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,484
+485,N244(CC),"Application Notice",n244(cc)-eng.pdf,application/pdf,71573,04/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,485
+486,N245,"Application for suspension of a warrant and/or variation of an order",n245-eng.pdf,application/pdf,305315,06/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,486
+488,N245,"Cais i ohirio gwarant a/neu i amrywio gorchymyn | Application for suspension of a warrant and/or variation of an order",n245-bil.pdf,application/pdf,199596,06/2016,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,488
+490,N251,"Notice of funding of case or claim",n251-eng.pdf,application/pdf,291145,10/2009,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,490
+491,N251,"Hysbysiad ynghylch ariannu achos neu hawliad | Notice of funding of case or claim",n251-bil.pdf,application/pdf,300366,04/2004,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,491
+492,N252,"Notice of commencement of assessment",n252-eng.pdf,application/pdf,16802,12/1999,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,492
+494,N253,"Notice of amount allowed on provisional assessment (Legal Aid only)",n253-eng.pdf,application/pdf,77855,07/2000,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,494
+496,N253,"Rhybudd o'r Swm a ganiateir ar Asesiad Dros Dro | Notice of amount allowed on provisional assessment",n253-bil.pdf,application/pdf,57628,02/2002,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,496
+497,N254,"Request for a default costs certificate",n254-eng.pdf,application/pdf,37058,05/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,497
+499,N254,"Cais am Dystysgrif Costau Diffygdalu | Request for a default costs certificate",n254-bil.pdf,application/pdf,950,07/2002,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,499
+500,N255(CC),"Default costs certificate (County Court)",n255(cc)-eng.pdf,application/pdf,205479,04/2006,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,500
+501,N255(HC),"Default costs certificate (High Court)",n255(hc)-eng.pdf,application/pdf,163514,04/2006,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,501
+502,N256(CC),"Final costs certificate (County Court)",n256(cc)-eng.pdf,application/pdf,207466,04/2006,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,502
+503,N256(HC),"Final costs certificate (High Court)",n256(hc)-eng.pdf,application/pdf,168353,04/2006,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,503
+504,N258,"Request for provisional/general detailed assessment",n258-eng.pdf,application/pdf,55282,05/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,504
+506,N258,"Cais am Wrandawiad Asesu Manwl (ffurflen gyffredinol) | Request for detailed assessment hearing (General form)",n258-bil.pdf,application/pdf,103975,07/2000,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,506
+507,N258A,"Request for detailed assessment (legal aid/Legal Services Commission only)",n258a-eng.pdf,application/pdf,27493,04/2013,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,507
+509,N258A,"Cais am asesiad manwl (Y Comisiwn Gwasanaethau Cyfreithiol/Cymorth Cyfreithiol yn unig) | Request for detailed assessment (Legal aid/Legal Services Commission only)",n258a-bil.pdf,application/pdf,135686,07/2000,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,509
+510,N258B,"Request for detailed assessment (Costs payable out of a fund other than the Community Legal Service Fund)",n258b-eng.pdf,application/pdf,25168,04/2013,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,510
+512,N258B,"Cais am asesiad manwl (Costau'n daladwy o gronfa ar wahân i Gronfa'r Gwasanaeth Cyfreithiol Cymunedol) | Request for detailed assessment (Costs payable out of a fund other than the Community Legal Service Fund)",n258b-bil.pdf,application/pdf,134876,07/2000,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,512
+513,N258C,"Request for detailed assessment hearing pursuant to an order under Part III of the Solicitors Act 1974",n258c-eng.pdf,application/pdf,133449,07/2000,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,513
+515,N258C,"Cais am wrandawiad asesu manwl yn unol â gorchymyn dan Ran III Deddf Twrneiod 1974 | Request for detailed assessment hearing pursuant to an order under Part III of the Solicitors Act 1974",n258c-bil.pdf,application/pdf,138385,07/2000,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,515
+516,N259,"Notice of appeal against a detailed assessment (Civil)",n259-eng.pdf,application/pdf,17864,03/2010,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,516
+517,N260,"Statement of costs (Summary Assessment)",n260-eng.pdf,application/pdf,126536,06/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,517
+519,N260,"Datganiad Costau(asesiad diannod) | Statement of Costs(summary assessment)",n260-bil.pdf,application/pdf,175966,10/2001,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,519
+520,N265,"Rhestr Dogfennau: dadleniad safonol | List of documents: standard disclosure",n265-bil.pdf,application/pdf,102574,04/1999,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,520
+521,N265,"List of documents: standard disclosure",n265-eng.pdf,application/pdf,250657,10/2005,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,521
+523,N265(CC),"List of documents",n265(cc)-eng.pdf,application/pdf,236275,10/2005,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,523
+524,N266,"Notice to admit facts/admission of facts",n266-eng.pdf,application/pdf,21269,04/1999,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,524
+525,N266,"Rhybudd i gydnabod ffeithiau | Notice to admit facts",n266-bil.pdf,application/pdf,950,04/1999,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,525
+526,N268,"Notice to prove documents at trial",n268-eng.pdf,application/pdf,16914,04/1999,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,526
+528,N270,"Administration orders - Notes for guidance",n270-eng.pdf,application/pdf,217328,05/2006,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,528
+529,N270,"Canllawiau (PDF llenwi cais am orchymyn gweinyddu)",n270-cym.pdf,application/pdf,384586,04/1999,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,529
+532,N279,"Notice of discontinuance",n279-eng.pdf,application/pdf,73640,06/1999,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,532
+533,N285,"Ffurflen gyffredinol affidafid | General form of affidavit",n285-bil.pdf,application/pdf,32825,04/1999,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,533
+534,N285,"General form of affidavit",n285-eng.pdf,application/pdf,19800,04/1999,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,534
+535,N292,"Order on Settlement on behalf of child or patient",n292-eng.pdf,application/pdf,154069,09/2009,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,535
+536,N293A,"Combined Certificate of Judgment and Request for Writ of Fieri Facias or Writ of Possession",n293a-eng.pdf,application/pdf,357879,04/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,536
+537,N293A,"Tystysgrif gyfunol o ddyfarniad a chais am writ fieri facias neu writ meddiant | Combined certificate of judgment and request for writ of fieri facias or writ of possession",n293a-bil.pdf,application/pdf,210818,04/2004,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,537
+538,N294,"Cais yr Hawlydd am Orchymyn Amrywio (heb wrandawiad) | Claimant's application for a variation order (Without hearing)",n294-bil.pdf,application/pdf,64263,06/2004,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,538
+539,N294,"Claimant's application for a variation order",n294-eng.pdf,application/pdf,21210,04/1999,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,539
+541,N2A,"Probate Claim - Notes for Claimant on Completing a Claim Form",n002a-eng.pdf,application/pdf,139443,04/2011,8,3,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,541
+542,N2A,"Hawliad Profiant Nodiadau i'r hawlydd ar lenwi ffurflen hawlio | Probate Claim Notes for claimant on completing a claim form",n002a-bil.pdf,application/pdf,106902,10/2001,26,3,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,542
+543,N2B,"Probate Claim - Notes for the Defendant",n002b-eng.pdf,application/pdf,16107,10/2001,8,3,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,543
+544,N2B,"Hawliad Profiant Nodiadau i'r diffynnydd | Probate Claim Notes for the defendant",n002b-bil.pdf,application/pdf,950,10/2001,26,3,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,544
+545,N3,"Acknowledgment of service (probate claim)",n003-eng.pdf,application/pdf,679587,10/2007,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,545
+546,N3,"Cydnabyddiad Cyflwyno (hawliad profiant) | Acknowledgment of service(probate claim)",n003-bil.pdf,application/pdf,186613,10/2001,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,546
+547,N316,"Application for order that debtor attend court for questioning",n316-eng.pdf,application/pdf,145054,06/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,547
+549,N316,"Cais am orchymyn i ddyledwr ddod i'r llys ar gyfer ei holi | Application for order that debtor attend court for questioning",n316-bil.pdf,application/pdf,148999,03/2002,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,549
+550,N316A,"Cais am orchymyn i swyddog cwmni'r dyledwr ddod i'r llys ar gyfer ei holi | Application for order that officer of the debtor company attend court for questioning",n316a-bil.pdf,application/pdf,176189,03/2002,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,550
+551,N316A,"Application for order that officer of the debtor company attend court for questioning",n316a-eng.pdf,application/pdf,158229,05/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,551
+552,N322A,"Application to enforce an award",n322a-eng.pdf,application/pdf,557160,07/2009,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,552
+553,N322A,"Cais i orfodi dyfarniad | Application to enforce an award",n322a-bil.pdf,application/pdf,731450,07/2009,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,553
+554,N323,"Cais am warant reolaeth | Request for Warrant of Control",n323-bil.pdf,application/pdf,134454,06/2016,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,554
+555,N323,"Request for Warrant of Control",n323-eng.pdf,application/pdf,71420,06/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,555
+557,N324,"Cais am Warant Trosglwyddiad o Nwyddau | Request for Warrant of Delivery of Goods",n324-bil.pdf,application/pdf,90185,04/1999,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,557
+559,N324,"Request for Warrant of Delivery of Goods",n324-eng.pdf,application/pdf,69490,05/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,559
+560,N325,"Cais am Warant Meddiannu Tir | Request for Warrant of Possession of Land",n325-bil.pdf,application/pdf,59806,10/2010,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,560
+562,N325,"Request for Warrant for Possession of Land",n325-eng.pdf,application/pdf,68066,05/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,562
+563,N336,"Request and result of search in the attachment of earnings index",n336-eng.pdf,application/pdf,29703,04/1999,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,563
+565,N336,"Cais i gynnal chwiliad yn y mynegai atafaelu enillion, a'r canlyniad | Request for and result of search in the attachment of earnings index",n336-bil.pdf,application/pdf,138987,01/2005,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,565
+566,N337,"Cais am Orchymyn Atafaelu Enillion | Request for Attachment of Earnings Order",n337-bil.pdf,application/pdf,63775,05/2014,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,566
+567,N337,"Request for Attachment of Earnings Order",n337-eng.pdf,application/pdf,244029,05/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,567
+569,N342,"Cais am Wys Dyfarniad | Request for Judgment Summons",n342-bil.pdf,application/pdf,118125,03/2002,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,569
+570,N342,"Request for Judgment Summons",n342-eng.pdf,application/pdf,98900,03/2002,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,570
+572,N349,"Cais am orchymyn i'r trydydd parti dalu dyled | Application for Third Party Debt Order",n349-bil.pdf,application/pdf,190240,03/2002,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,572
+573,N349,"Application for Third Party Debt Order",n349-eng.pdf,application/pdf,230417,05/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,573
+575,N379,"Cais am orchymyn arwystlo ar dir (RhTS Rhan 73) | Application for Charging Order on Land (CPR Part 73)",n379-bil.pdf,application/pdf,59707,06/2016,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,575
+576,N379,"Application for Charging Order on Land (CPR Part 73)",n379-eng.pdf,application/pdf,130070,06/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,576
+577,N380,"Application for Charging Order on Securities (CPR Part 73)",n380-eng.pdf,application/pdf,135247,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,577
+578,N380,"Cais am orchymyn arwystlo ar warannau (RhTS Rhan 73)",n380-cym.pdf,application/pdf,92989,04/2016,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,578
+581,N434,"Notice of Change of Solicitor",n434-eng.pdf,application/pdf,59603,04/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,581
+582,N434,"Rhybudd newid cyfreithiwr | Notice of change of solicitor",n434-bil.pdf,application/pdf,73611,07/2003,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,582
+583,N440,"Notice of application for Time Order by Debtor or Hirer",n440-eng.pdf,application/pdf,57710,04/1999,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,583
+584,N440,"Hysbysiad cais am orchymyn amser gan ddyledwr neu logwr  | Notice of application for Time Order by Debtor or Hirer",n440-bil.pdf,application/pdf,185452,04/1999,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,584
+585,N441,"Notification of request for Certificate of Satisfaction or Cancellation",n441-eng.pdf,application/pdf,476176,04/2006,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,585
+586,N445,"Cais am Ail-godi Gwarant | Request for re-issue of a Warrant",n445-bil.pdf,application/pdf,215458,04/1999,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,586
+587,N445,"Request for re-issue of warrant",n445-eng.pdf,application/pdf,50411,12/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,587
+589,N446,"Cais am Ailgychwyn Gorfodaeth neu orchymyn i gael gwybodaeth gan ddyledwr dyfarniad (nid gwarant) | Request for re-issue of enforcement or an order to obtain information from judgment debtor (not warrant)",n446-bil.pdf,application/pdf,102680,03/2002,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,589
+590,N446,"Request for re-issue of enforcement or an order to obtain information from judgment debtor",n446-eng.pdf,application/pdf,111814,08/2009,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,590
+594,N461,"Judicial review claim form",n461-eng.pdf,application/pdf,396413,06/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,594
+598,N461 Notes,"Guidance Notes on Completing the Judicial Review Claim Form",n461-notes-eng.pdf,application/pdf,272524,11/2013,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,598
+602,N462,"Judicial Review Acknowledgment of service",n462-eng.pdf,application/pdf,191760,07/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,602
+605,N463,"Judicial Review Application for Urgent Consideration",n463-eng.pdf,application/pdf,104506,09/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,605
+606,N463,"Adolygiad Barnwrol Cais am ystyriaeth frys | Judicial Review Application for urgent consideration",n463-bil.pdf,application/pdf,181842,03/2002,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,606
+608,N5,"Claim form for possession of property",n005-eng.pdf,application/pdf,84077,05/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,608
+610,N5,"Ffurflen hawlio ar gyfer meddiannu eiddo | Claim form for possession of property",n005-bil.pdf,application/pdf,745930,08/2011,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,610
+611,N56,"Form for replying to an attachment of earnings application (statement of means)",n056-eng.pdf,application/pdf,417312,06/2008,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,611
+613,N56,"Ffurflen Ateb Cais am Atafaelu Enillion | Form for replying to an attachment of earnings application",n056-bil.pdf,application/pdf,391936,04/2003,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,613
+614,N5A,"Ffurflen Hawlio ar gyfer osgoi fforffediad | Claim form for relief against forfeiture",n005a-bil.pdf,application/pdf,137242,10/2001,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,614
+616,N5A,"Claim form for relief against forfeiture",n005a-eng.pdf,application/pdf,53715,05/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,616
+618,N5B,"Claim form for possession of property (Accelerated procedure) (Assured shorthold tenancy)",n005b-eng.pdf,application/pdf,317265,05/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,618
+620,N5B,"Ffurflen hawlio ar gyfer meddiannu eiddo (trefn gyflymedig) (tenantiaeth fyrddaliadol sicr) | Claim form for possession of property (Accelerated procedure) (Assured shorthold tenancy)",n5b-bil.pdf,application/pdf,239916,05/2014,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,620
+622,N54A,"Notice of further attempt at eviction (Specimen form)",n054a-eng.pdf,application/pdf,104470,08/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,622
+626,N6,"Claim form for demotion of tenancy/suspension of right to buy",n006-eng.pdf,application/pdf,61503,05/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,626
+627,N6,"Ffurflen hawlio israddio tenantiaeth | Claim form for demotion of tenancy",n006-bil.pdf,application/pdf,130773,06/2004,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,627
+628,N7,"Notes for defendant - Mortgaged residential premises",n007-eng.pdf,application/pdf,40751,09/2013,8,3,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,628
+629,N7,"Nodiadau i'r diffynnydd (eiddo preswyl ar forgais) | Notes for defendant (Mortgaged residential premises)",n007-bil.pdf,application/pdf,115372,04/2006,26,3,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,629
+631,N77,"Notice as to consequences of disobedience to court order",n077-eng.pdf,application/pdf,9206,05/1999,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,631
+634,N7A,"Notes for defendant (Rented residential premises claim)",n007a-eng.pdf,application/pdf,101702,04/2013,8,3,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,634
+636,N7A,"Nodiadau i'r diffynnydd - hawliad adeilad preswyl ar rent | Notes for defendant - Rented residential premises claim",n007a-bil.pdf,application/pdf,121025,04/2006,26,3,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,636
+637,N7B,"Notes for defendant - Forfeiture of the lease (Residential premises)",n007b-eng.pdf,application/pdf,40269,09/2013,8,3,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,637
+638,N7B,"Nodiadau i'r diffynnydd - fforffedu'r les (adeilad preswyl) | Notes for defendant - Forfeiture of the lease (Residential premises)",n007b-bil.pdf,application/pdf,132420,04/2006,26,3,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,638
+641,N7D,"Notes for defendant (Demotion/suspension claim)",n007d-eng.pdf,application/pdf,39688,09/2013,8,3,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,641
+642,N7D,"Nodiadau i'r diffynnydd (hawliad israddio) | Notes for defendant (Demotion claim)",n007d-bil.pdf,application/pdf,88137,06/2004,26,3,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,642
+643,N8,"Claim form (Arbitration)",n008-eng.pdf,application/pdf,59172,01/2003,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,643
+644,N8A,"Arbitration claim - Notes for the claimant",n008a-eng.pdf,application/pdf,58662,04/2011,8,3,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,644
+645,N8B,"Arbitration claim - Notes for the defendant",n008b-eng.pdf,application/pdf,140543,10/2008,8,3,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,645
+647,N9,"Response pack",n009-eng.pdf,application/pdf,266343,04/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,647
+648,N9,"Pecyn Ymateb | Response pack",n009-bil.pdf,application/pdf,200977,10/2008,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,648
+649,N9(CC),"Acknowledgment of Service",n009(cc)-eng.pdf,application/pdf,362373,04/2011,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,649
+651,N92,"Application for an Administration Order",n092-eng.pdf,application/pdf,715787,04/2006,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,651
+652,N92,"Cais am orchymyn gweinyddu | Application for an Administration Order",n092-bil.pdf,application/pdf,275826,04/2006,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,652
+653,N93,"List of creditors furnished under the Act of 1971",n093-eng.pdf,application/pdf,25836,04/1999,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,653
+655,N93,"Rhestr Credydwyr | List of creditors",n093-bil.pdf,application/pdf,147329,04/1999,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,655
+656,N9A,"Ffurflen addefiad (swm penodol) | Form of admission (Specified amount)",n009a-bil.pdf,application/pdf,245534,04/2006,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,656
+657,N9A,"Form of admission (Specified Amount)",n009a-eng.pdf,application/pdf,125175,04/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,657
+659,N9B,"Defence/Counterclaim (Specified amount)",n009b-eng.pdf,application/pdf,351955,04/2013,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,659
+661,N9B,"Amddiffyniad a Gwrth-hawliad (swm penodol) | Defence and counterclaim (Specified amount)",n009b-bil.pdf,application/pdf,487287,04/2008,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,661
+663,N9C,"Addefiad (swm amhenodol,hawliadau anariannol a dychwelyd nwyddau) | Admission (Unspecified amount, non-money and return of goods claims)",n009c-bil.pdf,application/pdf,242242,04/2006,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,663
+664,N9C,"Admission (unspecified amount and non-money claims)",n009c-eng.pdf,application/pdf,368458,04/2006,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,664
+666,N9D,"Defence/Counterclaim (Unspecified amount and non-money claims)",n009d-eng.pdf,application/pdf,669207,04/2008,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,666
+668,N9D,"Amddiffyniad a Gwrth-hawliad (symiau amhenodol, hawliadau anari-annol a dychwelyd nwyddau) | Defence and counterclaim (Unspecified amount, non-money and return of goods claim)",n009d-bil.pdf,application/pdf,1299505,04/2008,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,668
+669,No. 100,"Notice of bail (sched.1- RSC O.79 r.9(7))",no100-eng.doc,application/msword,7168,04/2005,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,669
+672,No. 109,"Order for reference to the European Court (Sched 1- RSC O.114 r.2)",no109-eng.doc,application/msword,13312,04/2005,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,672
+677,No. 32,"Order for examination within jurisdiction of witness before trial or hearing (rule 34.8)",no.32-eng.doc,application/msword,28160,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,677
+678,No. 33,"Application for an order for the issue of a letter of request to judicial authorities out of the jurisdiction (rule 34.13 and PD34A para 5)",no.33-eng.doc,application/msword,27136,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,678
+679,No. 34,"Order for the issue of a letter of request to judicial authorities out of the jurisdiction (rule 34.13)",no.34-eng.doc,application/msword,27648,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,679
+680,No. 35,"Draft Letter of request for examination of witness out of jurisdiction (to be filed by a party under rule 34.13(6))",no.35-eng.doc,application/msword,29184,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,680
+681,No. 37,"Order for appointment of special examiner to take evidence of witness out of jurisdiction (rule 34.13(4) and PD34A para 5.8)",no.37-eng.doc,application/msword,29696,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,681
+682,No. 41,"Default judgment upon request in claim relating to detention of goods (rule 12.4(1)(c))",no.41-eng.doc,application/msword,25088,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,682
+683,No. 42,"Default judgment in claim for possession of land (rule 12.4(2)(a))",no042-eng.doc,application/msword,11264,04/2005,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,683
+684,No. 42A,"Order for possession (sched.1- RSC O.113)",no042a-eng.doc,application/msword,9728,04/2005,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,684
+685,No. 44,"Part 24 - Judgment for claimant",no.44-eng.doc,application/msword,28160,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,685
+686,No. 44A,"Part 24 - Judgment for defendant",no.44a-eng.doc,application/msword,27136,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,686
+687,No. 45,"Judgment after trial before Judge without Jury (Practice Direction 40B para 14.1(1))",no.45-eng.doc,application/msword,29184,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,687
+688,No. 46,"Judgment after trial before Judge with Jury (Practice Direction 40B para 14.1(2))",no.46-eng.doc,application/msword,28160,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,688
+689,No. 47,"Judgment after trial before a Master or District Judge (PD40B para 14)",no.47-eng.doc,application/msword,26112,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,689
+690,No. 48,"Order after separate trial of issue under rule 3.1(2)(i)",no.48-eng.doc,application/msword,25600,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,690
+691,No. 49,"Judgment against personal representative (PD40B para 14.3)",no.49-eng.doc,application/msword,26624,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,691
+694,No. 52,"Notice of Claim to non-parties (CPR 19.8A(4)(a)(i))",no.52-eng.doc,application/msword,47513,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,694
+695,No. 52A,"Notice of Judgment or Order to non-parties (CPR 19.8(4)(a)(i))",no.52a-eng.doc,application/msword,30208,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,695
+696,No. 53,"Writ of control",no053-eng.doc,application/msword,36352,04/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,696
+697,No. 54,"Writ of control on order for costs",no054-eng.doc,application/msword,52736,04/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,697
+699,No. 56,"Writ of control (For part)",no056-eng.doc,application/msword,53248,04/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,699
+700,No. 57,"Writ of control against personal representative",no057-eng.doc,application/msword,53760,04/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,700
+701,No. 58,"Writ of fieri facias de bonis ecclesiasticis (sched.1- RSC O.45 r.12)",no058-eng.doc,application/msword,12288,04/2005,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,701
+702,No. 59,"Writ of sequestrari de bonis ecclesiasticis (sched.1- RSC O.45 r.12)",no059-eng.doc,application/msword,12800,04/2005,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,702
+703,No. 62,"Writ of fieri facias to enforce Northern Irish or Scottish judgment",no062-eng.doc,application/msword,32768,04/2004,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,703
+704,No. 63,"Writ of control to enforce foreign registered judgment",no063-eng.doc,application/msword,56832,04/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,704
+705,No. 64,"Writ of delivery: delivery of goods, damages and costs",no064-eng.doc,application/msword,52736,04/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,705
+706,No. 65,"Writ of delivery: delivery of goods or value damages and costs",no065-eng.doc,application/msword,29184,04/2004,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,706
+707,No. 66,"Combined writ of possession and control",no066-eng.doc,application/msword,52224,04/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,707
+708,No. 66a,"Combined writ of possession and control for costs of action",no066a-eng.doc,application/msword,46080,04/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,708
+709,No. 67,"Writ of sequestration (rule 81.20(1) and rule 81.27)",no.67-eng.doc,application/msword,27648,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,709
+710,No. 68,"Writ of restitution",no068-eng.doc,application/msword,24064,04/2004,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,710
+711,No. 69,"Writ of assistance",no069-eng.doc,application/msword,24576,04/2004,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,711
+712,No. 71,"Notice of extension of writ of control",no071-eng.doc,application/msword,43008,04/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,712
+716,No. 75,"Charging order to show cause (sched. 1- RSC O.50 rr.1,2 and 4)",no075-eng.doc,application/msword,11264,04/2005,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,716
+717,No. 76,"Charging order absolute (sched. 1- RSC O.50 rr.3 and 4)",no076-eng.doc,application/msword,12288,04/2005,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,717
+718,No. 79,"Stop order on capital and income of funds in court (sched. 1- RSC O.50 r.10)",no079-eng.doc,application/msword,11264,04/2005,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,718
+719,No. 80,"Affidavit/witness statement And stop notice (sched 1- RSC O.50 r.11)",no080-eng.doc,application/msword,12288,04/2005,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,719
+720,No. 81,"Order on claim to restrain transfer of stock (sched 1- RSC O.50 r.15)",no081-eng.doc,application/msword,11264,04/2005,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,720
+721,No. 82,"Application for appointment of a receiver (sched. 1- RSC O.51 r.3)",no082-eng.pdf,application/pdf,5967,09/2000,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,721
+722,No. 83,"Order directing application for appointment of receiver and granting injunction meanwhile (sched. 1- RSC O.51 r.3)",no083-eng.doc,application/msword,11264,04/2005,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,722
+723,No. 84,"Order appointing receiver by way of equitable execution (Supreme Court Act 1981 s.37; sched. 1- RSC O.51)",no084-eng.doc,application/msword,14848,04/2005,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,723
+724,No. 85,"Order of committal or other penalty upon finding of contempt of court (sched. 1- RSC O.52)",no085-eng.doc,application/msword,12800,04/2005,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,724
+726,No. 93,"Order under the evidence (Proceedings in other jurisdictions) Act 1975 (sched. 1- RSC O.70 r.1)",no093-eng.doc,application/msword,23552,04/2005,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,726
+727,No. 94,"Order for production of documents in marine insurance claim (Part 49D PD para. 7)",no094-eng.doc,application/msword,15872,04/2005,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,727
+728,No. 95,"Certificate of order against the Crown (sched. 1- RSC O.77 r.15 and s.25 of the Crown Proceedings Act 1947)",no095-eng.doc,application/msword,11264,04/2005,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,728
+729,No. 96,"Certificate of order for costs against the Crown (sched. 1- RSC O.77 r.15 and s.25 of the Crown Proceedings Act 1947)",no096-eng.doc,application/msword,11264,04/2005,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,729
+730,No. 97,"Claim form to grant bail (criminal proceedings) (sched.1- RSC O.79 r.9(1))",no097-eng.pdf,application/pdf,5922,09/2000,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,730
+731,No. 97A,"Claim form to vary arrangements for bail (criminal proceedings) (sched.1- RSC O.79 r.9(1))",no097a-eng.doc,application/msword,20480,04/2005,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,731
+732,No. 98,"Order to release prisoner on bail (sched.1- RSC O.79 r.9(6) (6A) and (6B))",no098-eng.doc,application/msword,22528,04/2005,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,732
+733,No. 98A,"Order varying arrangements for bail (sched.1- RSC O.79 r.9(10))",no098a-eng.doc,application/msword,10240,04/2005,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,733
+734,No. 99,"Order of Court of Appeal to admit prisoner to bail (sched. 1- RSC O.59 r.20(5))",no099-eng.doc,application/msword,10240,04/2005,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,734
+735,PA1,"Probate application",pa1-eng.pdf,application/pdf,189608,11/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,735
+736,PA1,"Ffurflen Gais Profiant | Probate application form",pa001-bil.pdf,application/pdf,440959,04/2011,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,736
+739,PA1S,"Postal search of the Probate records of England and Wales",pa01s-eng-20160223.pdf,application/pdf,91466,03/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,739
+740,No. 44B,"Order under refusing judgment under Part 24 and giving directions as to the future conduct of the case",no.44b-eng.doc,application/msword,31744,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,740
+741,PA2,"Sut i gael profiant - Canllaw i bobl sy'n gweithredu heb gyfreithiwr",pa002-cym.pdf,application/pdf,220470,08/2014,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,741
+744,No. 44C,"Order under Part 24 imposing condition of payment into court (rule 3.1(3) and PD 24 paras 5.1 and 5.2)",no.44c-eng.doc,application/msword,31232,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,744
+748,No. 44D,"Order under Part 24 for detailed assessment of solicitor's bill of costs and for judgment on the amount found due thereunder",no.44d-eng.doc,application/msword,28160,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,748
+751,PF1,"Application for time (rule 3.1(2)(a)) (other than an application to extend time for service of a claim form)",pf001-eng.doc,application/msword,30720,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,751
+753,PF102,"Bench warrant",pf102-eng.doc,application/msword,25600,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,753
+754,PF103,"Warrant of committal (general) (rule 81.30)",pf103-eng.doc,application/msword,25088,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,754
+755,PF104,"Warrant of committal (contempt in face of court) (rules 81.16 and 81.30)",pf104-eng.doc,application/msword,25600,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,755
+756,PF105,"Bench warrant (failure of witness to attend)",pf105-eng.doc,application/msword,25600,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,756
+757,PF106,"Warrant of committal {of prisoner) (rule 81.30)",pf106-eng.doc,application/msword,25088,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,757
+759,PF11,"Application for Part 24 Judgment on the whole of a claim or on a particular issue (rule 24.2)",pf011-eng.doc,application/msword,30720,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,759
+760,PF113,"Evidence on Application for Service by an Alternative Method or at an Alternative Place (rules 6.15, 6.27 and PD6A paragraph 9)",pf113-eng.doc,application/msword,28672,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,760
+765,PF130,"Form of advertisement of service by an alternative method (rule 6.15)",pf130-eng.doc,application/msword,27136,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,765
+768,PF141,"Witness statement/affidavit of personal service of judgment or order (rules 81.6 and 81.9)",pf141-eng.doc,application/msword,26112,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,768
+769,PF147,"Application by another party for order declaring that solicitor has ceased to act by reason of death etc. (rule 42.4 and PD42 para 4)",pf147-eng.doc,application/msword,25088,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,769
+770,PF148,"Order declaring that solicitor has ceased to act by reason of death etc. (rule 42.4 and PD42 para 4)",pf148-eng.doc,application/msword,27136,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,770
+771,PF149,"Application by solicitor for declaration that he has ceased to act (rule 42.3 and PD42 para 3)",pf149-eng.doc,application/msword,25088,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,771
+774,PF150,"Order declaring that Solicitor has ceased to act for a party (rule 42.3 and PD42 para 3.3)",pf150-eng.doc,application/msword,26624,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,774
+775,PF152,"Evidence in support of application for examination of a witness and production of documents under the evidence (Proceedings in other jurisdictions) Act 1975 (rule 34.17 and PD34 paragraph  6.3)",pf152-eng.doc,application/msword,33792,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,775
+776,PF153,"Certificate following examination under the evidence (Proceedings in Other jurisdictions) Act 1975 (rule 34.19(2))",pf153-eng.doc,application/msword,31744,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,776
+778,PF16,"Notice of court's proposal to make an order of its own initiative (rules 3.3(2) and 3.3(3))",pf016-eng.doc,application/msword,30720,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,778
+779,PF166,"Certificate as to finality, etc. of Arbitration Award for Enforcement Abroad (Arbitration Act 1996, s.58)",pf166-eng.doc,application/msword,25600,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,779
+780,PF167,"Order to stay proceedings under Section 9 of the Arbitration Act 1996 (rule 62.8)",pf167-eng.doc,application/msword,25600,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,780
+781,PF168,"Order on application to transfer claim from High Court to County Court (sections 40(1) and (2) County Courts Act 1984; High Court and County Court Jurisdiction Order 1991 (as amended); rule 30.3)",pf168-eng.doc,application/msword,26624,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,781
+783,PF17,"Order made on court's own initiative without notice (rule 3.3(4) and (5))",pf017-eng.doc,application/msword,26624,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,783
+784,PF170A,"Application for approval of settlement or compromise for a child or protected party in personal injury or Fatal Accidents Act claim before proceedings are begun (rule 21.10(2) and PD21 paras.5 and 7)",pf170a-eng.doc,application/msword,29696,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,784
+785,PF170B,"Application for approval of settlement or compromise for a child or protected party in personal injury or Fatal Accidents Act claim after proceedings have been issued (rule 21.10(2) and PD21 paras.6.1 and 7)",pf170b-eng.doc,application/msword,26624,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,785
+786,PF172,"Request for directions in respect of funds in court or to be brought into court (rule 21.11 and PD para 8)",pf172-eng.doc,application/msword,25600,04/2005,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,786
+787,PF177,"Order for partnership membership statement (PD7A para 5B)",pf177-eng.doc,application/msword,26624,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,787
+788,PF179,"Evidence on registration of a Bill of Sale given by way of security for the payment of money (Bills of Sales Act 1878 ss.8 and 10; Bills of Sale Act (1878) Amendment Act 1882 s.10)",pf179-eng.doc,application/msword,27648,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,788
+790,PF180,"Evidence on registration of an Absolute Bill of Sale, Settlement and Deed of Gift (Bills of Sales Act 1878, ss.8 and 10)",pf180-eng.doc,application/msword,26112,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,790
+791,PF181,"Evidence on renewal of registration of a Bill of Sale (Bills of Sale Act 1878, s.11)",pf181-eng.doc,application/msword,25088,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,791
+792,PF182,"Order for extension of time to register a Bill of Sale or an affidavit of renewal thereof (Bills of Sale Act 1878, s.14; PD8A para 10A.3)",pf182-eng.doc,application/msword,25600,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,792
+793,PF183,"Evidence for permission to enter Memorandum of Satisfaction on Bill of Sale (Bills of Sale Act 1878, s.15; PD8A para 11.5)",pf183-eng.doc,application/msword,33280,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,793
+794,PF184,"Claim form for an order that a memorandum of satisfaction be written of the registered copy of a Bill of Sale (Bills of Sale Act 1878, s.15; PD8A para 11.2)",pf184-eng.doc,application/msword,26112,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,794
+795,PF185,"Order for entry of Memorandum of Satisfaction on the registered copy of a Bill of Sale (Bills of Sale Act 1878, s.15; PD8A para 11.5)",pf185-eng.doc,application/msword,25088,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,795
+796,PF186,"Evidence on application to register Assignment of Book Debts (s.344 Insolvency Act 1986; ss.8 and 10 Bills of Sales Act 1878; PD8A para 15B.4)",pf186-eng.doc,application/msword,28672,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,796
+797,PF187,"Application for solicitor's charging order (s.73 Solicitors Act 1974)",pf187-eng.doc,application/msword,25600,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,797
+798,PF188,"Charging order; solicitor's costs (s.73 Solicitors Act 1974)",pf188-eng.doc,application/msword,26624,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,798
+800,PF19,"Group Litigation Order (rule 19.11)",pf019-eng.doc,application/msword,43520,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,800
+801,PF197,"Application for order for transfer from the Royal Courts of Justice to a district registry or vice-versa or from one district registry to another (rule 30.2(4))",pf197-eng.doc,application/msword,26112,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,801
+802,PF198,"Order for transfer from the Royal Courts of Justice to a district registry or vice-versa or from one district registry to another (rule 30.2(4))",pf198-eng.doc,application/msword,26624,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,802
+804,PF2,"Order for time (rule 3.1(2)(a))",pf002-eng.doc,application/msword,26624,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,804
+806,PF205,"Evidence in support of application for permission to execute for costs of previous attempts to enforce judgment (s.15(3) and (4) of the Courts and Legal Services Act 1990)",pf205-eng.doc,application/msword,28160,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,806
+808,PF21,"Order for permission to make an additional claim under rules 20.4(2)(b), 20.5(1) or 20.7(3)(b) and directions following such permission",pf021-eng.doc,application/msword,29184,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,808
+811,PF22,"Notice claiming contribution or indemnity against another defendant (rule 20.6)",pf022-eng.doc,application/msword,33792,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,811
+813,PF23,"Group litigation order",pf023-eng.doc,application/msword,22528,04/2004,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,813
+815,PF24,"Notice by execution creditor of admission or dispute of title of interpleader claimant",pf024-eng.doc,application/msword,20992,04/2004,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,815
+818,PF25,"Interpleader application",pf025-eng.doc,application/msword,21504,04/2004,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,818
+820,PF26,"Interpleader application by an Enforcement Officer",pf026-eng.doc,application/msword,21504,04/2004,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,820
+822,PF27,"Evidence in support of interpleader application (sched. 1- RSC O.17 r.3(4))",pf027-eng.doc,application/msword,24064,04/2005,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,822
+824,PF28,"Interpleader order (1) - Claim barred where an Enforcement Officer interpleads",pf028-eng.doc,application/msword,23552,04/2004,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,824
+826,PF29,"Interpleader order (1a) - Enforcement Officer to withdraw",pf029-eng.doc,application/msword,22016,04/2004,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,826
+828,PF3,"Application for an extension of time for serving a claim form (rule 7.6)",pf003-eng.doc,application/msword,30720,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,828
+829,PF30,"Interpleader order (2) - Interpleader Claimant substituted as defendant (sched. 1-RSC O.17)",pf030-eng.doc,application/msword,19456,04/2005,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,829
+831,PF31,"Interpleader order (3) - Trial of issue",pf031-eng.doc,application/msword,23040,04/2004,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,831
+833,PF32,"Interpleader order (4) - Conditional order for an Enfocement Officer to withdraw and trial of issue",pf032-eng.doc,application/msword,23040,04/2004,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,833
+836,PF34,"Interpleader order (6) - Summary disposal",pf034-eng.doc,application/msword,24576,04/2004,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,836
+842,PF4,"Order for an extension of time for serving a claim form (rule 7.6)",pf004-eng.doc,application/msword,31232,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,842
+843,PF43,"Application for security for costs under rule 25.12 and 25.13",pf043-eng.doc,application/msword,25600,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,843
+844,PF44,"Order for security for costs (rules 25.12 and 25.13)",pf044-eng.doc,application/msword,27136,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,844
+845,PF48,"Court record form",pf048-eng.doc,application/msword,33792,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,845
+846,PF49,"Request to parties to state convenient dates for hearing of 1st CMC - Form to be returned with allocation questionnaire",pf049-eng.pdf,application/pdf,3834,08/2000,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,846
+847,PF5,"Order as to service in claim for possession where premises empty (sched.1- RSC O.10 r.4)",pf005-eng.doc,application/msword,18944,04/2005,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,847
+848,PF50,"Application for directions (Part 29)",pf050-eng.pdf,application/pdf,5714,08/2000,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,848
+849,PF52,"Order in the Queen's Bench Division for case and costs management directions in the multi-track (Part 29)",pf052-eng.doc,application/msword,54784,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,849
+850,PF53,"Order for separate trial of an issue (rule 3.1(2)(i))",pf053-eng.doc,application/msword,31744,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,850
+851,PF56,"Request for further information or clarification (Rule 18 and Practice Direction 18)",pf056-eng.doc,application/msword,36352,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,851
+852,PF57,"Application for further information or clarification (Rule 18 and Practice Direction 18, para 5)",pf057-eng.doc,application/msword,27648,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,852
+853,PF58,"Order for further information or clarification (Rule 18 and Practice Direction 18)",pf058-eng.doc,application/msword,27136,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,853
+855,PF63,"Interim Order for Receiver in Pending Claim (CPR Part 69)",pf063-eng.doc,application/msword,26624,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,855
+856,PF67,"Evidence in support of application to make Order of the Supreme Court of the United Kingdom an Order of the High Court of Justice (PD40B 13.2)",pf067-eng.doc,application/msword,28672,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,856
+857,PF68,"Order making an Order of the Supreme Court of the United Kingdom an Order of the High Court of Justice (PD40B para. 13.3)",pf068-eng.doc,application/msword,39424,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,857
+858,PF6A,"Application for permission to serve claim form out of jurisdiction (rules 6.36 and 6.37)",pf006a-eng.doc,application/msword,30208,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,858
+859,PF6B,"Order for permission to serve claim form out of jurisdiction (rule 6.37(5))",pf006b-eng.doc,application/msword,26624,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,859
+862,PF72,"List of exhibits handed in at trial (PD39A paragraph 7)",pf072-eng.doc,application/msword,33792,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,862
+863,PF74,"Order for trial of whole claim or of an issue by Master or District Judge (PD2B para. 4.1)",pf074-eng.doc,application/msword,28672,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,863
+864,PF78,"Solicitor's undertaking as to expenses (rule 34.13(6)(b))",pf078-eng.doc,application/msword,25088,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,864
+866,PF8,"Standard 'Unless' Order or other Order upon failure to file directions questionnaire (rule 26.3, PD 26 para. 2.5, and Form N181)",pf008-eng.doc,application/msword,27648,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,866
+867,PF83,"Judgment on non-attendance of party at trial (rule 39.3 and PD39A paragraph 2)",pf083-eng.doc,application/msword,28160,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,867
+868,PF84A,"Request for Judgment on failure to comply with an order made under rule 3.5(1) (rule 3.5(2))",pf084a-eng.doc,application/msword,27136,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,868
+869,PF84B,"Judgment on request arising from failure to comply with an order made under rule 3.5(1) (rule 3.5(2))",pf084b-eng.doc,application/msword,26624,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,869
+871,PF85B,"Order on application arising from a failure to comply with a condition imposed under rule 3.1(3)",pf085b-eng.doc,application/msword,31232,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,871
+872,PF86A,"Combined request for a Writ of Control, Writ of Possession, Writ of Delivery",pf086a-eng.doc,application/msword,38400,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,872
+873,PF87,"Request for issue of Writ of Sequestration (rule 83.9(3))",pf087-eng.doc,application/msword,26624,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,873
+875,PF9,"Application for judgment for possession of land (rule 12.4(2))",pf009-eng.pdf,application/pdf,5997,08/2000,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,875
+876,PF91,"Application for permission to issue a writ of possession (rule 83.13)",pf091-eng.doc,application/msword,26112,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,876
+877,PF97,"QB order for sale by an Enforcement Officer by private contract",pf097-eng.doc,application/msword,23040,04/2004,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,877
+896,PRA Form,"PRA form to be completed for a private room appointment before a Queen's Bench Master",pra-eng-20160115.doc,application/msword,59904,01/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,896
+897,PRA Cancellation Form,"Notice of cancellation of a private room appointment following lodging of consent order",pra-cancel-eng-20160115.doc,application/msword,39936,01/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,897
+898,Progress Monitoring Information Sheet,"Progress Monitoring Information Sheet",progress-monitoring-eng.doc,application/msword,19968,04/2005,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,898
+903,TCC/CM1,"Case Management Information Sheet",tcc-cm1-eng.pdf,application/pdf,93875,03/2002,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,903
+905,TCC/PTR1,"Pre-trial review questionnaire",tcc-ptr1-eng.pdf,application/pdf,251643,10/2005,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,905
+906,A61,"Application for an order for parental responsibility prior to adoption abroad (Section 84 Adoption and Children Act 2002)",a61-eng.pdf,application/pdf,407640,11/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,906
+908,5222,"Your guide to Jury Service",5222-eng.pdf,application/pdf,195958,10/2016,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,908
+914,MC100,"Make Sure You Can Pay Your Fine. (English)",mc100-eng.pdf,application/pdf,162515,12/2013,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,914
+916,EX345,"Beiliaid a Swyddogion Gorfodi",ex345-cym.pdf,application/pdf,216186,10/2007,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,916
+918,PA6,"Beth fydd yn digwydd yn fy nghyfweliad profiant?",pa006-cym.pdf,application/pdf,305538,08/2011,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,918
+919,ADM15B,"Notes for defendant - Admiralty limitation claim",adm15(b)-eng.pdf,application/pdf,42074,02/2013,8,3,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,919
+921,ADM1C,"Notes for Defendant on Replying to an Admiralty Claim Form",adm001(c)-eng.pdf,application/pdf,37856,02/2013,8,3,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,921
+929,EX342,"Yn dod i wrandawiad llys? Ambell beth y dylech ei wybod - Gwrandawiadau llys yn yr Uchel Lts a'r Llysoedd Sirol",ex342-cym.pdf,application/pdf,130063,04/2005,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,929
+930,FL700,"Sut gall hyn fy helpu i? Rhan 4 Deddf Cyfraith Teulu 1996",fl700-cym.pdf,application/pdf,278170,04/2016,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,930
+932,MC100,"Make Sure You Can Pay Your Fine. (Croatian)",mc100-hrv.pdf,application/pdf,515340,12/2013,6,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,932
+933,MC100,"Make Sure You Can Pay Your Fine (Greek)",mc100-gre.pdf,application/pdf,524633,12/2013,11,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,933
+934,MC100,"Make Sure You Can Pay Your Fine (Gujarati)",mc100-guj.pdf,application/pdf,221796,12/2013,12,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,934
+936,MC100,"Make Sure You Can Pay Your Fine (Hindi)",mc100-hin.pdf,application/pdf,226864,12/2013,13,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,936
+937,MC100,"Make Sure You Can Pay Your Fine (Kurdish)",mc100-kur.pdf,application/pdf,174696,12/2013,14,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,937
+938,MC100,"Make Sure You Can Pay Your Fine (Portuguese)",mc100-por.pdf,application/pdf,545387,12/2013,16,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,938
+939,MC100,"Make Sure You Can Pay Your Fine (Punjabi)",mc100-pun.pdf,application/pdf,209038,12/2013,17,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,939
+940,MC100,"Make Sure You Can Pay Your Fine (Serbian)",mc100-srp.pdf,application/pdf,545014,12/2013,18,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,940
+941,MC100,"Make Sure You Can Pay Your Fine. (Chinese - Simplified)",mc100-zho.pdf,application/pdf,764766,12/2013,4,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,941
+942,MC100,"Make Sure You Can Pay Your Fine (Spanish)",mc100-spa.pdf,application/pdf,541542,12/2013,20,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,942
+943,MC100,"Make Sure You Can Pay Your Fine. (Chinese - Traditional)",mc100-chi.pdf,application/pdf,891491,12/2013,5,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,943
+944,MC100,"Make Sure You Can Pay Your Fine (Turkish)",mc100-tur.pdf,application/pdf,544674,12/2013,23,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,944
+945,MC100,"Make Sure You Can Pay Your Fine (Urdu)",mc100-urd.pdf,application/pdf,194660,12/2013,24,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,945
+946,EX375,"European Enforcement Order",ex375-eng.pdf,application/pdf,152891,04/2014,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,946
+947,EX710,"Can I Talk About My Case Outside Court?  A Guide for Family Court Users",ex710-eng.pdf,application/pdf,216966,07/2013,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,947
+948,N119A,"Canllawiau ar gyfer llenwi manylion y ffurflen hawlio (adeilad preswyl ar rent) | Notes for guidance on completing particulars of claim form (Rented residential premises)",n119a-bil.pdf,application/pdf,98095,10/2005,26,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,948
+949,A50 Notes,"Application for a Placement Order (Form A50) - Notes on completing the form",a050-notes-eng.pdf,application/pdf,133430,04/2014,8,3,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,949
+950,A51 Notes,"Application for variation of a placement order (Form A51) - Notes on completing the form",a051-notes-eng.pdf,application/pdf,107004,04/2014,8,3,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,950
+951,A52 Notes,"Application for Revocation of a Placement Order (Form 52) - Notes on Completing the Form",a052-notes-eng.pdf,application/pdf,110051,04/2014,8,3,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,951
+952,A53 Notes,"Application for a Contact Order (Section 26 of the Adoption and Children Act 2002 or an order under section 51A of the Act) (Form A53). Notes on completing the form",a53-notes-eng.pdf,application/pdf,115201,11/2016,8,3,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,952
+953,A54 Notes,"Application for variation or revocation of a Contact Order (Section 27(1)(b) or Section 51B(1)(c) of the Adoption and Children Act 2002) (Form A54). Notes on completing the form",a54-notes-eng.pdf,application/pdf,214465,11/2016,8,3,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,953
+954,A55 Notes,"Application for permission to change a child's surname (Form A55). Notes on completing the form",a55-notes-eng.pdf,application/pdf,214257,11/2016,8,3,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,954
+955,A56 Notes,"Application for permission to remove a child from the United Kingdom (Form A56). Notes on completing the form",a56-notes-eng.pdf,application/pdf,219398,11/2016,8,3,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,955
+956,A57 Notes,"Application for a Recovery Order (Form A57). Notes on completing the form",a57-notes-eng.pdf,application/pdf,229525,11/2016,8,3,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,956
+957,A58 Notes,"Application for an Adoption Order (Form A58). Notes on completing the form",a58-notes-eng.pdf,application/pdf,277877,11/2016,8,3,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,957
+958,A59 Notes,"Application for a Convention Adoption Order (Form A59). Notes on completing the form",a59-notes-eng.pdf,application/pdf,266801,11/2016,8,3,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,958
+959,A60 Notes,"Application for an Adoption Order (excluding a Convention adoption order) where the child is habitually resident outside the British islands and is brought into the United Kingdom for the purposes of adoption (Form A60). Notes on completing the form",a60-notes-eng.pdf,application/pdf,266990,11/2016,8,3,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,959
+960,A61 Notes,"Application for an order for parental responsibilty prior to adoption abroad (Form A61). Notes on completing the form",a61-notes-eng.pdf,application/pdf,278515,11/2016,8,3,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,960
+961,A62 Notes,"Application for a Direction under Section 88(1) of the Adoption and Children Act 2002 (Form A62) ? Notes on Completing the Form",a062-notes-eng.pdf,application/pdf,112556,04/2014,8,3,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,961
+962,A63 Notes,"Application for an Order to Annul a Convention Adoption or Convention Adoption Order or for an Overseas Adoption or Determination Under Section 91 to Cease to be Valid (Form A63) - Notes on Completing the Form",a063-notes-eng.pdf,application/pdf,105923,04/2014,8,3,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,962
+963,FP1A,"Application Under Part 19 of the Family Procedure Rules 2010 - Notes for Applicant on Completing the Application (Form FP1)",fp001a-eng.pdf,application/pdf,485457,04/2011,8,3,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,963
+964,FP1B,"Application Under Part 19 of the Family Procedure 2010 - Notes for Respondent",fp001b-eng.pdf,application/pdf,484575,04/2011,8,3,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,964
+965,CB4,"Special Guardianship - A Guide for Family Court Users",cb004-eng.pdf,application/pdf,313059,04/2014,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,965
+966,D193,"Ynghylch diddymu",d193-cym.pdf,application/pdf,136546,08/2007,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,966
+967,D194,"Rydw i eisiau cael diddymiad - Beth ddylwn ei wneud?",d194-cym.pdf,application/pdf,185759,08/2007,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,967
+968,D195,"Plant a diddymu",d195-cym.pdf,application/pdf,149786,08/2007,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,968
+969,D196,"Ma'r atebydd wedi ateb fy neiseb",d196-cym.pdf,application/pdf,155807,08/2007,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,969
+970,D197,"Mae gen i orchymyn amodol",d197-cym.pdf,application/pdf,142596,08/2007,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,970
+973,Form E Notes,"Notes to Financial Statement for a Financial Order or for Financial Relief After an Overseas Divorce or Dissolution etc",form-e-notes-eng.pdf,application/pdf,142559,04/2014,8,3,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,973
+978,A52 Nodiadau | A52 Notes,"Cais am ddiddymu gorchymyn lleoli (Ffurflen 52). Nodiadau ar lenwi'r ffurflen | Application for revocation of a placement order (Form 52). Notes on completing the form",a052-notes-bil.pdf,application/pdf,199139,04/2011,26,3,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,978
+979,A55 Nodiadau | A55 Notes,"Cais am ganiatâd i newid cyfenw plentyn (Ffurflen A55)Nodiadau ar lenwi'r ffurflen | Application for permission to change a child's surname (Form A55)Notes on completing the form",a055-notes-bil.pdf,application/pdf,100765,12/2005,26,3,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,979
+980,A56 Nodiadau | A56 Notes,"Cais am ganiatâd i symud plentyn o'r Deyrnas Unedig (Ffurflen A56) Nodiadau ar lenwi'r ffurflen | Application for permission to remove a child from the United Kingdom (Form A56) Notes on completing the form",a056-notes-bil.pdf,application/pdf,103114,12/2005,26,3,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,980
+981,A62 Nodiadau | A62 Notes,"Cais am gyfarwyddyd dan adran 88(1) Deddf Mabwysiadu a Phlant 2002 (Ffurflen A62)Nodiadau ar lenwi'r ffurflen | Application for a direction under section 88(1) of the Adoption and Children Act 2002 (Form A62) Notes on completing the form",a062-notes-bil.pdf,application/pdf,98772,12/2005,26,3,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,981
+983,FP1B,"Cais dan Ran 19 Trefniadaeth Teulu 2010. Nodiadau i atebwyr | Application under Part 19 of the Family Procedure 2010. Notes for respondent",fp001b-bil.pdf,application/pdf,169261,04/2011,26,3,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,983
+986,A63 Nodiadau | A63 Notes,"Cais am orchymyn i ddirymu mabwysiad dan y Cytundeb neu orchymyn mabwysiadu dan y Cytundeb neu i fabwysiad tramor neu benderfyniad dan adran 91 beidio â bod yn ddilys (Ffurflen A63) | Application for an order to annul a Convention adoption or Convention adoption order or for an overseas adoption or determination under section 91 to cease to be valid (Form A63)",a063-notes-bil.pdf,application/pdf,106172,12/2005,26,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,986
+989,N8A,"Hawliad Cyflafareddu - nodiadau i'r hawlydd | Arbitration claim - Notes for the claimant",n008a-bil.pdf,application/pdf,143970,04/2006,26,3,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,989
+990,Form 201,"Routes of appeal",form-201-eng.pdf,application/pdf,248013,04/2013,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,990
+991,Form 202,"How to appeal to the Court of Appeal",form202-eng.pdf,application/pdf,181480,10/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,991
+993,Form 204,"How to prepare an appeal bundle for the Court of Appeal",form204-eng.pdf,application/pdf,210589,02/2017,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,993
+994,Form 205,"Sources of help for unrepresented appellants",form205-eng-20160115.pdf,application/pdf,335909,12/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,994
+996,Form 56A,"Court of Appeal Mediation Scheme",form-056a-eng.pdf,application/pdf,38013,10/2012,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,996
+997,Form 56B,"Court of Appeal mediation scheme - Form 56A and 56B",form-056b-eng.pdf,application/pdf,38768,10/2012,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,997
+999,A21,"Intercountry adoption and the 1993 Hague Convention",a21-eng.pdf,application/pdf,406191,11/2016,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,999
+1000,N86,"Interim Charging Order (CPR Part 73)",n086-eng.pdf,application/pdf,130309,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1000
+1001,Form 206,"Applying for permission to appeal to the Court of Appeal",form206-eng.pdf,application/pdf,160092,10/2016,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,1001
+1002,Form 207,"Time limits for appealing to the Court of Appeal",form207-eng.pdf,application/pdf,156394,10/2016,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,1002
+1003,A50 Nodiadau | A50 Notes,"Cais am Orchymyn Lleoli (Ffurflen A50) Nodiadau ar lenwi'r ffurflen | Application for a Placement Order (Form A50) Notes on completing the form",a050-notes-bil.pdf,application/pdf,112182,12/2005,26,3,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,1003
+1004,N87,"Final Charging Order (CPR Part 73)",n087-eng.pdf,application/pdf,126999,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1004
+1005,A53 Nodiadau | A53 Notes,"Cais am orchymyn cyswllt dan adran 26 Deddf Mabwysiadu a Phlant 2002 (Ffurflen A53). Nodiadau ar lenwi'r ffurflen | Application for a contact order under section 26 of the Adoption and Children Act 2002 (Form A53). Notes on completing the form",a053-notes-bil.pdf,application/pdf,203053,04/2011,26,3,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,1005
+1006,A54 Nodiadau | A54 Notes,"Cais i amrywio neu ddiddymu gorchymyn cyswllt a wnaed dan adran 26 Deddf Mabwysiadu a Phlant 2002 (Ffurflen A54) Nodiadau ar lenwi'r  ffurflen | Application for variation or revocation of a contact order made under section 26 of the Adoption and Children Act 2002 (Form A54) Notes on completing the form",a054-notes-bil.pdf,application/pdf,106074,12/2005,26,3,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,1006
+1007,D50,"Notice of application under section 17 of the Married Women's Property Act 1882 section 66 of the Civil Partnership Act 2004",d050-eng.pdf,application/pdf,83053,11/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1007
+1008,D50A,"Notice of proceedings acknowledgement of service under s17 of the Married Women's Property Act 1882 s66 of the Civil Partnership Act 2004",d050a-eng.pdf,application/pdf,355812,04/2012,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1008
+1009,A59 Nodiadau | A59 Notes,"Cais am orchymyn mabwysiadu dan y Cytundeb (Ffur en A59). Nodiadau ar lenwi'r ffur en | Application for a Convention adoption order (Form A59). Notes on completing the form",a59-notes-bil.pdf,application/pdf,178525,11/2016,26,3,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,1009
+1011,ADM1,"Claim Form (Admiralty claim in rem)",adm001-eng.pdf,application/pdf,36716,02/2013,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1011
+1012,ADM10,"Standard Directions to the Admiralty Marshal",adm010-eng.pdf,application/pdf,76524,03/2002,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1012
+1013,ADM11,"Request for caution against Release",adm011-eng.pdf,application/pdf,67284,03/2002,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1013
+1014,ADM12,"Request and undertaking for release",adm012-eng.pdf,application/pdf,78074,03/2002,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1014
+1015,ADM12A,"Request for withdrawal of caution against Release",adm012(a)-eng.pdf,application/pdf,60608,03/2002,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1015
+1016,ADM13,"Application for judgment in default of filing an acknowledgment of service and/or defence or collision statement of case",adm013-eng.pdf,application/pdf,79248,03/2002,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1016
+1017,ADM14,"Order for sale of a ship",adm014-eng.pdf,application/pdf,82960,03/2002,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1017
+1018,ADM15,"Claim Form (Admiralty limitation claim)",adm015-eng.pdf,application/pdf,44583,02/2013,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1018
+1019,ADM16,"Notice of admission of right of claimant to limit liability",adm016-eng.pdf,application/pdf,71445,03/2002,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1019
+1020,ADM16A,"Defence to admiralty limitation claim",adm016(a)-eng.pdf,application/pdf,77596,03/2002,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1020
+1021,AJ26,"Courts Charter - Magistrates' Courts",aj26-eng.pdf,application/pdf,214668,11/2006,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,1021
+1022,ADM17,"Application for restricted limitation decree",adm017-eng.pdf,application/pdf,76738,03/2002,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1022
+1023,ADM17A,"Application for general limitation decree",adm017(a)-eng.pdf,application/pdf,73674,11/2008,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1023
+1024,ADM18,"Restricted limitation decree",adm018-eng.pdf,application/pdf,83174,03/2002,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1024
+1025,ADM19,"General limitation decree",adm019-eng.pdf,application/pdf,85293,03/2002,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1025
+1026,ADM1A,"Claim Form (Admiralty claim)",adm001(a)-eng.pdf,application/pdf,35796,02/2013,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1026
+1027,ADM2,"Acknowledgment of Service (Admiralty claim)",adm002-eng.pdf,application/pdf,346285,04/2006,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1027
+1028,ADM20,"Defendant's claim in a limitation claim",adm020-eng.pdf,application/pdf,76562,03/2002,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1028
+1029,5222A,"Supporting you through Jury Service",5222a-eng.pdf,application/pdf,153457,11/2016,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,1029
+1030,ADM3,"Collision statement of case",adm003-eng.pdf,application/pdf,78678,03/2002,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1030
+1031,ADM4,"Application and undertaking for arrest and custody",adm004-eng.pdf,application/pdf,79032,03/2002,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1031
+1032,ADM5,"Declaration in support of applicationfor warrant of arrest",adm005-eng.pdf,application/pdf,89824,03/2002,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1032
+1033,ADM6,"Notice to Consular Officer of intention to apply for warrant of arrest",adm006-eng.pdf,application/pdf,83975,03/2002,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1033
+1034,ADM7,"Request for caution against arrest",adm007-eng.pdf,application/pdf,74960,11/2008,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1034
+1035,ADM9,"Warrant of Arrest",adm009-eng.pdf,application/pdf,21958,11/2008,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1035
+1037,EX660 Notes,"Communicating with the Home Office in Family Proceedings",ex660-notes-eng.pdf,application/pdf,126215,10/2014,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,1037
+1038,FL701,"Forced Marriage Protection Orders - How can they protect me?",fl701-eng.pdf,application/pdf,168241,07/2015,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,1038
+1040,EX711,"A yw'r cyfryngau'n cael bod yn bresennol yn fy achos llys?",ex711-cym.pdf,application/pdf,194439,04/2014,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,1040
+1041,EX715,"Datrys anghydfodau teuluol heb fynd i'r llys",ex715-cym.pdf,application/pdf,512915,08/2009,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,1041
+1042,Control Order,"Claim form (under Section 11)",co-claim-eng.doc,application/msword,67072,05/2005,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1042
+1044,N344,"Request for Warrant of Committal (Judgment summons)",n344-eng.pdf,application/pdf,154038,03/2002,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1044
+1045,CB5,"Applications Related to Enforcement of a Child Arrangements Order",cb005-eng.pdf,application/pdf,218717,11/2014,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,1045
+1046,CB6,"A guide to explain some words and expressions used in private children cases",cb006-eng.pdf,application/pdf,595648,07/2015,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,1046
+1048,EX725,"Making a Cross Border Claim in the EU",ex725-eng.pdf,application/pdf,196658,04/2014,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,1048
+1060,N500,"Claim form (Directors disqualification proceedings)",n500-eng.pdf,application/pdf,115772,05/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1060
+1063,N501,"Claim form (Directors disqualification proceedings Section 8A application)",n501-eng.pdf,application/pdf,195669,06/2005,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1063
+1066,N502,"Acknowledgment of service (Part 8)",n502-eng.pdf,application/pdf,201611,06/2005,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1066
+1067,N503,"Acknowledgment of service (Part 8) Section 8A applications",n503-eng.pdf,application/pdf,182465,06/2005,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1067
+1068,N504,"Pre-trial checklist (Directors disqualification)",n504-eng.pdf,application/pdf,408552,06/2005,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1068
+1069,N164,"Appellant's notice (Small claims track only)",n164-eng.pdf,application/pdf,250413,06/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1069
+1070,N219,"Application for European Enforcement Order Certificate (Judgment by agreement/admission/settlement)",n219-eng.pdf,application/pdf,317289,10/2005,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1070
+1071,N219A,"Application for European Enforcement Certificate (Judgment in default of a defence or objection)",n219a-eng.pdf,application/pdf,382676,10/2005,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1071
+1072,N164,"Hysbysiad apelydd (Trac Hawliadau Bychain yn unig) | Appellant's notice (Small Claims Track only)",n164-bil.pdf,application/pdf,138048,06/2016,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1072
+1073,EX107 Info,"Guidance, transcription panel list and prices",ex107-info-eng.pdf,application/pdf,253192,03/2017,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,1073
+1074,A50,"Application for a placement order (Section 22 Adoption and Children Act 2002)",a050-eng.pdf,application/pdf,616096,11/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1074
+1075,A51,"Application for variation of a placement order (Section 23 Adoption and Children Act 2002)",a051-eng.pdf,application/pdf,617447,11/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1075
+1076,A52,"Application for Revocation of a Placement Order - Section 24 Adoption and Children Act 2002",a052-eng.pdf,application/pdf,323721,11/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1076
+1077,A53,"Application for a Contact Order (Section 26 Adoption and Children Act 2002 or an order for contact or prohibiting contact under section 51A of the Adoption and Children Act 2002)",a53-eng.pdf,application/pdf,612020,11/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1077
+1078,A54,"Application for variation or revocation of a Contact Order (Section 27(1)(b) or Section 51B(1)(c) Adoption and Children Act 2002)",a54-eng.pdf,application/pdf,317093,11/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1078
+1079,A55,"Application for permission to change a child's surname (Section 28 Adoption and Children Act 2002)",a55-eng.pdf,application/pdf,340449,11/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1079
+1080,A56,"Application for permission to remove a child from the United Kingdom (Section 28 Adoption and Children Act 2002)",a56-eng.pdf,application/pdf,346384,11/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1080
+1081,A57,"Application for a Recovery Order (Section 41 Adoption and Children Act 2002)",a57-eng.pdf,application/pdf,340420,11/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1081
+1082,A58,"Application for an Adoption Order (Section 46 Adoption and Children Act 2002)",a58-eng.pdf,application/pdf,680284,11/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1082
+1083,A59,"Application for a Convention Adoption Order (Section 46 Adoption and Children Act 2002)",a59-eng.pdf,application/pdf,387210,11/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1083
+1084,A60,"Application for an Adoption Order (excluding a Convention adoption order) where the child is habitually resident outside the British islands and is brought into the United Kingdom for the purposes of adoption (Section 46 Adoption and Children Act 2002)",a60-eng.pdf,application/pdf,674771,11/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1084
+1085,A61,"Cais am orchymyn cyfrifoldeb rhiant cyn mabwysiadu dramor (Adran 84 Deddf Mabwysiadu a Phlant 2002) | Application for an order for parental responsibility prior to adoption abroad (Section 84 Adoption and Children Act 2002)",a61-bil.pdf,application/pdf,456686,11/2016,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1085
+1086,A62,"Application for a direction under section 88(1) of the Adoption and Children Act 2002",a062-eng.pdf,application/pdf,623727,11/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1086
+1087,A63,"Application for an order to annul a Convention adoption or Convention adoption order or for an overseas adoption or determination under section 91 to cease to be valid. Section 89 Adoption and Children Act 2002",a063-eng.pdf,application/pdf,354413,11/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1087
+1088,A64,"Application to receive information from court records Section 60(4) Adoption and Children Act 2002",a064-eng.pdf,application/pdf,143522,11/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1088
+1089,A65,"Confidential information",a065-eng.pdf,application/pdf,738978,12/2005,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1089
+1090,FP1,"Application under Part 19 of the Family Procedure Rules 2010",fp001-eng.pdf,application/pdf,298876,11/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1090
+1091,FP2,"Application notice. Part 18 of the Family Procedure Rules 2010",fp002-eng.pdf,application/pdf,316881,11/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1091
+1092,FP3,"Application for injunction (General form)",fp003-eng.pdf,application/pdf,288513,11/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1092
+1093,FP5,"Acknowledgment of service (Application under Part 19 of the Family Procedure Rules 2010)",fp005-eng.pdf,application/pdf,321284,04/2011,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1093
+1094,FP6,"Certificate of service",fp006-eng.pdf,application/pdf,417532,04/2011,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1094
+1095,FP8,"Notice of change of solicitor",fp008-eng.pdf,application/pdf,442275,04/2011,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1095
+1096,FP9,"Certificate of suitability of litigation friend",fp009-eng.pdf,application/pdf,319666,11/2008,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1096
+1097,FP25,"Witness summons",fp25-eng-2016.03.16.pdf,application/pdf,346094,03/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1097
+1098,C(PRA2),"Step-Parent Parental  Responsibility Agreement",c(pra002)-eng.pdf,application/pdf,351061,08/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1098
+1099,C13A,"Supplement for an Application for a Special Guardianship Order",c013a-eng.pdf,application/pdf,300528,04/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1099
+1105,D508,"Deiseb Diddymiad/Dissolution Petition",d508-cym.pdf,application/pdf,750088,08/2007,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,1105
+1106,D508 Nodiadau | D508 notes,"Deiseb Diddymiad - Nodiadau Canllaw/Dissolution Petition Notes for Guidance",d508-notes-cym.pdf,application/pdf,192104,08/2007,25,4,false,1,2017-03-17,W_GetForm.do?court_forms_id=,1106
+1112,D13B,"Statement in support to dispense with service of the divorce dissolution nullity (judicial) separation petition on the Respondent",d013b-eng.pdf,application/pdf,363991,04/2012,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1112
+1114,D36,"Notice of application for decree nisi to be made absolute or conditional order to be made final",d036-eng.pdf,application/pdf,109429,11/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1114
+1115,D8,"Divorce/dissolution/(judicial) separation petition",d8-eng.pdf,application/pdf,507537,06/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1115
+1116,D81,"Statement of information for a consent order in relation to a financial remedy",d081-eng.pdf,application/pdf,427959,04/2012,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1116
+1117,FL401,"Application for: a non-molestation order/an occupation order",fl401-eng-20160213.pdf,application/pdf,286566,01/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1117
+1120,Form F,"Notice of allegation in proceedings for a financial remedy",form-f-eng.pdf,application/pdf,303658,04/2011,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1120
+1121,Form i,"Notice of Request for Periodical Payments Order at Same Rate as Order for Maintenance Pending Outcome of Proceedings",form-i-eng.pdf,application/pdf,64023,04/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1121
+1122,Form P,"Pension Inquiry Form Information needed when a Pension Sharing Order or Pension Attachment Order may be made",form-p-eng.pdf,application/pdf,402244,04/2011,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1122
+1123,Form P1,"Pension sharing annex under [section 24B of the Matrimonial Causes Act 1973] [paragraph 15 of Schedule 5 to the Civil Partnership Act 2004]",p01-eng.pdf,application/pdf,390093,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1123
+1124,Form P2,"Pension Attachment Annex Under [section 25B or 25C of the Matrimonial Causes Act 1973] [paragraph 25 or 26 of Schedule 5 to the Civil Partnership Act 2004]",p02-eng.pdf,application/pdf,150509,04/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1124
+1125,Form E,"Financial Statement: For a Financial Order (Matrimonial Causes Act 1973/Civil Partnership Act 2004)/for Financial Relief After an Overseas Divorce Etc (Part 3 of the Matrimonial and Family Proceedings Act 1984/Schedule 7 to the Civil Partnership Act 2004)",form-e-eng-20160121.pdf,application/pdf,821231,01/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1125
+1128,D650,"Notice of application to vary or set aside a financial order (Form E calculator error)",d650-eng-20160121.pdf,application/pdf,217204,01/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1128
+1129,D651,"Notice of application to vary or set aside a financial remedy (Form E1 calculator error)",d651-eng-2016.02.24.pdf,application/pdf,205008,02/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1129
+1131,D62,"Request for issue of judgment summons",d062-eng.pdf,application/pdf,330994,11/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1131
+1134,A51,"Cais i amrywio gorchymyn lleoli. Adran 23 Deddf Mabwysiadu a Phlant 2002 | Application for variation of a placement order Section 23 Adoption and Children Act 2002",a051-bil.pdf,application/pdf,278091,04/2011,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1134
+1135,A52,"Cais am ddiddymu gorchymyn lleoli Adran 24 Deddf Mabwysiadu a Phlant 2002 | Application for revocation of a placement order Section 24 Adoption and Children Act 2002",a052-bil.pdf,application/pdf,260286,04/2011,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1135
+1136,A53,"Cais am orchymyn cyswllt Adran 26 Deddf Mabwysiadu a Phlant 2002 | Application for a contact order Section 26 Adoption and Children Act 2002",a053-bil.pdf,application/pdf,284280,04/2011,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1136
+1137,A54,"Cais i amrywio neu ddiddymu gorchymyn cyswllt (Adran 27(1)(b) Deddf Mabwysiadu a Phlant 2002) | Application for variation or revocation of a contact order (Section 27(1)(b) Adoption and Children Act 2002)",a54-bil.pdf,application/pdf,311952,11/2016,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1137
+1138,A55,"Cais am ganiatad i newid cyfenw plentyn (Adran 28 Deddf Mabwysiadu a Phlant 2002) | Application for permission to change a child's surname (Section 28 Adoption and Children Act 2002)",a55-bil.pdf,application/pdf,269452,11/2016,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1138
+1139,A56,"Cais am ganiatad i symud plentyn o'r Deyrnas Unedig (Adran 28 Deddf Mabwysiadu a Phlant 2002) | Application for permission to remove a child from the United Kingdom (Section 28 Adoption and Children Act 2002)",a56-bil.pdf,application/pdf,237392,11/2016,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1139
+1140,A57,"Cais am orchymyn dychwelyd plentyn (Adran 41 Deddf Mabwysiadu a Phlant 2002) | Application for a recovery order (Section 41 Adoption and Children Act 2002)",a57-bil.pdf,application/pdf,259747,11/2016,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1140
+1141,A64,"Cais i dderbyn gwybodaeth o gofnodion y llys Adran 60(4) Deddf Mabwysiadu a Phlant 2002 | Application to receive information from court records Section 60(4) Adoption and Children Act 2002",a064-bil.pdf,application/pdf,157036,12/2005,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1141
+1142,A65,"Gwybodaeth gyfrinachol | Confidential information",a065-bil.pdf,application/pdf,177564,12/2005,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1142
+1144,D580(F),"Affidafid gan ddeisebydd i gefnogi deiseb i ddiddymu dan Adran 12(g) | Affidavit by petitioner in support of petition for annulment under Section 12(g)",d580f-bil.pdf,application/pdf,132037,12/2005,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1144
+1145,Ffurflen A | Form A,"Hysbysiad o gais [o fwriad i fwrw ymlaen a chais] am orchymyn ariannol | Notice of [intention to proceed with] an application for a financial order",form-a-bil.pdf,application/pdf,264621,06/2016,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1145
+1146,Ffurflen E | Form E,"Datganiad ariannol | Financial statement",form-e-bil.pdf,application/pdf,349224,04/2012,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1146
+1147,N149,"Holiadur Dyrannu (Trac hawliadau bychain) | Allocation questionnaire (Small claims track)",n149-bil.pdf,application/pdf,316594,03/2012,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1147
+1150,Form H1,"Statement of costs (financial remedy)",form-h1-eng.pdf,application/pdf,190701,04/2011,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1150
+1153,N443,"Cais am dystysgrif boddhad/canslo | Application for a Certificate of Satisfaction or Cancellation",n443-bil.pdf,application/pdf,116033,04/2006,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1153
+1154,ADM2,"Cydnabyddiad Cyflwyno (hawliad Morlys)",adm002-cym.pdf,application/pdf,168634,04/2006,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,1154
+1155,N213(CC),"Cydnabyddiad Cyflwyno (Hawliad Rhan 20) | Acknowledgment of Service (Part 20 claim)",n213(cc)-bil.pdf,application/pdf,198964,04/2006,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1155
+1156,N441,"Hysbysiad o Gais am Dystysgrif Bodlonrwydd neu Ddileu | Notification of Request for Certificate of Satisfaction or Cancellation",n441-bil.pdf,application/pdf,216354,04/2006,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1156
+1157,N443,"Application for a Certificate of Satisfaction or Cancellation",n443-eng.pdf,application/pdf,388670,04/2006,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1157
+1158,Ffurflen H1 | Form H1,"Datganiad costau (rhwymedi ariannol) | Statement of costs (financial remedy)",form-h1-bil.pdf,application/pdf,218711,04/2011,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1158
+1159,Ffurflen H | Form H,"Amcangyfrif o gostau (rhwymedi ariannol) | Estimate of costs (financial remedy)",form-h-bil.pdf,application/pdf,193945,04/2011,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1159
+1160,N9(CC),"Cydnabyddiad Cyflwyno | Acknowledgment of Service",n009(cc)-bil.pdf,application/pdf,226760,04/2006,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1160
+1161,N228,"Hysbysiad o Addefiad - Dychwelyd Nwyddau (hurbrynu neu werthiant amodol)",n228-cym.pdf,application/pdf,227621,04/2006,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,1161
+1162,N255(CC),"Tystysgrif costau diffygdalu",n255(cc)-cym.pdf,application/pdf,168624,04/2006,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,1162
+1163,N255(HC),"Tystysgrif costau diffygdalu",n255(hc)-cym.pdf,application/pdf,168550,04/2006,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,1163
+1164,N256(CC),"Tystysgrif costau terfynol",n256(cc)-cym.pdf,application/pdf,245579,04/2006,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,1164
+1166,Form 4,"Complaint against a certificated bailiff (Distress for Rent Rules 1988 Rule 8)",form-004-eng.pdf,application/pdf,218624,05/2012,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1166
+1187,Costs,"Bill of  Costs for Taxation by Registrar - Court of Appeal (Criminal Division)",co-acd-costs-eng.doc,application/msword,203776,05/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1187
+1272,A50,"Cais am orchymyn lleoli. Adran 22 Deddf Mabwysiadu a Phlant 2002 | Application for a placement order Section 22 Adoption and Children Act 2002",a050-bil.pdf,application/pdf,309282,04/2011,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1272
+1273,C(PRA2),"Cytundeb Cyfrifoldeb Rhieni i Lys-riant | Step-Parent Parental Responsibility Agreement",c(pra002)-bil.pdf,application/pdf,134391,08/2014,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1273
+1274,A59,"Cais am orchymyn mabwysiadu dan y Cytundeb (Adran 46 Deddf Mabwysiadu a Phlant 2002) | Application for a Convention adoption order (Section 46 Adoption and Children Act 2002)",a59-bil.pdf,application/pdf,439346,11/2016,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1274
+1275,A62,"Cais am gyfarwyddyd dan adran 88(1) Deddf Mabwysiadu a Phlant 2002 | Application for a direction under section 88(1) of the Adoption and Children Act 2002",a062-bil.pdf,application/pdf,377678,04/2011,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1275
+1277,N225A,"Notice of part admission (Specified amount)",n225a-eng.pdf,application/pdf,404423,04/2013,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1277
+1278,EX660,"Court request for information to the Home Office",ex660-eng.pdf,application/pdf,329553,05/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1278
+1279,EX105,"Request that the costs of transcripts be paid at public expense",ex105-eng.pdf,application/pdf,391870,01/2007,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1279
+1310,CH1,"Draft Chancery case management directions (amended February 2017)",ch1-eng.doc,application/msword,79360,02/2017,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1310
+1320,CH2,"Additional draft case management directions (amended February 2017)",ch2-eng.doc,application/msword,81408,02/2017,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1320
+1330,CH3,"Case and costs management conference",ch3-eng.doc,application/msword,37888,02/2017,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1330
+1340,CH4,"Unless order",ch04-eng-2016.04.01.doc,application/msword,36352,02/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1340
+1350,CH5,"Order for service out of the jurisdiction",ch5-eng.doc,application/msword,51200,05/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1350
+1360,CH6,"Group litigation order",ch06-eng-2016.04.01.doc,application/msword,79872,02/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1360
+1370,CH7,"Notice of claim to non-parties",ch07-eng-2016.04.01.doc,application/msword,36352,02/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1370
+1380,CH8,"Notice of judgment or order to non-parties",ch08-eng-2016.04.01.doc,application/msword,38400,02/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1380
+1390,CH9,"[Witness Statement][Affidavit] in support of application for appointment by the Court of new litigation friend of child claimant (see CPR rules 21.7 and 8, rule 21 4(3) and PD21 paragraph 3.3)",ch09-eng-2016.04.01.doc,application/msword,25600,02/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1390
+1400,CH10,"Order for an injunction (intended action)",ch10-eng-2016.04.01.doc,application/msword,36864,02/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1400
+1410,CH11,"Order for interim injunction",ch11-eng-2016.04.01.doc,application/msword,53248,02/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1410
+1420,CH12,"Stay for alternative dispute resolution",ch12-eng-2016.04.01.doc,application/msword,30720,02/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1420
+1430,CH13,"Executors'/Administrators' account (CPR 64.2(b) and 64 PD paragraph 3)",ch13-eng-2016.04.01.doc,application/msword,53248,02/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1430
+1440,CH14,"Order stating the result of proceedings on the usual accounts and inquiries in an administration claim",ch14-eng-2016.04.01.doc,application/msword,46080,02/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1440
+1450,CH15,"Common form of order for sale",ch15-eng-2016.04.01.doc,application/msword,62976,02/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1450
+1460,CH16,"Order nominating person to execute sale",ch16-eng-2016.04.01.doc,application/msword,45056,02/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1460
+1470,CH17,"Order for account and inquiry",ch17-eng-2016.04.01.doc,application/msword,46592,02/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1470
+1480,CH18,"Order for partnership account and inquiry",ch18-eng-2016.04.01.doc,application/msword,44544,02/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1480
+1490,CH19,"Result of partnership account and inquiry",ch19-eng-2016.04.01.doc,application/msword,47104,02/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1490
+1500,CH20,"Result of account of money due",ch20-eng-2016.04.01.doc,application/msword,45056,02/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1500
+1501,D192,"Ynglyn a gorchmynion/dyfarniadau ymwahaniad (cyfreithiol)",d192-cym.pdf,application/pdf,205368,04/2014,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,1501
+1503,Lwfansau,"lwfansau rheithwyr",jury-allowances-cym.pdf,application/pdf,165760,05/2011,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,1503
+1510,CH21,"Order declaring that solicitor has ceased to act",ch21-eng-2016.04.01.doc,application/msword,36352,02/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1510
+1512,PA10,"Sut i gychwyn chwiliad sefydlog. Arweiniad i bobl sydd eisiau gwybod am ystad rhywun sydd wedi marw'n ddiweddar",pa010-cym.pdf,application/pdf,178126,02/2012,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,1512
+1516,UT1 Nodiadau,"Nodiadau i Geisyddion ac Apelyddion Ffurflen UT1 (Hawl Cymdeithasol)",ut001-notes-cym.pdf,application/pdf,100185,11/2008,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,1516
+1517,UT8 Taflen,"Apelio yn erbyn penderfyniad gan y Siambr Gofal Iechyd, Addysg a Gwasanaethau Cymdeithasol y Tribiwnlys Haen Gyntaf (Iechyd Meddwl) (Apelau o benderfyniadau'r Tribiwnlys Haen Gyntaf)",ut008-leaflet-cym.pdf,application/pdf,227330,07/2008,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,1517
+1518,UT9 Taflen,"Apelio yn erbyn penderfyniad gan y Siambr Gofal Iechyd, Addysg a Gwasanaethau Cymdeithasol y Tribiwnlys Haen Gyntaf (Anghenion Addysgol Arbennig Cymru) (Apelau o benderfyniadau'r Tribiwnlys Haen Gyntaf)",ut009-leaflet-cym.pdf,application/pdf,229508,06/2009,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,1518
+1519,UT1 Taflen,"Apelio yn erbyn penderfyniad gan y Siambr Hawl Cymdeithasol y Tribiwnlys Haen Gyntaf (Welsh) (Apelau o benderfyniadau'r Tribiwnlys Haen Gyntaf)",ut001-leaflet-cym.pdf,application/pdf,227992,07/2008,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,1519
+1520,CH22,"Mortgage: Suspended possession order",ch22-eng-2016.04.01.doc,application/msword,37376,02/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1520
+1521,UT1 Nodiadau,"Nodiadau i Geisyddion ac Apelyddion Ffurflen UT1 (Hawl Cymdeithasol)",ut001-notes-cym.doc,application/msword,64512,11/2008,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,1521
+1523,T118,"Gwybodaeth i ddioddefwyr",t118-cym.pdf,application/pdf,214619,04/2012,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,1523
+1524,T001,"Taflen esbonio - Canllaw cryno i ddefnyddwyr",t001-cym.pdf,application/pdf,276293,04/2012,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,1524
+1525,T002,"Cyfeiriadau - Ambell gwestiwn ac ateb",t002-cym.pdf,application/pdf,254084,04/2012,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,1525
+1527,T006,"Canllawiau ar gyfer llenwi Cais I'r Tribiwnlys Haen Gyntaf (Elusennau) am Ganiatad i Apelio I'r Uwch Dribiwnlys",t006-cym.pdf,application/pdf,236666,04/2012,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,1527
+1528,EX710,"A gaf i siarad am fy achos y tu allan I'r llys? - Arweiniad i ddefnyddwyr y llys teulu",ex710-cym.pdf,application/pdf,151590,04/2012,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,1528
+1530,CH23,"Mortgage: Possession order",ch23-eng-2016.04.01.doc,application/msword,35840,02/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1530
+1540,CH24,"Order appointing administrator pending determination of probate claim (CPR rule 57 Part 1 and 57PD paragraph 8)",ch24-eng-2016.04.01.doc,application/msword,44032,02/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1540
+1547,Mynd i Lys Ynadon,"Mynd i Lys Ynadon - Gwybodaeth ar gyfer pobl gydag anableddau dysgu",going-to-magistrates-court-cym.pdf,application/pdf,443628,02/2013,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,1547
+1550,CH25,"Security of receiver or of administrator pending determination of a probate claim (CPR PD57 paragraph 8)",ch25-eng-2016.04.01.doc,application/msword,43520,02/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1550
+1560,CH26,"Order in probate claim involving compromise (CPR rule 57 Part 1 and 57PD paragraph 6.1)",ch26-eng-2016.04.01.doc,application/msword,48640,02/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1560
+1570,CH27,"Handing out testamentary documents for examination",ch27-eng-2016.04.01.doc,application/msword,48128,02/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1570
+1580,CH28,"Revocation/refusal of revocation of grant of probate",ch28-eng-2016.04.01.doc,application/msword,45568,02/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1580
+1590,CH29,"Order pronouncing for some words, against others",ch29-eng-2016.04.01.doc,application/msword,46080,02/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1590
+1600,CH30,"Pronouncing for completed copy/torn up will",ch30-eng.doc,application/msword,53000,02/2017,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1600
+1610,CH31,"Tomlin order - 1975 Act",ch31-eng-2016.04.01.doc,application/msword,45568,02/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1610
+1620,CH32,"Order for approval of compromise",ch32-eng-2016.04.01.doc,application/msword,46592,02/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1620
+1630,CH33,"Order granting permission to make application under the Inheritance (provision for family and dependants) Act 1975 after time expired",ch33-eng-2016.04.01.doc,application/msword,45568,02/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1630
+1640,CH34,"Order for claimant to be defendant: Inheritance (provision for family and dependants) Act 1975",ch34-eng-2016.04.01.doc,application/msword,43520,02/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1640
+1650,CH35,"Orders for provision under the Inheritance (provision for family and dependants) Act 1975",ch35-eng-2016.04.01.doc,application/msword,55296,02/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1650
+1660,CH36,"Enforcing charging order (single defendant)",ch36-eng-2016.04.01.doc,application/msword,38912,02/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1660
+1670,CH37,"Enforcing charging order (multiple defendants)",ch37-eng-2016.04.01.doc,application/msword,40960,02/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1670
+1680,CH38,"Order for distribution of a Lloyd's Estate",ch38-eng-2016.04.01.doc,application/msword,27136,02/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1680
+1690,CH39,"Lloyd's Estate form of witness statement",ch39-eng-2016.04.01.doc,application/msword,31232,02/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1690
+1700,CH40,"Costs Management Order (For use where budgets have not been wholly agreed)",ch40-eng.doc,application/msword,37888,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1700
+1702,CH41,"Order removing personal representative/appointing substitute",ch41-eng.doc,application/msword,54784,03/2017,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1702
+1704,PF7A,"Request for service of document abroad through foreign government, foreign judicial authority or British consular authority (rule 6.43)",pf007a-eng.doc,application/msword,34816,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1704
+1706,CH42,"Presumption of Death Act 2013",ch42-eng.doc,application/msword,45568,01/2017,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1706
+1708,PF7B,"Request for service of document on a State (rule 6.44) (to be filed in the Central Office of the Royal Courts of Justice)",pf007b-eng.doc,application/msword,35328,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1708
+1710,CH43,"Variation of trusts: confidentiality order",ch43-eng.doc,application/msword,26112,02/2017,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1710
+1712,PF10,"Anonymity and prohibition of publication order",pf010-eng.doc,application/msword,37888,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1712
+1716,PF20A,"Application for permission to issue an additional claim under rules 20.4(2)(b), 20.5(1) or 20.7(3)(b)",pf020a-eng.doc,application/msword,28672,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1716
+1720,PF20B,"Application for directions in an additional claim",pf020b-eng.doc,application/msword,26624,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1720
+1724,PF52A,"Shortened PF52 in the Queen's Bench Division for multi-track case and costs management directions in Mesothelioma and Asbestosis claims",pf052a-eng.doc,application/msword,45056,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1724
+1728,PF71,"PF 71 Evidence in support of application for relief from sanctions (CPR 3.8 and 3.9)",pf071-eng.doc,application/msword,27648,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1728
+1732,PF84C,"Application for entry of judgment on failure to comply with an order made under rule 3.5(1) (rule 3.5(5))",pf084c-eng.doc,application/msword,24576,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1732
+1736,PF84D,"Judgment on application arising from a failure to comply with an order made under rule 3.5(1) (rule 3.5(1) and (5))",pf084d-eng.doc,application/msword,28160,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1736
+1740,PF85A,"Application for order arising on failure to comply with a condition imposed under rule 3.1(3)",pf085a-eng.doc,application/msword,24576,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1740
+1744,PF86,"Request for issue of Writ of Control (rule 83.9(3))",pf086-eng.doc,application/msword,27648,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1744
+1748,PF88,"Request for issue of Writ of Possession (rule 83.9(3) and rule 83.13)",pf088-eng.doc,application/msword,29696,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1748
+1752,PF89,"Request for issue of Writ of Possession and Writ of Control combined (rule 83.9(3) and rule 83.13(9))",pf089-eng.doc,application/msword,28160,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1752
+1756,PF90A,"Request for issue of a Writ of Specific Delivery where judgment or order does not give the alternative of paying the assessed value of the goods (rules 83.9(3) and 83.14(1))",pf090a-eng.doc,application/msword,27648,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1756
+1760,PF90B,"Request for issue of a Writ of Delivery where judgment or order gives the alternative of paying the assessed value of the goods (rules 83.9(3) and 83.14(2)(a))",pf090b-eng.doc,application/msword,27648,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1760
+1764,PF90C,"Request for issue of a Writ of Specific Delivery where order made under rule 83.14(2)(b) (rules 83.9(3) and 83.14(2)(b))",pf090c-eng.doc,application/msword,27648,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1764
+1766,PF92,"Order for permission to issue a writ of possession in the High Court to enforce a Judgment or Order for giving of possession of land in proceedings in the County Court (other than a claim against trespassers under Part 55)(Rule 83.13(2) and (8))",pf092-eng.doc,application/msword,30208,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1766
+1768,PF154,"Order for permission to register a foreign judgment under [s.9 of the Administration of Justice Act 1920] [s.2 of the Foreign Judgments (Reciprocal Enforcement) Act 1933] [s.4 of the Civil Jurisdiction and Judgments Act 1982] [EU Regulation 1215/2012] (rule 74.3 and 4)",pf154-eng.doc,application/msword,35328,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1768
+1772,PF156,"Evidence in support of application for registration of a community judgment (rules 74.19 and 74.21)",pf156-eng.doc,application/msword,41472,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1772
+1776,PF157,"Order for registration of a community judgment to be served on every person against whom the judgment is given (rule 74.22)",pf157-eng.doc,application/msword,42496,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1776
+1780,PF159A,"Evidence in support of application for registration for enforcement in England and Wales of a foreign judgment under the Administration of Justice Act 1920 (CPR 74.3 and 74.4 and Practice Direction 74A paragraph 4.4 and paragraph 5)",pf159a-eng.doc,application/msword,45568,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1780
+1784,PF159B,"Evidence in support of application for registration for enforcement in England and Wales of a foreign judgment under the Foreign Judgments (Reciprocal Enforcement) Act 1933 (CPR 74.3 and 74.4 and Practice Direction 74A paragraph 4.4 and paragraph 5)",pf159b-eng.doc,application/msword,47104,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1784
+1788,PF159C,"Evidence in support of application for registration for enforcement in England and Wales of a foreign judgment under section 4 of the Civil Jurisdiction and Judgments Act 1982 (CPR 74.3 and 74.4 and Practice Direction 74A paragraph 4.4)",pf159c-eng.doc,application/msword,46080,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1788
+1792,PF159D,"Evidence in support of application for registration for enforcement in England and Wales of a foreign judgment under the Lugano Convention (CPR 74.3 and 74.4 and Practice Direction 74A paragraphs 4 and 6A)",pf159d-eng.doc,application/msword,44544,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1792
+1796,PF159E,"Evidence in support of application for registration for enforcement in England and Wales of a foreign judgment under section 4B of the Civil Jurisdiction and Judgments Act 1982 (registration and enforcement of Judgments under the 2005 Hague Convention) (CPR 74.3(1) and CPR 74.4(5A))",pf159e-eng.doc,application/msword,51712,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1796
+1800,PF160,"Order for registration for enforcement in England and Wales of a foreign judgment under the Administration of Justice Act 1920, the Foreign Judgments (Reciprocal Enforcement) Act 1933, s.4 of the Civil Jurisdiction and Judgments Act 1982, s.4A of the Civil Jurisdiction and Judgments Act 1982 (the Lugano Convention) or s.4B of the Civil Jurisdiction and Judgments Act 1982 (the Hague Convention) (CPR 74.6)",pf160-eng.doc,application/msword,46080,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1800
+1804,PF163,"PF 163 Evidence in support of application for certified copy of a judgment obtained in the High Court or in the County Court for enforcement in a foreign country  (CPR 74.12 and 74.13)",pf163-eng.doc,application/msword,50688,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1804
+1808,PF164A,"Evidence in support of application to the High Court for the registration of a certificate for the enforcement of money provisions of a judgment given in another part of the United Kingdom (rule 74.15)",pf164a-eng.doc,application/msword,48128,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1808
+1812,PF164B,"Evidence in support of application to the High Court for the registration for the enforcement of the non-money provisions of a judgment in another part of the United Kingdom (rule 74.16)",pf164b-eng.doc,application/msword,48640,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1812
+1816,PF165,"Evidence in support of application for registration in the High Court of a Judgment of a court in another part of the United Kingdom containing non-money provisions (rule 74.16)",pf165-eng.doc,application/msword,48640,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1816
+1820,PF168A,"Order of the court's own initiative to transfer claim from High Court to County Court (sections 40(1) and (2) County Courts Act 1984; High Court and County Court Jurisdiction Order 1991 (as amended); rule 30.3)",pf168a-eng.doc,application/msword,27648,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1820
+1824,PF180A,"Evidence on application to extend time for registration of a bill of sale or an affidavit of its renewal (Bills of Sales Act 1878, s.14; PD8A para 10A)",pf180a-eng.doc,application/msword,26624,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1824
+1828,PF180B,"Evidence on application to rectify an omission or misstatement in the registration or renewal of registration of a bill of sale (Bills of Sales Act 1878, s.14; PD 8A para 10A)",pf180b-eng.doc,application/msword,27136,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1828
+2186,A63,"Cais am orchymyn i ddirymu mabwysiad dan y Cytundeb neu orchymyn mabwysiadu dan y Cytundeb neu i fabwysiad tramor neu benderfyniad dan adran 91 beidio a bod yn ddilys Adran 89 Deddf Mabwysiadu a Phlant 2002 | Application for an order to annul a Convention adoption or Convention adoption order or for an overseas adoption or determination under section 91 to cease to be valid Section 89 Adoption and Children Act 2002",a063-bil.pdf,application/pdf,271637,04/2011,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2186
+2187,FP2,"Rhybudd o gais Rhan 18 Rheolau Trefniadaeth Teulu 2010 | Application notice Part 18 of the Family Procedure Rules 2010",fp002-bil.pdf,application/pdf,230631,04/2011,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2187
+2190,N162,"Rhybudd yr Atebydd | Respondent's notice",n162-bil.pdf,application/pdf,346256,04/2007,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2190
+2195,PF244,"Application Notice (Part 23) in the High Court of Justice Queens Bench Division Administrative Court List",pf244-eng.doc,application/msword,49152,04/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2195
+2209,PLO1,"Application for a care order or supervision order: Supplementary form",plo001-eng.doc,application/msword,91648,04/2008,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2209
+2210,PLO2,"The local authority's case summary",plo002-eng.doc,application/msword,98816,04/2008,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2210
+2211,PLO3,"Draft case management order",plo003-eng.doc,application/msword,78336,04/2008,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2211
+2212,PLO4,"Allocation record and timetable for the child(ren)",plo004-eng.doc,application/msword,75776,04/2008,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2212
+2213,PLO5,"Directions and allocation on issue of proceedings",plo005-eng.pdf,application/pdf,35057,04/2008,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2213
+2214,PLO6,"Directions and allocation at first appointment",plo006-eng.pdf,application/pdf,76625,04/2008,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2214
+2216,C8,"Confidential contact details (Family Procedure Rules 2010 Rule 29.1)",c008-eng-20160203.pdf,application/pdf,300199,01/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2216
+2217,TE3,"Order for recovery of unpaid penalty charge (Parking)",te003-eng.pdf,application/pdf,334188,06/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2217
+2235,N510,"Service out of the Jurisdiction",n510-eng.pdf,application/pdf,90192,07/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2235
+2238,FL401A,"Application for a forced marriage protection order",fl401a-eng.pdf,application/pdf,366256,01/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2238
+2239,FL407A,"Application for a Warrant of Arrest Forced Marriage Protection Order",fl407a-eng.pdf,application/pdf,341192,11/2008,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2239
+2240,FL431,"Application to be joined as, or cease to be a party to an Forced Marriage Protection Proceedings",fl431-eng.pdf,application/pdf,316470,01/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2240
+2241,FL403A,"Application to vary, extend or discharge a forced marriage protection order",fl403a-eng.pdf,application/pdf,314382,01/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2241
+2242,FL430,"Application for leave to apply for a Forced Marriage Protection Order",fl430-eng.pdf,application/pdf,297354,11/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2242
+2250,5138,"Application for Extension of a Representation Order to More Than One Advocate, or to a QC Alone",5138-eng.doc,application/msword,271872,04/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2250
+2251,C78,"Application for attachment of a warning notice to a child arrangements order",c078-eng.pdf,application/pdf,661755,01/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2251
+2252,C79,"Application related to enforcement of a child arrangement order",c79-eng.pdf,application/pdf,707862,06/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2252
+2253,C100,"Application under the Children Act 1989 for a child arrangements, prohibited steps, specific issue section 8 order or to vary or discharge a section 8 order",c100-eng.pdf,application/pdf,402639,10/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2253
+2254,5050A,"Schedule of available or realisable assets",5050a-eng.doc,application/msword,113152,12/2008,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2254
+2256,5050A,"Schedule of available or realisable assets",5050a-eng.pdf,application/pdf,51690,12/ 2008,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2256
+2257,PA8A,"Caveat application form",pa8a-eng.pdf,application/pdf,29448,03/2017,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2257
+2258,PA7A,"Application to withdraw documents from safekeeping",pa007a-eng.pdf,application/pdf,33265,01/2009,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2258
+2262,LOC009,"I wish to apply to extend time for Registration of a Charge or to rectify a mis-statement or omission (in the Registered Particulars of a Charge or of a Memorandum of Satisfaction)",loc009-eng.pdf,application/pdf,242452,01/2013,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2262
+2264,N464,"Application for Directions as to Venue for Administration and Determination",n464-eng.pdf,application/pdf,406345,04/2009,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2264
+2266,N465,"Response to application as to venue for administration and determination",n465-eng.pdf,application/pdf,576844,04/2009,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2266
+2267,LOC010,"I wish to apply to rescind a winding up order. What do I do?",loc010-eng.pdf,application/pdf,167240,04/2011,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2267
+2270,LOC013,"I wish to apply for my cert of discharge",loc013-eng.doc,application/msword,78848,03/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2270
+2278,Mercantile Directions,"Specimen Order for Directions",standard-directions-eng.doc,application/msword,48128,12/2010,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2278
+2279,LOC040,"Royal Courts of Justice Family Video Conferencing Booking Request",loc040-eng.doc,application/msword,100864,02/2011,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2279
+2340,N322B,"Application for an order to allow enforcement of a decision or an ACAS settlement (Form COT3) that does not require permission to proceed",n322b-eng.pdf,application/pdf,341509,06/2009,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2340
+2341,EX328,"I have a Tribunal decision but the respondent has not paid. How do I enforce it?",ex328-eng.pdf,application/pdf,149131,04/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2341
+2342,EX80B,"Legal Aid/Legal Aid Agency assessment certificate in Family Proceedings where a fixed fee is payable",ex080b-eng.pdf,application/pdf,566525,04/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2342
+2343,C23,"C23 - Emergency Protection Order",c023-eng.pdf,application/pdf,209387,04/2009,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2343
+2344,EX329,"I Have an Advisory, Conciliation and Arbitration Service (ACAS) settlement or conditional settlement (Form COT3) but the respondent has not paid. How do I enforce it?",ex329-eng.pdf,application/pdf,154262,04/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2344
+2346,N461,"Ffurflen Hawlio Adolygiad Barnwrol | Judicial review claim form",n461-bil.pdf,application/pdf,146862,06/2016,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2346
+2348,N462,"Adolygiad Barnwrol Cydnabyddiad Cyflwyno | Judicial Review Acknowledgment of Service",n462-bil.pdf,application/pdf,180066,05/2009,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2348
+2349,N464,"Cais am gyfarwyddiadau ynghylch lleoliad ar gyfer gweinyddu a phenderfynu | Application for directions as to venue for administration and determination",n464-bil.pdf,application/pdf,215103,05/2009,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2349
+2350,N465,"Ymateb i gais am gyfarwyddiadau ynghylch lleoliad ar gyfer gweinyddu a phenderfynu | Response to application for directions as to venue for administration and determination",n465-bil.pdf,application/pdf,203423,05/2009,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2350
+2351,PF244,"Hysbysiad Cais (Rhan 23) yn rhestr llys Gweinyddol Adran Mainc y Frenhines yr Uchel lys Cyfiawnder | Application Notice (Part 23) in the High Court of Justice Queen's Bench Division Administrative Court list",pf244-bil.doc,application/msword,114176,05/2009,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2351
+2352,You have to go to court,"You have to go to court - What do you do?",go-to-court-eng.pdf,application/pdf,1120044,06/2009,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2352
+2354,You have to go to court,"You have to go to court - What do you do? (Bengali)",go-to-court-ben.pdf,application/pdf,1329521,06/2009,3,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2354
+2355,You have to go to court,"You have to go to court - What do you do? (Polish)",go-to-court-pol.pdf,application/pdf,1272180,06/2009,15,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2355
+2356,You have to go to court,"You have to go to court - What do you do? (Punjabi)",go-to-court-pun.pdf,application/pdf,1305301,06/2009,17,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2356
+2357,You have to go to court,"You have to go to court - What do you do? (Simplified Chinese)",go-to-court-zho.pdf,application/pdf,1403271,06/2009,4,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2357
+2358,You have to go to court,"You have to go to court - What do you do? (Somali)",go-to-court-som.pdf,application/pdf,1270835,06/2009,19,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2358
+2359,You have to go to court,"You have to go to court - What do you do? (Traditional Chinese)",go-to-court-chi.pdf,application/pdf,1392553,06/2009,5,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2359
+2360,You have to go to court,"You have to go to court - What do you do? (Gujarati)",go-to-court-guj.pdf,application/pdf,1286948,06/2009,12,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2360
+2361,You have to go to court,"You have to go to court - What do you do? (Arabic)",go-to-court-ara.pdf,application/pdf,1436080,06/2009,2,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2361
+2367,Mercantile Template 1,"Specimen Directions Template (Birmingham Mercantile Court)",specimen-birmingham-eng.doc,application/msword,992768,11/2011,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2367
+2368,Mercantile Template 2,"Specimen Directions Template (Bristol Mercantile Court)",specimen-bristol-eng.doc,application/msword,88576,11/2011,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2368
+2369,Mercantile Template 3,"Specimen Directions Template (Cardiff Mercantile Court)",specimen-cardiff-eng.doc,application/msword,1164800,11/2011,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2369
+2370,Mercantile Template 4,"Specimen Directions Template (Leeds Mercantile Court)",specimen-leeds-eng.doc,application/msword,1075712,11/2011,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2370
+2371,Mercantile Template 5,"Specimen Directions Template (London Mercantile Court)",specimen-london-eng.doc,application/msword,1480192,11/2011,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2371
+2372,Mercantile Template 6,"Specimen Directions Template (Manchester Mercantile Court)",specimen-manchester-eng.doc,application/msword,1353216,10/2012,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2372
+2375,N322B,"Cais am orchymyn i ganiatau gorfodi penderfyniad neu setliad ACAS (Ffurflen COT3) nad yw angen caniatâd i fynd rhagddo | Application for an order to allow enforcement of a decision or an ACAS settlement (Form COT3) that does not require permission to proceed",n322b-bil.pdf,application/pdf,601067,07/2009,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2375
+2376,EX328,"Rwyf wedi cael penderfyniad Tribiwnlys ond nid yw'r atebydd wedi talu - Sut maei ei orfodi?",ex328-cym.pdf,application/pdf,138709,04/2014,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,2376
+2377,EX329,"Mae gennyf setliad neu setliad amodol y Gwasanaeth Cynghori, Cymodi a Chyflafareddu (ACAS) (Ffurflen COT3) ond nid yw'r atebydd wedi talu - Sut alla'  i ei orfodi?",ex329-cym.pdf,application/pdf,103523,04/2014,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,2377
+2378,MC100,"Gwnewch yn siwr y gallwch dalu eich dirwy | Make sure you can pay your fine",mc100-bil.pdf,application/pdf,256650,12/2013,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2378
+2380,C(PRA3),"Parental Responsibility Agreement. Section 4ZA Children Act 1989 (Acquisition of parental responsibility by second female parent)",c(pra003)-eng.pdf,application/pdf,155791,08/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2380
+2382,AC001,"Request for an Adjournment (Birmingham)",ac001-birmingham-eng.pdf,application/pdf,13047,09/2008,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2382
+2383,AC001,"Request for an Adjournment (Cardiff)",ac001-cardiff-eng.pdf,application/pdf,12911,09/2008,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2383
+2384,AC001,"Request for an Adjournment (Leeds)",ac001-leeds-eng.pdf,application/pdf,13590,04/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2384
+2385,AC001,"Request for an Adjournment (London)",ac001-london-eng.pdf,application/pdf,12872,09/2008,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2385
+2386,AC001,"Request for an Adjournment (Manchester)",ac001-manchester-eng.pdf,application/pdf,13039,09/2008,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2386
+2387,N123,"Mortgage pre-action protocol checklist",n123-eng.pdf,application/pdf,97430,08/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2387
+2388,A58,"Cais am orchymyn mabwysiadu (Adran 46 Deddf Mabwysiadu a Phlant 2002) | Application for an adoption order (Section 46 Adoption and Children Act 2002)",a58-bil.pdf,application/pdf,498888,11/2016,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2388
+2389,C(PRA1),"Cytundeb Cyfrifoldeb Rhieni | Parental Responsibility Agreement",c(pra001)-bil.pdf,application/pdf,128242,08/2014,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2389
+2390,C(PRA3),"Cytundeb Cyfrifoldeb Rhieni | Parental Responsibility Agreement",c(pra003)-bil.pdf,application/pdf,133558,08/2014,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2390
+2392,PA4,"Cyfeiriadur Cofrestrfeydd Profiant a Chanolfannau Apwyntiadau | Directory of Probate Registries and Appointment Venues",pa004-bil.pdf,application/pdf,191428,09/2014,26,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2392
+2393,EX727,"I have an Employment or an Employment Appeal Tribunal award but the respondent has not paid. How do I enforce it?",ex727-eng.pdf,application/pdf,214182,08/2016,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2393
+2394,SCCO,"Information for Litigants Enquiring About the Assessment of Costs Awarded Between Parties",scco-eng.pdf,application/pdf,190135,06/2012,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2394
+2395,A64A,"A64A - Application to receive information from court records about a parental order",a064a-eng.pdf,application/pdf,56560,11/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2395
+2396,A101A,"Agreement to the making of a parental order in respect of my child. Section 54 of the Human Fertilisation and Embryology Act 2008",a101a-eng.doc,application/msword,32256,04/2011,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2396
+2397,C51,"Application for a Parental Order (Section 54 Human Fertilisation and Embryology Act 2008)",c51-eng.pdf,application/pdf,196217,06/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2397
+2398,C52,"Acknowledgment (Section 54 Human Fertilisation and Embryology Act 2008)",c52-eng.pdf,application/pdf,130443,01/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2398
+2400,N471,"Application to Enforce an Award of an Employment Tribunal and Request a Writ of Control",n471-eng.pdf,application/pdf,71181,05/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2400
+2401,PLP10,"PLP10 - Order Menu - Directions Revised Private Law Programme",plp10-eng.doc,application/msword,141312,04/2010,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2401
+2402,PLO8,"Standard Directions on Issue",plo008-eng.doc,application/msword,79360,04/2010,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2402
+2403,PLO9,"Standard Directions at First Appointment",plo009-eng.doc,application/msword,101376,04/2010,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2403
+2404,EX727,"Rydw i wedi cael dyfarniad Tribiwnlys Cyflogaeth neu Dribiwnlys Apêl Cyflogaeth ond nid yw'r atebydd wedi talu. Sut mae ei orfodi?",ex727-cym.pdf,application/pdf,218479,04/2014,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,2404
+2405,C1,"Cais am orchymyn | Application for an order",c001-bil.pdf,application/pdf,343282,04/2010,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2405
+2406,C110,"Application under the Children Act 1989 for a care or supervision order",c110-eng.pdf,application/pdf,683624,11/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2406
+2407,C120,"Witness statement template - Child arrangements - Parental dispute",c120-eng.pdf,application/pdf,112097,11/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2407
+2408,RTA1,"Claim notification form",rta001-eng.pdf,application/pdf,326810,04/2013,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2408
+2409,RTA2,"Defendant only claim notification form",rta02-eng.pdf,application/pdf,402691,04/2013,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2409
+2410,RTA3,"Medical report form",rta003-eng.pdf,application/pdf,74871,04/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2410
+2411,RTA4,"Interim settlement pack form and response to interim settlement pack",rta04-eng.pdf,application/pdf,112511,04/2013,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2411
+2412,RTA5,"Stage 2 settlement pack form and response to settlement pack",rta05-eng.pdf,application/pdf,130646,04/2013,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2412
+2413,RTA6 - RTA 7,"Court proceedings pack (part A - part B) form",rta06-and-07-eng.pdf,application/pdf,153389,04/2013,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2413
+2420,EX343A,"Cwyn | Complaint",ex343a-bil.pdf,application/pdf,204981,04/2010,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2420
+2421,N471,"Cais i orfodi dyfarniad Tribiwnlys Cyflogaeth a gwneud cais am Writ Fieri Facias | Application to enforce an award of an Employment Tribunal and request a Writ of Fieri Facias",n471-bil.pdf,application/pdf,94382,04/2010,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2421
+2424,N209A,"Notice of Issue",n209a-eng.pdf,application/pdf,56519,04/2010,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2424
+2425,N210B,"Acknowledgment of Service",n210b-eng.pdf,application/pdf,161987,04/2010,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2425
+2426,Rent 3,"Application for Certificate to Levy Distress",rent3-eng.pdf,application/pdf,539323,05/2009,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2426
+2428,Tystysgrif Colli Enillion neu Fudd-dal,"Tystysgrif Colli Enillion neu Fudd-dal",loss-certificate-cym.pdf,application/pdf,36786,05/2011,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,2428
+2429,N264,"Electronic documents questionnaire (Civil Procedure Rules Practice Direction 31B)",n264-eng.doc,application/msword,174592,10/2010,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2429
+2432,EX728,"I have an Advisory, Conciliation and Arbitration Service (Acas) settlement (Form COT3) but the respondent has not paid. How do I enforce it?",ex728-eng.pdf,application/pdf,222356,08/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2432
+2433,N471A,"Application to enforce an ACAS settlement and request a Writ of Control",n471a-eng.pdf,application/pdf,71637,05/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2433
+2438,N139,"Application for Warrant of Arrest",n139-eng.pdf,application/pdf,106609,02/2011,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2438
+2462,UT1,"Cais am ganiatad i apelio a hysbysiad am apêl o Dribiwnlys Haen Gyntaf (Siambr Hawl Cymdeithasol)",ut001-cym.pdf,application/pdf,206365,07/2012,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,2462
+2463,UT8,"Cais am ganiatad i apelio a rhybudd o apêl yn sgil penderfyniadau Tribiwnlys Adolygu Iechyd Meddwl Cymru",ut008-cym.pdf,application/pdf,258555,04/2009,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,2463
+2464,UT9,"Cais am ganiatad I apelio a rhybudd o apêl yn sgil penderfyniadau Tribiwnlys Anghenion Addysgol Arbennig Cymru",ut009-cym.pdf,application/pdf,97738,04/2009,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,2464
+2465,UT1,"Cais am ganiatad i apelio a hysbysiad am apêl o Dribiwnlys Haen Gyntaf (Siambr Hawl Cymdeithasol)",ut001-cym.doc,application/msword,291840,11/2008,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,2465
+2466,UT9,"Cais am ganiatad I apelio a rhybudd o apêl yn sgil penderfyniadau Tribiwnlys Anghenion Addysgol Arbennig Cymru",ut009-cym.doc,application/msword,269824,04/2009,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,2466
+2470,T005,"Cais am ganiatad i apelio I'r Uwch Dribiwnlys",t005-cym.pdf,application/pdf,568561,04/2012,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,2470
+2487,UT8,"Cais am ganiatad i apelio a rhybudd o apêl yn sgil penderfyniadau Tribiwnlys Adolygu Iechyd Meddwl Cymru",ut008-cym.doc,application/msword,326144,04/2009,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,2487
+2488,T420,"Gwneud hawliad i Dribiwnlys Cyflogaeth",t420-cym.pdf,application/pdf,449114,03/2015,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,2488
+2489,T421,"Eich hawliad - beth nesaf",t421-cym.pdf,application/pdf,216334,03/2015,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,2489
+2490,T422,"Ymateb i hawliad i Dribiwnlys Cyflogaeth",t422-cym.pdf,application/pdf,246209,05/2014,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,2490
+2491,T423,"Ymateb i hawliad i Dribiwnlys Cyflogaeth (Manylion gwrandawiad I'w hanfon)",t423-cym.pdf,application/pdf,330248,03/2015,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,2491
+2492,T424,"Y gwrandawiad - cyfarwyddyd i hawlwyr",t424-cym.pdf,application/pdf,255982,03/2015,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,2492
+2493,T425,"Y gwrandawiad - cyfarwyddyd i hawlwyr ac atebwyr",t425-cym.pdf,application/pdf,288254,03/2015,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,2493
+2495,T426,"Y dyfarniad",t426-cym.pdf,application/pdf,267705,03/2015,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,2495
+2499,D258B,"Cais am asesiad manwl (Costau'n daladwy o gronfa ar wahan i Gymorth Cyfreithiol Sifil)",d258b-cym.pdf,application/pdf,38709,04/2013,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,2499
+2500,A107,"Consent by the child's parent to adoption by their partner. The Adoption and Children Act 2002",a107-eng.pdf,application/pdf,79425,04/2013,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2500
+2501,D192,"About (Judicial) Separation Decrees/Orders",d192-eng.pdf,application/pdf,249589,04/2014,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2501
+2502,N1C(CC),"Notes for Defendant on Replying to the Part 7 Claim Form",n001c(cc)-eng.pdf,application/pdf,34179,04/2014,8,3,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2502
+2503,C66,"Cais am orchymyn o dan awdurdodaeth gynhenid yr Uchel Lys yng nghyswllt plant | Application for an order under the High Court inherent jurisdiction in relation to children",c66-bil.pdf,application/pdf,345369,06/2016,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2503
+2504,C64,"Cais Am ddatganiad cyfreithustra neu gyfreithuso o dan adran 56(1)(b) a (2) o Ddeddf Cyfraith Teulu 1986 | Application For declaration of legitimacy or legitimation under section 56(1)(b) and (2) of the Family Law Act 1986.",c064-bil.pdf,application/pdf,159981,04/2011,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2504
+2505,C65,"Cais Am ddatganiad ynghylch mabwysiadu a wnaethpwyd dramor dan adran 57 Deddf Cyfraith Teulu 1986 | Application For declaration as to adoption effected overseas under section 57 of the Family Law Act 1986",c065-bil.pdf,application/pdf,188295,04/2011,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2505
+2507,C8,"Manylion cyswllt cyfrinachol Ffurflen C8. Rheolau Achosion Teulu 2010 Rheol 29.1 | Confidential contact details Form C8. Family Procedure Rules 2010 Rule 29.1",c008-bil.pdf,application/pdf,49071,04/2011,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2507
+2508,D151,"Cais i gofrestru gorchymyn cynhaliaeth mewn llys ynadon | Application for registration of a maintenance order in a magistrates' court",d151-bil.pdf,application/pdf,170629,04/2011,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2508
+2509,D20,"Archwiliad meddygol:datganiad y partion a'r archwilydd | Medical examination:statement of parties and examiner",d020-bil.pdf,application/pdf,138968,04/2012,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2509
+2510,D8D Notes,"Supporting Notes for Guidance on Completing a Petition for a Presumption of Death Decree/Order and Dissolution of the Marriage/Civil Partnership",d008d-notes-eng.pdf,application/pdf,155043,04/2014,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2510
+2511,D8N Notes,"Supporting Notes for Guidance on Completing a Nullity Petition",d008n-notes-eng.pdf,application/pdf,193961,04/2014,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2511
+2512,D5,"Hysbysiad I'w arnodi ar ddogfen a gyflwynir yn unol a rheol 6.14 | Notice to be indorsed on document served in accordance with rule 6.14",d005-bil.pdf,application/pdf,161286,04/2011,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2512
+2513,Canllawiau i Wys Rheithgor | Guide to Jury Summons,"Canllawiau i Wys Rheithgor | Guide to Jury Summons",jury-summons-guide-bil.pdf,application/pdf,221984,05/2011,26,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2513
+2514,Allowances,"Allowances",jurors-allowances-eng.pdf,application/pdf,115053,05/2011,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2514
+2515,PA97,"Notice to personal applicant",pa097-eng.doc,application/msword,90112,05/2014,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2515
+2516,D50C,"Cais ar sail methiant i ddarparu cynhaliaeth resymol | Application on ground of failure to provide reasonable maintenance",d050c-bil.pdf,application/pdf,119554,01/2014,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2516
+2517,D50D,"Cais i newid cytundeb cynhaliaeth yn dilyn marwolaeth un o'r partion dan adran 36 Deddf Achosion Priodasol 1973/paragraff 73 Atodlen 5 Deddf Partneriaeth Sifil 2004 | Application for alteration of maintenance agreement after the death of one of the parties under section 36 of the Matrimonial Causes Act 1973/paragraph 73 to Schedule 5 to the Civil Partnership Act 2004",d050d-bil.pdf,application/pdf,217592,04/2012,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2517
+2518,D50E,"Cais am ganiatad i wneud cais am gymorth ariannol ar ol ysgariad dramor ayb. dan adran 13 Deddf Achosion Priodasol a Theuluol 1984 | paragraff 4 Atodlen 7 Deddf Partneriaethau Sifil 2004 | Application for permission to apply for financial relief after an overseas divorce etc. under section 13 of the Matrimonial and Family Proceedings Act 1984/paragraph 4 of Schedule 7 to the Civil Partnership Act 2004",d050e-bil.pdf,application/pdf,186855,04/2011,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2518
+2519,D50F,"Cais am gymorth ariannol ar ol ysgariad dramor ayb. dan adran 12 Deddf Achosion Priodasol a Theuluol 1984/Atodlen 7 Deddf Partneriaethau Sifil 2004 | Application for financial relief after an overseas divorce etc. under section 12 of the Matrimonial and Family Proceedings Act 1984/Schedule 7 to the Civil Partnership Act 2004",d050f-bil.pdf,application/pdf,203661,04/2011,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2519
+2520,N161C,"Guidance Notes on Completing Form N161 - Appellant's Notice for Appeals Relating to Deduction Orders",n161c-eng.pdf,application/pdf,154063,03/2012,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2520
+2521,Juror Charter,"Juror Charter",jurors-charter-eng.pdf,application/pdf,150083,08/2014,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2521
+2522,D6,"Datganiad cymodi | Statement of reconciliation",d006-bil.pdf,application/pdf,145349,04/2011,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2522
+2523,Form PE3 Guidance,"Guidance Notes for Completion of the Application to File a Statutory Declaration out of Time and Statutory Declaration",pe003-guidance-eng.doc,application/msword,33792,05/2014,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2523
+2524,Form PE3 (Vehicle Emissions) Guidance,"Guidance Notes for Completion of the Application to File a Statutory Declaration out of Time and Statutory Declaration for Vehicle Emissions",pe003(ve)-guidance-eng.doc,application/msword,32768,05/2014,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2524
+2525,D80F,"Datganiad i gefnogi dirymiad - priodas/partneriaeth sifil ddi-rym | Statement in support of annulment - void marriage/civil partnership",d080f-bil.pdf,application/pdf,107187,04/2014,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2525
+2526,PA3,"Ffioedd Profiant o fis Ebrill 2011 ymlaen | Probate Fees from April 2011",pa003-bil.pdf,application/pdf,163785,04/2011,26,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2526
+2528,D8N,"Deiseb Dirymu | Nullity Petition",d008n-bil.pdf,application/pdf,180316,04/2014,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2528
+2529,Ffurflen F | Form F,"Hysbysiad am honiad mewn achos ar gyfer rhwymedi ariannol | Notice of allegation in proceedings for a financial remedy",form-f-bil.pdf,application/pdf,165170,04/2011,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2529
+2530,T10,"General Regulatory Chamber - Explanatory Leaflet. First-tier Tribunal (Claims Management Services)",t010-eng.pdf,application/pdf,248062,12/2011,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2530
+2531,T11,"Guide to Completing the Notice of Appeal Form.  First-tier Tribunal (Claims Management Services)",t011-eng.pdf,application/pdf,269217,12/2011,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2531
+2532,T12,"Guidance Notes on Completing the First-tier Tribunal (Claims Management Services) Application for Permission to Appeal to the Upper Tribunal",t012-eng.pdf,application/pdf,312479,12/2011,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2532
+2533,FP6,"Tystysgrif cyflwyno | Certificate of service",fp006-bil.pdf,application/pdf,244088,04/2011,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2533
+2535,T252,"At Your hearing - Explanatory Booklet",t252-eng.pdf,application/pdf,529271,03/2015,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2535
+2537,T251,"Guidance Notes on Completing the Notice of Appeal",t251-eng.pdf,application/pdf,540716,03/2015,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2537
+2538,T112,"Guidance Notes for Applications and Referrals",t112-eng.pdf,application/pdf,14819,01/2012,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2538
+2539,T117,"Information for Nearest Relatives",t117-eng.pdf,application/pdf,166030,11/2014,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2539
+2540,AC010,"Notice of appeal to the High Court (modification/renewal of Non-Derogating Control Orders)",ac010-eng.pdf,application/pdf,178892,08/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2540
+2542,T120,"Guidance for the observation of tribunal hearings",t120-eng.pdf,application/pdf,230444,12/2016,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2542
+2543,T121,"Information for Restricted Patients Detained Under the Mental Health Act 1983 (as Amended by the Mental Health Act 2007)",t121-eng.pdf,application/pdf,59668,01/2012,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2543
+2544,AC011,"Claim form (under Section 11)",ac011-eng.pdf,application/pdf,165934,08/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2544
+2545,T123,"Community Treatment Orders (CTO)",t123-eng.pdf,application/pdf,78880,04/2014,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2545
+2547,Form P10 guidance notes,"Form P10 Guidance Notes on Completing the Application Form for Permission to Appeal",p10-notes-eng.pdf,application/pdf,205464,01/2012,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2547
+2548,Form P9 guidance notes,"Form P9 Guidance Notes on Completing the Application Form to Set Aside a Decision, or Part of It",p09-notes-eng.pdf,application/pdf,188984,01/2012,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2548
+2549,T127,"Practice Guidance on Procedures Concerning Handling Representations from Victims in the First-tier Tribunal (Mental Health)",t127-eng.pdf,application/pdf,61324,01/2012,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2549
+2556,AC014,"Skeleton argument template",ac014-eng.pdf,application/msword,38000,08/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2556
+2557,N161A,"Nodiadau canllaw ar lenwi ffurflen N161 - Hysbysiad apelydd (pob apel ac eithrio apeliadau ar y trac hawliadau bychain) | Guidance notes on completing form N161 - Appellant's notice (all appeals except small claims track appeals)",n161a-bil.pdf,application/pdf,224659,03/2012,26,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2557
+2558,N161C,"Nodiadau canllaw ar lenwi ffurflen N161 Hysbysiad Apelydd am apeliadau sy'n ymwneud a gorchmynion didynnu | Guidance notes on completing form N161 Appellant's notice for appeals relating to deduction orders",n161c-bil.pdf,application/pdf,168689,03/2012,26,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2558
+2564,EX711,"Can the Media Attend My Court Case?  A Guide for Family Court Users",ex711-eng.pdf,application/pdf,226915,04/2014,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2564
+2565,EX710,"A gaf i siarad am fy achos y tu allan i'r llys? - Arweiniad i ddefnyddwyr y llys teulu | Can I talk about my case outside court? A guide for family court users",ex710-bil.pdf,application/pdf,761000,05/2009,26,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2565
+2566,EX711,"A gaiff y cyfryngau fynychu fy achos llys? - Arweiniad i ddefnyddwyr y llys teulu | Can the media attend my court case? A guide for family court users",ex711-bil.pdf,application/pdf,772708,04/2009,26,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2566
+2568,T001,"Explanatory Leaflet - A Short Guide for Users",t001-eng.pdf,application/pdf,350260,04/2012,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2568
+2569,T002,"References - Some Questions and Answers",t002-eng.pdf,application/pdf,300265,04/2012,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2569
+2571,T006,"Guidance Notes on Completing the First-tier Tribunal (Charity) Application for Permission to Appeal to the Upper Tribunal",t006-eng.pdf,application/pdf,339518,04/2012,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2571
+2593,PA97,"Hysbysiad i geisydd personol | Notice to personal applicant",pa097-bil.doc,application/msword,553472,08/2014,26,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2593
+2596,Bill of costs (SCCO),"Information for Clients Enquiring About How to Have Their Solicitor's Bill of Costs Assessed - Senior Courts Costs Office",scco-bill-of-costs-eng.pdf,application/pdf,182175,06/2012,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2596
+2597,T97,"Guide to Completing the Notice of Appeal",t097-eng.pdf,application/pdf,160914,09/2016,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2597
+2598,T95,"Guidance Notes on Completing the First-tier General Regulatory Chamber Application for Permission to Appeal to the Upper Tribunal",t095-eng.pdf,application/pdf,154301,07/2012,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2598
+2600,A1,"Notice of [intention to proceed with] an application for a financial remedy (other than a financial order) in the county or High Court",a001-eng.pdf,application/pdf,332822,04/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2600
+2601,A2,"Notice of [intention to proceed with] an application for a financial remedy in the magistrates' court",a002-eng.pdf,application/pdf,413491,04/2011,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2601
+2602,Form E1,"Financial Statement for a financial remedy (other than a financial order or financial relief after an overseas divorce or dissolution etc) in the county or High Court",form-e001-eng.pdf,application/pdf,302785,11/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2602
+2603,Form E2,"Financial Statement for a variation of an order for a financial remedy",form-e002-eng.pdf,application/pdf,489564,11/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2603
+2604,Form PPF,"Pension Protection Fund (PPF) Inquiry Form Information needed when a Pension Compensation Sharing Order or Pension Compensation Attachment Order may be made",ppf-eng.pdf,application/pdf,379891,04/2011,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2604
+2605,Form PPF1,"Pension Protection Fund (PPF) Sharing Annex to a Pension Compensation Sharing Order [section 24E of the Matrimonial Causes Act 1973] [paragraph 19A of Schedule 5 to the Civil Partnership Act 2004]",ppf1-eng.pdf,application/pdf,369633,04/2011,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2605
+2606,Form PPF2,"Pension Protection Fund (PPF) Attachment Annex to a Pension Compensation Attachment Order [section 25F of the Matrimonial Causes Act 1973] [paragraph 34A of Schedule 5 to the Civil Partnership Act 2004]",form-ppf002-eng.pdf,application/pdf,114645,04/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2606
+2607,D50G,"Application to prevent transaction intended to defeat prospective applications for financial relief",d050g-eng.pdf,application/pdf,340596,11/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2607
+2608,D50K,"Notice of Application for Enforcement by such method of enforcement as the court may consider appropriate Family Procedure Rules 2010 Rule 33.3(2)(b)",d50k-eng.pdf,application/pdf,388157,06/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2608
+2609,D80G,"Datganiad i gefnogi dirymiad - priodas/partneriaeth sifil ddirymadwy | Statement in support of annulment - voidable marriage/civil partnership",d080g-bil.pdf,application/pdf,134403,04/2014,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2609
+2610,Ffurflen 6.28 Nodiadau | Form 6.28 Notes,"Canllawiau ar gyfer Llenwi'r Ffurflen Datganiad o Amgylchiadau Ariannol (Deiseb Dyledwr) dan Adran 272 Deddf Ansolfedd 1986 | Guidance Notes for Completion of your Statement of Affairs (Debtor's Petition) Form Under Section 272 of the Insolvency Act 1986",form-628-notes-bil.pdf,application/pdf,135542,10/2012,26,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2610
+2612,T36,"Guide to completing the notice of appeal form (T35) (Nitrate Vulnerable Zone)",t036-guidance-eng.pdf,application/pdf,406443,05/2012,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2612
+2613,T37,"Nitrate Vulnerable Zone appeals - A guide for individuals",t037-guidance-eng.pdf,application/pdf,284778,05/2012,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2613
+2616,IAFT-2 Guide,"A guide to completing IAFT-2 appeal form",iaft002-guide-eng.pdf,application/pdf,196884,09/2015,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2616
+2620,A100,"Consent to the placement of my child for adoption with any prospective adopters chosen by the Adoption Agency. Section 19 of the Adoption and Children Act 2002",a100-eng.pdf,application/pdf,119981,04/2013,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2620
+2621,A101,"Consent to the placement of my child for adoption with identified prospective adopters. Section 19 of the Adoption and Children Act 2002",a101-eng.pdf,application/pdf,115136,04/2013,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2621
+2622,A102,"Consent to the placement of my child for adoption with identified prospective adopter(s) and, if the placement breaks down, with any prospective adopter(s) chosen by the adoption agency. Section 19 of the Adoption and Children Act 2002",a102-eng.pdf,application/pdf,115970,04/2013,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2622
+2623,A103,"Advance Consent to Adoption. Section 20 of the Adoption and Children Act 2002",a103-eng.pdf,application/pdf,96748,04/2013,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2623
+2624,A104,"Consent to Adoption. The Adoption and Children Act 2002",a104-eng.pdf,application/pdf,129325,04/2013,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2624
+2625,A105,"Consent to the making of an Order under Section 84 of the. Adoption and Children Act 2002",a105-eng.pdf,application/pdf,123164,04/2013,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2625
+2626,A106,"Withdrawal of Consent. Sections 19 and 20 of the Adoption and Children Act 2002",a106-eng.pdf,application/pdf,156199,04/2011,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2626
+2627,T425,"The hearing - guidance for claimants and respondents",t425-eng.pdf,application/pdf,292105,03/2017,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2627
+2628,C5,"Application concerning the registration of a child-minder or provider of day-care",c005-eng.pdf,application/pdf,344975,11/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2628
+2629,C61,"Certificate referred to in Article 41(1) of Council Regulation (EC) No. 2201/2003 of 27 November 2003(1) concerning judgments on rights of access",c061-eng.pdf,application/pdf,140519,04/2011,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2629
+2630,C62,"Certificate referred to in Article 42(1) of Council Regulation (EC) No. 2201/2003 of 27 November 2003(1) concerning the return of the child",c062-eng.pdf,application/pdf,93370,04/2011,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2630
+2631,C63,"Application for declaration of parentage under section 55A of the Family Law Act 1986",c63-eng.pdf,application/pdf,366916,06/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2631
+2632,C64,"Application For declaration of legitimacy or legitimation under section 56(1)(b) and (2) of the Family Law Act 1986",c064-eng-20160203.pdf,application/pdf,341711,01/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2632
+2633,C65,"Application for declaration as to adoption effected overseas under section 57 of the Family Law Act 1986",c65-eng.pdf,application/pdf,320644,01/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2633
+2634,C66,"Application for an order under the High Court inherent jurisdiction in relation to children",c66-eng.pdf,application/pdf,533153,06/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2634
+2635,C67,"Application under the Child Abduction and Custody Act 1985 or Article 11 of Council Regulation (EC) 2201/2003",c67-eng.pdf,application/pdf,442974,06/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2635
+2636,C68,"Application for international transfer of jurisdiction to or from England and Wales",c68-eng.pdf,application/pdf,414271,01/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2636
+2637,C69,"Application for registration, recognition or non recognition of a judgment under Council Regulation (EC) 2201/2003 or the 1996 Hague Convention",c069-eng-20160203.pdf,application/pdf,447807,01/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2637
+2638,D20,"Medical examination statement of parties and examiner",d020-eng.pdf,application/pdf,303532,04/2012,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2638
+2639,D5,"Notice to be indorsed on document served in accordance with rule 6.14",d005-eng.pdf,application/pdf,127113,04/2011,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2639
+2640,D50B,"Application under s17 of the Married Women's Property Act 1882 s66 of the Civil Partnership Act 2004 Application to transfer a property",d050b-eng.pdf,application/pdf,363583,11/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2640
+2641,D50C,"Application on ground of failure to provide reasonable maintenance",d050c-eng.pdf,application/pdf,324858,11/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2641
+2642,D50D,"Application for alteration of maintenance agreement after the death of one of the parties, under s36 of the Matrimonial Causes Act 1973",d050d-eng.pdf,application/pdf,371397,11/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2642
+2643,D50E,"Application for permission to apply for financial relief after an overseas divorce etc. under section 13 of the Matrimonial and Family Proceedings Act 1984/paragraph 4 of Schedule 7 to the Civil Partnership Act 2004",d050e-eng.pdf,application/pdf,346802,11/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2643
+2644,D50F,"Application for financial relief after an overseas divorce etc. under section 12 of the Matrimonial and Family Proceedings Act 1984/Schedule 7 to the Civil Partnership Act 2004",d050f-eng.pdf,application/pdf,337488,11/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2644
+2645,D50H,"Application for alteration of maintenance agreement during parties lifetime",d050h-eng.pdf,application/pdf,360008,11/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2645
+2646,D50J,"Application for an order preventing avoidance under section 32L of the Child Support Act 1991",d050j-eng.pdf,application/pdf,362247,11/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2646
+2647,D6,"Statement of reconciliation",d006-eng.pdf,application/pdf,381210,04/2011,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2647
+2648,D70,"Application for declaration of marital/civil partnership status",d070-eng.pdf,application/pdf,167989,04/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2648
+2649,D80F,"Statement in Support of Annulment - Void Marriage/Civil Partnership",d080f-eng.pdf,application/pdf,562119,04/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2649
+2650,D80G,"Statement in Support of Annulment - Voidable Marriage/Civil Partnership",d080g-eng.pdf,application/pdf,649276,04/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2650
+2651,D8B,"Answer to a divorce/dissolution/(judicial) separation or nullity petition",d008b-eng.pdf,application/pdf,377668,04/2012,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2651
+2652,D8D,"Petition for a presumption of death decree/order and the dissolution of a marriage/civil partnership",d008d-eng.pdf,application/pdf,224966,04/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2652
+2653,D8N,"Nullity Petition",d008n-eng.pdf,application/pdf,724307,11/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2653
+2654,FM1,"Family Mediation Information and Assessment Meeting Form",fm001-eng.pdf,application/pdf,200055,10/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2654
+2655,Form A,"Notice of [intention to proceed with] an application for a financial order",form-a-eng.pdf,application/pdf,320681,10/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2655
+2656,Form A1,"Notice of [intention to proceed with] an application for a financial remedy (other than a financial order) in the county or High Court",form-a001-eng.pdf,application/pdf,270796,10/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2656
+2657,Form A2,"Notice of [intention to proceed with] an application for a financial remedy in the magistrates' court",form-a2-eng.pdf,application/pdf,413491,04/2011,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2657
+2659,Form B,"Notice of an Application to Consider the Financial Position of the Respondent After Divorce/Dissolution",form-b-eng.pdf,application/pdf,738310,10/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2659
+2660,Form H,"Estimate of costs (financial remedy)",form-h-eng.pdf,application/pdf,191836,04/2011,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2660
+2661,FP8,"Rhybudd newid cyfreithiwr | Notice of change of solicitor",fp008-bil.pdf,application/pdf,166918,04/2011,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2661
+2665,D258B,"Request for detailed assessment (Costs payable out of a fund other than the Community Legal Service Fund)",d258b-eng.pdf,application/pdf,261308,11/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2665
+2666,D258C,"Request for detailed assessment hearing pursuant to an order under Part III of the Solicitors Act 1974",d258c-eng.pdf,application/pdf,45963,11/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2666
+2667,LOC006,"Bankruptcy Court Guide",loc006-eng.pdf,application/pdf,190927,11/2013,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2667
+2668,N1(FD),"Nodiadau i'r diffynnydd ar ymateb i'r ffurflen hawlio (hawliad Deddf Credyd Defnyddwyr) | Notes for defendant on replying to the claim form (Consumer Credit Act claim)",n001(fd)-bil.pdf,application/pdf,50609,06/2014,26,3,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2668
+2669,N1C,"Nodiadau I'r diffynnydd ar ateb y ffurflen hawlio | Notes for defendant on replying to the claim form",n001c-bil.pdf,application/pdf,164994,04/2013,26,3,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2669
+2670,N1C,"Notes for defendant on replying to the claim form",n001c-eng.pdf,application/pdf,75912,04/2013,8,3,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2670
+2671,N1D,"Nodiadau i'r diffynnydd ar ateb i'r ffurflen hawlio y tu allan i'r awdurdodaeth | Notes for defendant on replying to the claim form out of the jurisdiction",n001d-bil.pdf,application/pdf,211773,10/2008,26,3,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2671
+2672,N1D,"Notes for defendant on replying to the claim form out of the jurisdiction",n001d-eng.pdf,application/pdf,83667,04/2013,8,3,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2672
+2673,LOC045,"Model directions for clinical negligence cases (2012) - before Master Roberts and Master Cook",loc045-eng.doc,application/msword,84480,08/2015,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2673
+2674,N8B,"Hawliad Cyflafareddu. Nodiadau i'r diffynnydd | Arbitration claim. Notes for the defendant",n008b-bil.pdf,application/pdf,124943,10/2008,26,3,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2674
+2675,N161B,"Nodiadau Pwysig i'r Atebydd | Important notes for respondent",n161b-bil.pdf,application/pdf,120011,04/2000,26,3,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2675
+2676,N208C(CC),"Nodiadau I'r diffynnydd ar ymateb i ffurflen hawlio Rhan 8 | Notes for defendant on replying to the Part 8 claim form",n208c(cc)-bil.pdf,application/pdf,217988,10/2008,26,3,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2676
+2677,N500A,"Notes for claimant on completing a Part 8 claim form (Directors disqualification application)",n500a-eng.pdf,application/pdf,107689,06/2005,8,3,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2677
+2678,N500B,"Notes for defendant (Directors disqualification application)",n500b-eng.pdf,application/pdf,101604,06/2005,8,3,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2678
+2679,N501A,"Notes for claimant on completing claim form N501",n501a-eng.pdf,application/pdf,153692,06/2005,8,3,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2679
+2680,N501B,"Notes for defendant (Directors disqualification proceedings, Section 8A application)",n501b-eng.pdf,application/pdf,99352,06/2005,8,3,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2680
+2683,T451,"Guidance on completing the application form for a Gender Recognition Certificate",t451-eng.pdf,application/pdf,610220,06/2016,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2683
+2684,T452,"Guidelines for Registered Medical Practitioners and Registered Psychologists.  To Facilitate Completion of the Medical Report Proforma for Gender Recognition",t452-eng.pdf,application/pdf,185666,10/2014,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2684
+2701,Ffurflen 6.27 Nodiadau | Form 6.27 Notes,"Deiseb Methdaliad Dyledwr | Debtor's Bankruptcy Petition",form-627-notes-bil.doc,application/msword,96256,10/2012,26,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2701
+2702,T246,"Guidance Notes on Completing the Application to Close Enquiry form",t246-eng.pdf,application/pdf,530906,03/2015,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2702
+2703,T241,"Guidance Notes on Completing the Notice of Appeal",t241-eng.pdf,application/pdf,548984,03/2015,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2703
+2704,T249,"Guidance to Accompany a Decision from the First-tier Tribunal (Tax Chamber)",t249-eng.pdf,application/pdf,533076,03/2015,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2704
+2705,EX506,"Family advocacy scheme - Advocates attendance form",ex506-eng.pdf,application/pdf,328684,06/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2705
+2706,Certificate of Loss,"Certificate of Loss of Earnings or Benefit",loss-certificate-eng.pdf,application/pdf,60121,05/2011,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2706
+2708,Form PE2,"Application to File a Statutory Declaration Out of Time",pe002-eng.doc,application/msword,45568,05/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2708
+2709,Form PE3,"Statutory Declaration - Unpaid Penalty Charge",pe003-eng.doc,application/msword,45568,05/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2709
+2710,Form PE3 (Vehicle Emissions),"Statutory Declaration (Vehicle Emissions) - Unpaid Penalty Charge",pe003(ve)-eng.doc,application/msword,45568,05/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2710
+2711,TE7,"Application to File a Statement Out of Time/Extension of Time (Parking)",te007-eng.doc,application/msword,67072,05/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2711
+2712,TE7 (Dart Charge),"Application to File a Statement Out of Time/Extension of Time",te007-dart-eng.pdf,application/pdf,1175548,02/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2712
+2713,TE9,"Witness statement - Unpaid Penalty Charge (Parking)",te009-eng.doc,application/msword,69632,05/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2713
+2714,TE9 (Dart Charge),"Witness statement - Unpaid Penalty Charge",te009-dart-eng.pdf,application/pdf,330063,11/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2714
+2715,Ffurflen E1 | Form E1,"Datganiad Ariannol am rwymedi ariannol (ar wahan i orchymyn ariannol neu gymorth ariannol ar ol ysgariad neu diddymiad dramor) yn y Llys Sirol neu'r Uchel Lys | Financial Statement for a financial remedy (other than a financial order or financial relief after an overseas divorce or dissolution etc) in the county or High Court",form-e1-bil.pdf,application/pdf,387548,04/2012,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2715
+2716,Ffurflen E2 | Form E2,"Datganiad Ariannol am rwymedi ariannol yn y llys ynadon | Financial Statement for a financial remedy in the magistrates' court",form-e2-bil.pdf,application/pdf,367507,04/2012,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2716
+2717,PPF2,"Cronfa Diogelu Pensiynau (PPF) - Atodiad Atafaelu i Orchymyn Atafaelu Iawndal Pensiwn [Adran 25F Deddf Achosion Priodasol 1973] [paragraff 34A Atodlen 5 Deddf Partneriaethau Sifil 2004] | Pension Protection Fund (PPF) Attachment Annex to a Pension Compensation Attachment Order [section 25F of the Matrimonial Causes Act 1973] [paragraph 34A of Schedule 5 to the Civil Partnership Act 2004]",ppf2-bil.pdf,application/pdf,280158,04/2011,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2717
+2719,SEND9,"Guidance for Summonsed Witnesses",send009-eng.pdf,application/pdf,233475,09/2014,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2719
+2720,SEND10,"Guidance for Expert Witnesses Giving Evidence in Special Educational Needs Appeals and Disability Discrimination Claims Hearings",send010-eng.pdf,application/pdf,165371,03/2013,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2720
+2721,CMIS,"Case Management Information Sheet",case-management-info-eng.doc,application/msword,37376,01/2012,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2721
+2724,SSCS1A,"How to Appeal Against a Decision Made by the Department for Work and Pensions",sscs001a-eng.pdf,application/pdf,256154,07/2015,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2724
+2725,FTC1 Notes,"Notes for Appellants",ftc001-notes-eng.pdf,application/pdf,547798,11/2014,8,3,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2725
+2726,FTC2 Notes,"Notes for Appellants Requesting an Order for Costs or Expenses",ftc002-notes-eng.pdf,application/pdf,536025,11/2014,8,3,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2726
+2727,SSCS1A,"How to appeal against a decision made by the Department for Work and Pensions (Large print)",sscs001a-large-eng.pdf,application/pdf,296574,07/2015,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2727
+2728,SEND18,"Carrying out our order in special educational needs cases: A parents' guide to what happens now",send018-eng.pdf,application/pdf,138886,08/2015,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2728
+2729,EX728,"Mae gennyf setliad gan y Gwasanaeth Cynghori, Cymodi a Chyflafareddu (Acas) (Ffurflen COT3) ond nid yw'r atebydd wedi talu",ex728-cym.pdf,application/pdf,194717,04/2014,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,2729
+2730,T108,"Appealing to the First-tier Tribunal (Care Standards) - A Guide to the Appeals Procedures",t108-eng.pdf,application/pdf,362091,10/2014,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2730
+2731,EX725,"Gwneud hawliad trawsffiniol yn yr UE",ex725-cym.pdf,application/pdf,191870,04/2014,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,2731
+2732,T108B,"Telephone Case Management Hearing Guide",t108b-eng.pdf,application/pdf,183406,10/2014,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2732
+2733,N244 Notes,"Application Notice (Form N244) - Notes for Guidance",n244-notes-eng.pdf,application/pdf,102827,10/2013,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2733
+2734,MC102,"A Guide on How and Where to Pay Your Fine",mc102-eng.pdf,application/pdf,715601,05/2013,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2734
+2735,EX730,"Hoffech chi setlo eich achos heb fynd i wrandawiad llys?",ex730-cym.pdf,application/pdf,158510,04/2014,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,2735
+2736,T113,"CMR1 Case Management Request Form",t113-eng.doc,application/msword,110080,08/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2736
+2737,T435,"Ffioedd tribiwnlys cyflogaeth ar gyfer unigolion (O'r 29 Gorffennaf 2013 ymlaen)",t435-cym.pdf,application/pdf,216381,03/2015,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,2737
+2738,T114,"Witness expenses Form and Guidelines",t114-eng.pdf,application/pdf,357350,10/2014,8,4,false,1,2017-03-17,GetForm.do?court_forms_id=,2738
+2739,T541,"Guidance on service charges, administration charges and other management matters. General information about the process",t541-eng.pdf,application/pdf,563819,01/2017,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2739
+2740,Form P9,"Form P9 - Application to set aside a decision or part of a decision (Rule 45)",p09-eng.doc,application/msword,60928,11/2011,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2740
+2741,Form P9,"Form P9 - Application to set aside a decision or part of a decision (Rule 45)",p09-eng.pdf,application/pdf,15151,11/2011,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2741
+2742,Form P10,"Form P10 - Application for permission to appeal (Rule 46)",p10-eng.doc,application/msword,68608,11/2011,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2742
+2743,Form P10,"Form P10 - Application for permission to appeal (Rule 46)",p10-eng.pdf,application/pdf,16074,11/2011,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2743
+2744,B1,"Application to be released on bail",b001-eng.doc,application/msword,182272,10/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2744
+2745,CB7,"Canllaw i rieni wedi gwahanu: plant a'r llysoedd teulu",cb7-cym.pdf,application/pdf,264283,09/2015,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,2745
+2746,ET1A,"Dalen flaen Ffioedd a Dileu Ffioedd",et001a-cym.pdf,application/pdf,257425,04/2014,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,2746
+2747,ET1,"Ffurflen Hawlio",et001-cym.pdf,application/pdf,341584,05/2014,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,2747
+2748,ET3,"Ffurflen ymateb",et003-cym.pdf,application/pdf,175989,07/2013,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,2748
+2750,N244 Nodiadau | N244 Notes,"Rhybudd Cyflwyno Cais (Ffurflen N244) - Canllawiau | Application notice (Form N244) - Notes for guidance",n244-notes-bil.pdf,application/pdf,182668,07/2008,26,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2750
+2751,PPF,"Ffurflen Ymholi am y Gronfa Diogelu Pensiynau (CDP) Gwybodaeth sydd ei hangen pan ellir gwneud Gorchymyn Rhannu Iawndal Pensiwn neu Orchymyn Atafaelu Iawndal Pensiwn | Pension Protection Fund (PPF) Inquiry Form Information needed when a Pension Compensation Sharing Order or Pension Compensation Attachment Order may be made",ppf-bil.pdf,application/pdf,250341,04/2011,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2751
+2752,Ffurflen P1 | Form P1,"Atodiad Rhannu Pensiwn dan [adran 24B Deddf Achosion Priodasol 1973] [baragraff 15 Atodlen 5 Deddf Partneriaeth Sifil 2004] | Pension Sharing Annex under [section 24B of the Matrimonial Causes Act 1973] [paragraph 15 of Schedule 5 to the Civil Partnership Act 2004]",p01-bil.pdf,application/pdf,256417,04/2012,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2752
+2753,D50G,"Cais i atal trafodyn a fwriedir i rwystro ceisiadau tebygol am gymorth ariannol | Application to prevent transaction intended to defeat prospective applications for financial relief",d050g-bil.pdf,application/pdf,181386,04/2012,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2753
+2754,TALG964,"Protocol for Inspection of Land in Agricultural Land and Drainage Cases",talg964-eng.pdf,application/pdf,40158,07/2013,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2754
+2755,TALG900,"Practice Statement 2013",talg900-eng.pdf,application/pdf,77733,07/2013,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2755
+2756,CB7,"Guide for Separated Parents: Children and the Family Courts",cb007-eng.pdf,application/pdf,322902,09/2015,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2756
+2757,T005,"Application for permission to appeal to Upper Tribunal",t005-eng.pdf,application/pdf,226780,04/2012,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2757
+2758,SSCS6A,"Sut i apelio yn erbyn penderfyniad gan Weinyddwr y Cynllun Taliadau Mesothelioma Ymledol",sscs006a-cym.pdf,application/pdf,236403,10/2014,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,2758
+2759,FTC3 Notes,"Notes for Applicants - Form FTC3 (Tax and Chancery Chamber)",ftc003-notes-eng.pdf,application/pdf,534515,11/2014,8,3,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2759
+2760,T399,"Appealing to the Upper Tribunal (Tax and Chancery Chamber): Tax, Charity and Land Registration Appeals",t399-eng.pdf,application/pdf,605745,11/2014,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2760
+2761,T400,"References to the Upper Tribunal (Tax and Chancery Chamber): Financial Services Cases",t400-eng.pdf,application/pdf,629559,11/2014,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2761
+2763,UT3,"Application for permission to appeal to an Upper Tribunal judge and notice of appeal form for mental health cases (England)",ut003-eng.doc,application/msword,314368,10/2011,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2763
+2764,UT4,"Application for Permission to Appeal and Notice of Appeal From First-Tier Tribunal Special Educational Needs and Disability Discrimination in Schools",ut004-eng.pdf,application/pdf,67403,04/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2764
+2765,UT4,"Application for Permission to Appeal and Notice of Appeal From First-Tier Tribunal Special Educational Needs and Disability Discrimination in Schools",ut004-eng.doc,application/msword,264704,04/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2765
+2766,T434,"Expenses and allowances payable to parties and witnesses attending an Employment Tribunal",t434-eng.pdf,application/pdf,168874,08/2013,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2766
+2767,UT5,"Application for permission to appeal to an Upper Tribunal judge and notice of appeal form for care standards and primary health lists cases",ut005-eng.doc,application/msword,372224,10/2011,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2767
+2768,UT6,"Application for permission to appeal to an Upper Tribunal judge and notice of appeal form for war pensions and armed forces compensation cases",ut006-eng.pdf,application/pdf,96987,10/2011,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2768
+2769,UT6,"Application for permission to appeal to an Upper Tribunal judge and notice of appeal form for war pensions and armed forces compensation cases",ut006-eng.doc,application/msword,248832,03/2013,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2769
+2770,COP5A,"Guidance notes on completing form COP5 (Acknowledgment of service/notification)",cop005a-eng.pdf,application/pdf,49600,09/2015,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2770
+2771,UT7,"Application/appeal form for the Secretary of State for war pensions and armed forces compensation cases",ut007-eng.doc,application/msword,185856,10/2011,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2771
+2772,UT8,"Application for permission to appeal to an Upper Tribunal judge and notice of appeal form against decisions of the Mental Health Review Tribunal Wales",ut008-eng.pdf,application/pdf,224701,04/2009,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2772
+2773,UT8,"Application for permission to appeal to an Upper Tribunal judge and notice of appeal form against decisions of the Mental Health Review Tribunal Wales",ut008-eng.doc,application/msword,319488,04/2009,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2773
+2774,UT9,"Application for permission to appeal to an Upper Tribunal judge and notice of appeal form against decisions of the Special Educational Needs Tribunal Wales",ut009-eng.pdf,application/pdf,190023,04/2009,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2774
+2775,UT9,"Application for permission to appeal to an Upper Tribunal judge and notice of appeal form against decisions of the Special Educational Needs Tribunal Wales",ut009-eng.doc,application/msword,265728,04/2009,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2775
+2777,UT10,"Form to Appeal Against a Decision of the Disclosure and Barring Service, England and Wales",ut010-eng.doc,application/msword,228352,04/2013,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2777
+2778,UT11,"Application for permission to appeal and notice of appeal from a decision of the First-tier Tribunal (General Regulatory Chamber) - but not for an information rights case",ut011-eng.pdf,application/pdf,657985,09/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2778
+2781,UT12,"Form to appeal to the Upper Tribunal against a Traffic Commissioner decision",ut012-eng.doc,application/msword,218112,12/2013,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2781
+2782,UT12NI,"Appeal to the Upper Tribunal against a Goods Vehicle Operator licensing decision of the Department for Infrastructure (DfI)",ut12ni-eng.doc,application/msword,190976,11/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2782
+2783,COP14A,"COP14 Guidance Notes",cop014a-eng.pdf,application/pdf,40876,09/2015,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2783
+2784,COP15A,"COP15 Guidance Notes",cop015a-eng.pdf,application/pdf,46700,09/2015,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2784
+2787,UT14,"Application for Permission and Notice of Appeal - Diffuse Mesothelioma Payments Scheme",ut014-eng.pdf,application/pdf,216603,09/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2787
+2788,JR1,"Judicial Review Claim Form, England and Wales (Upper Tribunal - Administrative Appeals Chamber)",jr001(acc)-eng.doc,application/msword,327168,03/2013,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2788
+2789,JR2,"Judicial Review - Acknowledgment of Service Form (Upper Tribunal - Administrative Appeals Chamber)",jr002(aac)-eng.doc,application/msword,264704,10/2011,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2789
+2790,COP21A,"Guidance notes on completing form COP20A (Certificate of notification/non-notification of the person to whom the proceedings relate)",cop021a-eng.pdf,application/pdf,47097,09/2015,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2790
+2791,COP21B,"Guidance notes on completing form COP20B (Certificate of service non-service notification/non-notification)",cop021b-eng.pdf,application/pdf,42086,09/2015,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2791
+2797,T128,"Options for your Tribunal Referral Hearing",t128-eng.doc,application/msword,104960,12/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2797
+2798,PA1T,"Cais am chwiliad sefydlog | Application for a standing search",pa001t-bil.pdf,application/pdf,142004,02/2012,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2798
+2799,T96,"Application for permission to appeal to the Upper Tribunal.  First-tier Tribunal (General Regulatory Chamber)",t096-eng.doc,application/msword,117760,07/2012,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2799
+2800,T98,"Notice of appeal. General Regulatory Chamber (GRC)",t098-eng.doc,application/msword,126464,09/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2800
+2804,T604,"Explanatory leaflet for compulsory purchase compensation, land compensation disputes and other references",t604-eng.pdf,application/pdf,258081,01/2016,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2804
+2805,T605,"Explanatory leaflet for appeals against decisions of the First-tier Tribunal (Property Chamber) in England, and Leasehold Valuation and Residential Property Tribunals in Wales",t605-eng.pdf,application/pdf,341785,01/2016,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2805
+2806,T606,"Explanatory leaflet for appeals against decisions of the Valuation Tribunal for England and the Valuation Tribunal for Wales",t606-eng.pdf,application/pdf,326978,01/2016,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2806
+2807,T607,"Explanatory leaflet for applications for rights of light certificates",t607-eng.pdf,application/pdf,259868,01/2016,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2807
+2808,T608,"Explanatory leaflet for applications to discharge or modify restrictive covenants",t608-eng.pdf,application/pdf,337047,01/2016,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2808
+2809,T440,"I Want to Appeal to the Employment Appeal Tribunal",t440-eng-20151230.pdf,application/pdf,178627,12/2015,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2809
+2810,A64A,"Cais i dderbyn gwybodaeth o gofnodion y llys am orchymyn rhieni | Application to receive information from court records about a parental order",a064a-bil.pdf,application/pdf,77725,04/2010,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2810
+2812,MC100,"Make Sure You Can Pay Your Fine. (Czech)",mc100-cze.pdf,application/pdf,545874,12/2013,7,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2812
+2814,COP GN1,"Applications for the appointment of a deputy for property and financial affairs",cop-gn001-eng.pdf,application/pdf,148175,09/2015,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2814
+2815,COP GN2,"Guidance on the sale of jointly owned property",cop-gn002-eng.pdf,application/pdf,183964,09/2015,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2815
+2816,COP GN3,"Applications by existing deputies - Guidance note",cop-gn003-eng.pdf,application/pdf,138915,09/2015,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2816
+2817,COP GN4,"Making a personal welfare application to the Court of Protection",cop-gn004-eng.pdf,application/pdf,73556,09/2015,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2817
+2818,COP GN5,"Coming for a hearing at the Court of Protection in London or at one of our regional courts",cop-gn005-eng.pdf,application/pdf,53227,09/2015,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2818
+2819,C17,"Atodiad i gais am Orchymyn Goruchwylio Addysg | Supplement for an application for an Education Supervision Order",c017-bil.pdf,application/pdf,107821,09/1999,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2819
+2820,C51,"Cais am Orchymyn Rhiant (Adran 54 o Ddeddf Ffrwythloni Dynol ac Embryoleg 2008) | Application for a Parental Order (Section 54 Human Fertilisation and Embryology Act 2008)",c51-bil.pdf,application/pdf,171756,06/2016,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2820
+2821,COP GN8,"Applications for statutory wills, gifts, settlements and other dealings with P's property",cop-gn008-eng.pdf,application/pdf,118728,09/2015,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2821
+2822,COP FAQ,"Making an application to the Court of Protection - Frequently asked questions",cop-faq-eng.pdf,application/pdf,132079,11/2016,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2822
+2823,EX50A,"Full list of fees applicable in the Civil and Family Courts (from 25th July 2016)",ex50a-eng.doc,application/msword,391680,07/2016,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2823
+2824,C78,"Cais i ychwanegu hysbysiad rhybudd at orchymyn cyswllt | Application for attachment of a warning notice to a contact order",c078-bil.pdf,application/pdf,159870,04/2014,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2824
+2825,T455,"The general guide for all users (Gender Recognition Act 2004)",t455-eng-2016.04.01.pdf,application/pdf,672321,04/2016,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2825
+2827,T454,"Guidance on completing the Overseas application form for a Gender Recognition Certificate",t454-eng.pdf,application/pdf,540490,06/2016,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2827
+2828,Child Support: How to Appeal,"Child Support: How to Appeal",child-support-how-to-appeal-eng.pdf,application/pdf,52640,10/2013,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2828
+2829,Child Support: How to Appeal,"Child Support: How to Appeal (Scotland)",child-support-how-to-appeal-scotland.pdf,application/pdf,56097,10/2013,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2829
+2830,Your Appeal - What Happens Next,"Your Appeal - What Happens Next",information-leaflet-eng.pdf,application/pdf,32820,04/2012,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2830
+2832,T53,"Fee guidance notes for individuals",t053-eng.pdf,application/pdf,309604,10/2015,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2832
+2833,EX160A,"How to apply for help with fees",ex160a-eng.pdf,application/pdf,553609,02/2017,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2833
+2834,EX160B,"Undertaking to Apply for Remission of a Court Fee or Tribunal Fee, or to Pay a Court Fee or Tribunal Fee for Emergency Applications Only",ex160b-eng.pdf,application/pdf,112385,09/2013,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2834
+2835,EX160C,"Fee remissions contribution calculator",ex160c-eng.xls,application/vnd.ms-excel,28160,09/2013,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2835
+2837,UT Table of cases,"UTAAC Table of Cases",utaac-table-cases-eng.pdf,application/pdf,442261,06/2015,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2837
+2838,UTAAC FAQ,"Upper Tribunal (Administrative Appeals Chamber) - what to expect",utaac-faq-eng.pdf,application/pdf,574250,05/2015,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2838
+2839,JR1 Guidance,"Claim Form JR1 - Notes for Guidance  (Upper Tribunal - Administrative Appeals Chamber)",jr001(aac)-guidance-eng.doc,application/msword,53248,10/2011,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2839
+2841,T481 Notes,"Upper Tribunal - Immigration and Asylum Chamber. Guidance Notes on Completing the UTIAC Judicial Review Claim Form",t481-notes-eng.pdf,application/pdf,51394,08/2015,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2841
+2842,JR1 Guidance,"Claim Form JR1 - Notes for Guidance (Upper Tribunal - Tax & Chancery Chamber)",jr001(tcc)-guidance-eng.pdf,application/pdf,532174,11/2014,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2842
+2843,Application for Anonymity - Guidance Notes,"Application for Anonymity - Guidance Notes (UTIAC)",anonymity-guide-utiac-eng.pdf,application/pdf,8720,11/2013,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2843
+2844,JRC1 Notes,"Information Notes and Guidance for Completing Claim Form JRC1",jrc001-notes-eng.doc,application/msword,64512,07/2012,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2844
+2845,T03,"General Regulatory Chamber Guidance Note for Policy Makers",policy-makers-guidance-eng.pdf,application/pdf,71759,11/2013,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2845
+2848,AC013,"Guidance as to how the parties should assist the Court when applications for costs are made following settlement of claims for judicial review (April 2016)",ac13-eng.pdf,application/pdf,150515,09/2016,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2848
+2849,EX105,"Cais i gost trawsgrifau gael ei thalu ag arian cyhoeddus | Request that the costs of transcripts be paid at public expense",ex105-bil.pdf,application/pdf,475271,01/2007,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2849
+2850,AC015,"Regionalisation guidance",ac015-eng.pdf,application/pdf,107806,08/2016,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2850
+2851,FL401,"Cais am: orchymyn peidio â molestu/orchymyn anheddu | Application for: a non-molestation order/an occupation order",fl401-bil.pdf,application/pdf,238946,04/2014,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2851
+2852,FL401A,"Cais am Orchymyn Amddiffyn Priodi Dan Orfod | Application for a Forced Marriage Protection Order",fl401a-bil.pdf,application/pdf,242930,06/2014,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2852
+2853,FL403A,"Cais i amrywio, ymestyn neu ddiddymu gorchymyn amddiffyn priodi dan orfod | Application to vary, extend or discharge a forced marriage protection order",fl403a-bil.pdf,application/pdf,121104,11/2008,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2853
+2854,AC016,"Appeals under Section 289 of the Town and Country Planning Act 1990. Notes for guidance for court users",ac016-eng.pdf,application/pdf,88829,08/2016,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2854
+2855,FL430,"Cais am ganiatâd i wneud cais am Orchymyn Amddiffyn Priodi Dan Orfod | Application for leave to apply for a Forced Marriage Protection Order",fl430-bil.pdf,application/pdf,86219,11/2008,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2855
+2856,FL431,"Cais i ymuno fel parti, neu i roi'r gorau i fod yn barti, mewn Achos Amddiffyn Priodi Dan Orfod | Application to be joined as, or cease to be, a party to Forced Marriage. Protection Proceedings",fl431-bil.pdf,application/pdf,115560,11/2008,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2856
+2857,FP9,"Tystysgrif addasrwydd cyfaill cyfreitha | Certificate of suitability of litigation friend",fp09-bil.pdf,application/pdf,156675,11/2008,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2857
+2858,AC017,"Claims for planning statutory review. Notes for guidance for court users",ac017-eng.pdf,application/pdf,116718,08/2016,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2858
+2865,N264,"Holiadur dogfennau electronig (Rheolau Trefniadaeth Sifil Cyfarwyddyd Ymarfer 31B) | Electronic documents questionnaire (Civil Procedure Rules Practice Direction 31B)",n264-bil.doc,application/msword,468480,10/2010,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2865
+2866,Ground Rules Hearing Form,"Defence Ground Rules Hearing Form - multiple-defendants (Section 28)",ground-rules-hearing(multiple-defendants)-eng.doc,application/msword,104448,11/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2866
+2867,Crown Court Preliminary Hearing Form,"Crown Court Preliminary Hearing Form - multiple-defendants (Section 28)",preliminary-hearing(multiple-defendants)-eng.doc,application/msword,284672,11/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2867
+2868,N510,"Cyflwyno y tu allan i'r Awdurdodaeth | Service out of the Jurisdiction",n510-bil.pdf,application/pdf,201670,10/2008,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2868
+2869,N5C,"Nodiadau i'r hawlydd (trefn gyflymedig) | Notes for the claimant (Accelerated procedure)",n005c-bil.pdf,application/pdf,140187,04/2010,26,3,false,1,2017-03-17,GetForm.do?court_forms_id=,2869
+2871,HQ1,"Hearing questionnaire 1 - To the patient's representative and to the responsible authority",hq1-eng-2016.03.24.doc,application/msword,1211904,03/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2871
+2872,HQ1 Guardianship,"Hearing questionnaire 1 - To the patient's representative, the local social services authority and guardian (If not the LSSA)",hq1-guardianship-eng-2016.02.24.doc,application/msword,87552,02/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2872
+2873,PCMH,"Gwrandawiad Pledio a Rheoli Achos. Holiadur I Adfocadau | Plea and Case Management Hearing",pcmh-bil.doc,application/msword,839168,04/2010,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2873
+2875,T35,"Notice of appeal (Nitrate vulnerable zone)",t035-eng.doc,application/msword,105472,05/2012,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2875
+2876,HQ2,"Hearing Questionnaire 2",hq002-eng.doc,application/msword,65536,05/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2876
+2877,Application for Anonymity,"Application for anonymity (IAT)",anonymity-form-iat-eng.doc,application/msword,38912,08/2012,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2877
+2878,IAFT-1,"Appeal to the First-Tier Tribunal (Immigration and Asylum Chamber) against an in country (Asylum/Immigration) decision",iaft001-eng.pdf,application/pdf,199316,10/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2878
+2879,IAFT-2,"Appeal to the First-Tier Tribunal (Immigration and Asylum Chamber) against a decision of an Entry Clearance Officer",iaft002-eng.pdf,application/pdf,159807,10/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2879
+2880,IAFT-3,"Appeal to the First-Tier Tribunal (Immigration and Asylum Chamber) against your Home Office (Asylum/Immigration) decision",iaft003-eng.pdf,application/pdf,186281,10/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2880
+2882,T38,"Cover sheet for Nitrate Vulnerable Zone appeal",t38-eng.pdf,application/pdf,74472,12/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2882
+2884,IAFT-4,"First-Tier Tribunal application for permission to appeal to Upper Tribunal",iaft004-eng.pdf,application/pdf,77747,10/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2884
+2889,SEND4A,"Disability discrimination claim by a parent",send004a-eng.pdf,application/pdf,159883,09/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2889
+2890,SEND15A,"Expenses claim form - parents",send015a-eng.pdf,application/pdf,123821,09/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2890
+2891,SEND16A,"Expenses claim form - witnesses",send016a-eng.pdf,application/pdf,163218,09/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2891
+2892,SEND17,"Explanation for missing travel tickets/receipts",send017-eng.pdf,application/pdf,147452,09/2012,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2892
+2893,SEND15AYP,"Expenses claim form - young person",send15ayp-eng.pdf,application/pdf,164654,08/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2893
+2894,N210C,"Acknowledgment of Service (Part 81, Section 4 - Certification, or application under section 336 of the Charities Act 2011, in relation to conduct alleged to constitute contempt of court (CPR Part 81, Section 4))",n210c-eng.pdf,application/pdf,98505,10/2012,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2894
+2896,T450,"Standard application for a Gender Recognition Certificate",t450-eng.pdf,application/pdf,194303,11/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2896
+2900,CAPSBACS1,"Payment of Attachment of Earnings Orders by BACS",capsbacs1-eng-2016.02.24.pdf,application/pdf,103361,02/2016,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2900
+2904,CAPSBACS2,"Payment details",capsbacs2-eng-2016.02.24.pdf,application/pdf,114180,02/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2904
+2908,CAPSBACS3,"BACS registration form",capsbacs3-eng-2016.02.24.pdf,application/pdf,116848,02/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2908
+2912,CAPSBACS4,"BACS schedule - payments to CAPS",cpasbacs4-eng-2016.02.24.pdf,application/pdf,126480,02/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2912
+2980,IAFT-5,"Appeal to the First-Tier Tribunal (Immigration and Asylum Chamber) - Complete this form if you are appealing from inside the United Kingdom and you have the right to do so",iaft5-eng.pdf,application/pdf,195232,11/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2980
+2982,IAFT-6,"Appeal to the First-Tier Tribunal (Immigration and Asylum Chamber) against a decision of an Entry Clearance Officer (ECO)",iaft6-eng.pdf,application/pdf,161869,11/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2982
+2983,IAFT-7,"Appeal to the First-Tier Tribunal (Immigration and Asylum Chamber) - Complete this form if your right of appeal can only be exercised after having left the United Kingdom or you have chosen to leave the United Kingdom before exercising your right of appeal",iaft7-eng.pdf,application/pdf,181182,11/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2983
+2990,T144,"Victim's representations to the Tribunal",t144-eng.pdf,application/pdf,756938,03/2017,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2990
+3000,Fee Account Application form,"Fee account - Customer application form",fee-account-application-eng.pdf,application/pdf,1260443,05/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3000
+3001,N1SDT,"Claim form (MCOL secure data transfer)",n001sdt-eng.pdf,application/pdf,236752,09/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3001
+3006,Ffurflen 6.27 | Form 6.27,"Deiseb Methdaliad Dyledwr | Debtor's Bankruptcy Petition",form-627-bil.doc,application/msword,84480,10/2012,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3006
+3007,QBD OHA,"Out of hours application ? Queen's Bench Division",qbd-oha-eng.doc,application/msword,71168,06/2013,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3007
+3008,N16,"General form of injunction for interim application or originating application",n016-eng.pdf,application/pdf,1283981,10/2012,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3008
+3009,N16(1),"General form of injunction for interim application or originating application (Formal parts - See complete N16 for wording of operating clauses)",n016(1)-eng.pdf,application/pdf,27840,10/2012,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3009
+3010,N110A,"Power of arrest attached to injunction",n110a-eng.pdf,application/pdf,374902,06/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3010
+3015,T240,"Notice of Appeal",t240-eng.pdf,application/pdf,560625,03/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3015
+3019,T245,"Application to Close Enquiry",t245-eng.pdf,application/pdf,532715,03/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3019
+3020,IAUT1,"Application for permission to appeal from First-Tier Tribunal (Immigration and Asylum Chamber)",iaut001-eng.pdf,application/pdf,120979,07/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3020
+3025,N253A,"Notice of provisional assessment (general form)",n253a-eng.pdf,application/pdf,45325,04/2013,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3025
+3027,N261,"Provisional assessment hearing notice",n261-eng.pdf,application/pdf,19315,04/2013,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3027
+3030,N149A,"Notice of proposed allocation to the small claims track",n149a-eng.pdf,application/pdf,95302,04/2013,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3030
+3031,N149B,"Notice of proposed allocation to the fast track",n149b-eng.pdf,application/pdf,95532,04/2013,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3031
+3032,N149C,"Notice of proposed allocation to the multi-track",n149c-eng.pdf,application/pdf,132637,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3032
+3033,N263,"Disclosure report",n263-eng.pdf,application/pdf,107237,04/2013,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3033
+3034,N180,"Directions questionnaire (Small claims track)",n180-eng.pdf,application/pdf,157332,04/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3034
+3035,N181,"Directions questionnaire (Fast track and multi-track)",n181-eng.pdf,application/pdf,153042,04/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3035
+3036,N180,"Holiadur Cyfarwyddiadau (Trac Hawliadau Bychain) | Directions questionnaire (Small claims track)",n180-bil.pdf,application/pdf,126699,04/2014,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3036
+3037,N181,"Holiadau Cyfarwyddiadau (Y trac cyflym a'r Amldrac) | Directions questionnaire (Fast track and multi-track)",n181-bil.pdf,application/pdf,183797,04/2014,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3037
+3038,SSCS1,"Notice of Appeal Against a Decision of the Department for Work and Pensions",sscs001-eng.pdf,application/pdf,135263,09/2013,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3038
+3039,Precedent H,"Form Precedent H",precedent(h)-eng.xls,application/vnd.ms-excel,93696,10/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3039
+3041,FTC1,"Application for Permission to Appeal and Notice of Appeal From First-tier Tribunal Including Notes for Applicants and Appellants (Tax and Chancery Chamber)",ftc001-eng.pdf,application/pdf,553886,11/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3041
+3042,FTC2,"Form FTC2 Application for Costs or Expenses",ftc002-eng.pdf,application/pdf,503564,11/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3042
+3043,FTC3,"Reference notice (Financial Services)",ftc003-eng.pdf,application/pdf,543726,11/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3043
+3044,SEND7,"Request for change",send7-eng.pdf,application/pdf,87792,11/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3044
+3045,SEND8,"Withdrawal of appeal or claim",send008-eng.pdf,application/pdf,68677,10/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3045
+3053,Form EDMO,"Applications relating to Empty Dwelling Management Orders (EDMOs)",edmo-eng.doc,application/msword,272896,01/2017,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3053
+3054,Form HHSRS,"Applications relating to Improvement Notices, Prohibition Orders, Demolition Orders and Emergency Measures",hhsrs-eng.doc,application/msword,265728,01/2017,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3054
+3055,Form HMO,"Applications relating to licensing of Houses in Multiple Occupation (HMOs) and selective licensing",hmo-eng.doc,application/msword,222720,01/2017,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3055
+3056,Form MO,"Applications relating to interim and final Management Orders (MOs)",mo-eng.doc,application/msword,236032,01/2017,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3056
+3060,Form OCN,"Applications relating to Overcrowding Notice",ocn-eng.doc,application/msword,227840,01/2017,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3060
+3071,T385,"Notice of appeal against a decision of a Valuation Tribunal",t385-eng.pdf,application/pdf,130853,01/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3071
+3074,Form RP PTA,"Application for permission to appeal a decision to the Upper Tribunal (Lands Chamber)",rp-pta-eng.doc,application/msword,128512,01/2017,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3074
+3075,Form RRO1,"Application by a local housing authority for a Rent Repayment Order (Housing Act 2004)",rro1-eng.doc,application/msword,147456,01/2017,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3075
+3076,Form RRO2,"Application by occupier for a Rent Repayment Order (Housing Act 2004)",rro2-eng.doc,application/msword,158208,01/2017,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3076
+3077,Form RTB1,"Application for a determination as to whether a dwelling house is suitable for occupation by elderly persons",rtb1-eng.doc,application/msword,165376,01/2017,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3077
+3078,Form RTM,"Application relating to (No fault) right to manage",rtm-eng.doc,application/msword,178688,01/2017,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3078
+3079,Form TA,"Application for recognition of a Tenants' Association",ta-eng.doc,application/msword,224768,01/2017,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3079
+3080,Leasehold 1,"Application for a determination as to liability to pay an administration charge or for the variation of a fixed administration charge",leasehold1-eng.doc,application/msword,212480,01/2017,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3080
+3081,Leasehold 2,"Application by a tenant for the appointment of a manager or for the variation or discharge of an order appointing a manager",leasehold2-eng.doc,application/msword,228864,01/2017,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3081
+3082,Leasehold 3,"Application for a determination of liability to pay and reasonableness of service charges",leasehold3-eng.doc,application/msword,243712,01/2017,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3082
+3083,Leasehold 4,"Application for the variation of a lease or leases",leasehold4-eng.doc,application/msword,206336,01/2017,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3083
+3084,Leasehold 5,"Application for the dispensation of all or any of the consultation requirements provided for by Section 20 of the Landlord and Tenant Act 1985",leasehold5-eng.doc,application/msword,216064,01/2017,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3084
+3085,Leasehold 6,"Application for an order that a breach of covenant or a condition in the lease has occurred",leasehold6-eng.doc,application/msword,178688,01/2017,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3085
+3086,Leasehold 7,"Application for an order under Section 20C of the Landlord and Tenant Act 1985",leasehold7-eng.doc,application/msword,201728,01/2017,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3086
+3087,Leasehold 8,"Application for determination of reasonable costs - Flats and Premises (Section 91(2)(d) of the Leasehold Reform, Housing and Urban Development Act 1993)",leasehold8-eng.doc,application/msword,252416,01/2017,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3087
+3088,Leasehold 9,"Application form: Flats and premises leasehold enfranchisement (Missing landlord lease terms and/or premium)",leasehold9-eng.doc,application/msword,214528,01/2017,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3088
+3089,Leasehold 10,"Application for determination of the terms of acquisition remaining in dispute. Flats and premises (Collective enfranchisement)",leasehold10-eng.doc,application/msword,261632,01/2017,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3089
+3090,Leasehold 11,"Application for determination of premium or other terms of acquisition remaining in dispute. Flats and premises (Lease renewal)",leasehold11-eng.doc,application/msword,301056,01/2017,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3090
+3091,Leasehold 12,"Application for determination of price payable. houses and premises (Leasehold enfranchisement)",leasehold12-eng.doc,application/msword,352256,01/2017,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3091
+3092,Leasehold 13,"Applications for determination of price payable, provisions in the conveyance, apportionment of rent and determination of sub-tenant's share. Houses and premises - Leasehold enfranchisement (Missing landlord)",leasehold13-eng.doc,application/msword,297984,01/2017,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3092
+3093,Leasehold 14,"Application for a Reasonable Costs Order",leasehold14-eng.doc,application/msword,326656,01/2017,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3093
+3094,Rents 1,"Application referring a notice proposing a new rent under an Assured Periodic Tenancy or Agricultural Occupancy, to the Tribunal",rents1-eng.doc,application/msword,159232,01/2017,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3094
+3095,Rents 2,"Application to the Tribunal for Determination of a Rent under an Assured Shorthold Tenancy",rents2-eng.doc,application/msword,178176,01/2017,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3095
+3096,Rents 3,"Application referring a notice proposing different terms for a Statutory Periodic Tenancy to the Tribunal",rents3-eng.doc,application/msword,159232,01/2017,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3096
+3097,T410,"Application to Rectify or Set Aside Documents",t410-eng.doc,application/msword,103936,07/2013,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3097
+3098,T411,"Land Registration Objection to an Application to the Tribunal to Rectify or Set Aside Document(s)",t411-eng.doc,application/msword,83968,07/2013,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3098
+3100,Leasehold 15,"Application form: Flats and premises collective enfranchisement (Missing landlord)",leasehold15-eng.doc,application/msword,215040,01/2017,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3100
+3103,TAHB511,"Notice of Application for Certificate of Bad Husbandry",tahb511-eng.doc,application/msword,260608,02/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3103
+3104,TAHB521,"Response to application for certificate of bad husbandry",tahb521-eng.doc,application/msword,226304,02/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3104
+3105,TALD711,"Notice of Application for an Order under the Land Drainage Act 1991",tald711-eng.doc,application/msword,573952,02/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3105
+3106,TALD721,"Response to an Application for an Order under the Land Drainage Act 1991",tald721-eng.doc,application/msword,244736,02/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3106
+3107,TALG911,"Notice of Application.  For use where there is no other dedicated form",talg911-eng.doc,application/msword,299008,02/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3107
+3108,TALG921,"Response to Notice of Application on Form TALG911.  For use where there is no other dedicated form",talg921-eng.doc,application/msword,246272,02/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3108
+3111,TASD111,"Notice of Application for Direction for Succession Tenancy on Death",tasd111-eng.doc,application/msword,730624,08/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3111
+3112,TASD121,"Response to application for direction for succession tenancy on death",tasd121-eng.doc,application/msword,445952,02/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3112
+3113,TASR211,"Notice of Application for Direction for Succession Tenancy on Retirement",tasr211-eng.doc,application/msword,483840,02/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3113
+3114,TASR221,"Response to application for direction for succession tenancy on retirement",tasr221-eng-20151223.doc,application/msword,388096,12/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3114
+3115,C110A,"Application for a care or supervision order and other orders under Part 4 of the Children Act 1989 or an Emergency Protection Order under section 44 of the Children Act 1989",c110a-eng.pdf,application/pdf,371388,09/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3115
+3117,TANQ411,"Notice of Application for Consent to the Operation of a Notice to Quit",tanq411-eng.doc,application/msword,468992,02/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3117
+3118,TANQ421,"Response to application for consent to the operation of a notice to quit",tanq421-eng.doc,application/msword,260608,02/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3118
+3119,EL1,"Claim Notification Form (EL1): Low Value Personal Injury Claims in Employers' Liability - Accident Only (£1,000 - £25,000)",el01-eng.pdf,application/pdf,266613,04/2013,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3119
+3120,EL2,"Claim Notification Form (EL2): Low Value Personal Injury Claims in Employers' Liability - Accident Only (£1,000 - £25,000).  Defendant Only",el02-eng.pdf,application/pdf,191880,04/2013,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3120
+3121,ELD1,"Claim Notification Form (ELD1): Low Value Personal Injury Claims in Employers' Liability - Disease (£1,000 - £25,000)",eld01-eng.pdf,application/pdf,153247,04/2013,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3121
+3122,ELD2,"Claim Notification Form (ELD2): Low Value Personal Injury Claims in Employers' Liability - Disease (£1,000 - £25,000).  Defendant Only",eld02-eng.pdf,application/pdf,138620,04/2013,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3122
+3123,EPL3,"Medical Report Form (EPL3): Low Value Personal Injury Claims in Employers' Liability and Public Liability (£1,000 - £25,000)",epl03-eng.pdf,application/pdf,86764,04/2013,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3123
+3124,EPL4,"Interim Settlement Pack and Response to Interim Settlement Pack (EPL4): Low Value Personal Injury Claims in Employers' Liability and Public Liability (£1,000 - £25,000)",epl04-eng.pdf,application/pdf,137019,04/2013,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3124
+3125,EPL5,"Stage 2 Settlement Pack and Response to Settlement Pack (EPL5): Low Value Personal Injury Claims in Employers' Liability and Public Liability (£1,000 - £25,000)",epl05-eng.pdf,application/pdf,113034,04/2013,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3125
+3126,EPL6 and EPL7,"Court Proceedings Pack (Part A) (EPL6) and (Part B) (EPL7): Low Value Personal Injury Claims in Employers' Liability and Public Liability (£1,000 - £25,000)",epl06-and-07-eng.pdf,application/pdf,112933,04/2013,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3126
+3127,PL1,"Claim Notification Form (PL1): Low Value Personal Injury Claims in Public Liability Accidents (£1,000 - £25,000)",pl01-eng.pdf,application/pdf,176585,04/2013,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3127
+3128,PL2,"Claim Notification Form (PL2): Low Value Personal Injury Claims in Public Liability Accidents (£1,000 - £25,000).  Defendant Only",pl02-eng.pdf,application/pdf,172314,04/2013,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3128
+3130,ET1A,"Employment Tribunal claim form for multiple claimants",et1a-eng.pdf,application/pdf,502061,02/2017,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3130
+3131,ET1,"Employment Tribunal claim form for single claimants",et1-eng.pdf,application/pdf,398167,02/2017,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3131
+3133,ET3,"Employment Tribunal response form",et003-eng.pdf,application/pdf,104081,04/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3133
+3135,T443,"Form 8 Appeal From Decision of Employment Tribunal - Appellant's Reply to Cross Appeal",t443-eng.pdf,application/pdf,9355,07/2013,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3135
+3136,T444,"Form 1 Notice of Appeal From Decision of Employment Tribunal",t444-eng.pdf,application/pdf,9923,07/2013,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3136
+3137,T445,"Form 3 Appeal From Decision of Employment Tribunal/Certification Officer - Respondent's Answer",t445-eng.pdf,application/pdf,8565,07/2013,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3137
+3138,TSF4,"Party/witness claim for attending an Employment Tribunal",tsf4-eng.pdf,application/pdf,198375,08/2013,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3138
+3139,T439,"Declaration from a party/witness who is self employed and claiming loss of earnings",t439-eng.pdf,application/pdf,61706,08/2013,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3139
+3202,T362,"Absent owner application form",t362-eng.pdf,application/pdf,105196,12/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3202
+3362,T370,"Notice of reference by an authority",t370-eng.pdf,application/pdf,172588,01/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3362
+3371,T371,"Notice of reference by a claimant",t371-eng.pdf,application/pdf,153774,01/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3371
+3373,T372,"Response by an authority to a notice of reference",t372-eng.pdf,application/pdf,119488,01/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3373
+3375,T373,"Response by a claimant to a notice of reference",t373-eng.pdf,application/pdf,111261,01/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3375
+3380,T374,"Form BNO - Notice of Reference relating to the validity of a Blight or Purchase Counter Notice",t374-eng.pdf,application/pdf,128037,01/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3380
+3382,T375,"Response to a notice of reference BNO",t375-eng.pdf,application/pdf,109135,01/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,3382
+4362,T379,"Application under Section 84 of the Law of Property Act 1925 to discharge or modify a restrictive covenant",t379-eng.pdf,application/pdf,160229,01/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4362
+4371,T380,"Form LPB - Restrictive Covenant Application: Publicity Notice",t380-eng.doc,application/msword,42496,08/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4371
+4373,T381,"Form LPD - Notice of Objection to a Restrictive Covenant Application",t381-eng.pdf,application/pdf,573550,10/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4373
+4374,T382,"Form LPCoC - Certificate of Compliance",t382-eng.doc,application/msword,91136,12/2010,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4374
+4375,T382,"Form LPCoC - Certificate of Compliance",t382-eng.pdf,application/pdf,62676,12/2010,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4375
+4379,T383,"Form 1 - Application for a Certificate of the Tribunal - Rights of Light Act 1959",t383-eng.doc,application/msword,31232,12/2010,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4379
+4380,T383,"Form 1 - Application for a Certificate of the Tribunal - Rights of Light Act 1959",t383-eng.pdf,application/pdf,22842,12/2010,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4380
+4381,T384,"Form A - Light Obstruction Notice - Rights of Light Act 1959",t384-eng.doc,application/msword,29696,12/2010,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4381
+4382,T384,"Form A - Light Obstruction Notice - Rights of Light Act 1959",t384-eng.pdf,application/pdf,19996,12/2010,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4382
+4383,T601,"Notice of appeal against a decision of the First-tier Tribunal (Property Chamber) in England, or a Leasehold Valuation or Residential Property Tribunal in Wales",t601-eng.pdf,application/pdf,606168,01/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4383
+4384,T602,"Application for permission to appeal against a decision of the First-tier Tribunal (Property Chamber) in England, or a Leasehold Valuation or Residential Property Tribunal in Wales",t602-eng.pdf,application/pdf,616465,01/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4384
+4385,N226,"Notice of admission (Unspecified amount)",n226-eng.pdf,application/pdf,256739,04/2006,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4385
+4387,T603,"Respondent's notice to an appeal against a decision of the first-tier tribunal (Property Chamber) in England, or a Leasehold Valuation or Residential Property Tribunal in Wales",t603-eng.pdf,application/pdf,533020,01/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4387
+4388,N39,"Order to attend court for questioning",n039-eng.pdf,application/pdf,599230,03/2002,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4388
+4389,T453,"Application for a Gender Recognition Certificate (Overseas legal recognition application) (Gender Recognition Act 2004)",t453-eng.pdf,application/pdf,293871,11/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4389
+4390,Enquiry Form,"Enquiry Form (Appellant)",appellant-enquiry-form-eng.pdf,application/pdf,31222,10/2013,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4390
+4391,Enquiry Form,"Enquiry Form (Other Party)",other-party-enquiry-form-eng.pdf,application/pdf,30435,10/2013,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4391
+4392,SSCS1,"Notice of Appeal Against a Decision of the Department for Work and Pensions (Large Print)",sscs001-large-eng.pdf,application/pdf,125042,09/2013,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4392
+4393,SSCS2,"Notice of Appeal Against a Decision of the Department for Work and Pensions - Child Maintenance Group",sscs002-eng.pdf,application/pdf,209299,08/2013,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4393
+4394,SSCS2,"Notice of Appeal Against a Decision of the Department for Work and Pensions - Child Maintenance Group (Large Print)",sscs002-large-eng.pdf,application/pdf,126178,08/2013,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4394
+4395,SSCS3,"Notice of Appeal Against a Decision of the Department for Work and Pensions - Compensation Recovery Unit",sscs003-eng.pdf,application/pdf,149052,01/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4395
+4397,EX160,"Apply for help with fees",ex160-eng.pdf,application/pdf,127032,02/2017,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4397
+4398,EX160,"Gwneud cais am help i dalu ffioedd | Apply for help with fees",ex160-bil.pdf,application/pdf,258000,02/2017,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4398
+4403,T480,"Judicial review claim form",t480-eng.pdf,application/pdf,157206,08/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4403
+4404,T482,"Judicial review, acknowledgment of service",t482-eng.pdf,application/pdf,80055,08/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4404
+4405,T483,"UTIAC Judicial Review. Application for urgent consideration",t483-eng.pdf,application/pdf,102207,11/2013,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4405
+4406,T484,"Application notice (Upper Tribunal Immigration and Asylum Chamber)",t484-eng.pdf,application/pdf,99910,06/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4406
+4407,T485,"Statement under Upper Tribunal Rule 28A (2)(b)",t485-eng.pdf,application/pdf,76015,08/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4407
+4408,T486,"Notice of Change of Solicitor",t486-from-november-eng.pdf,application/pdf,89500,08/2013,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4408
+4409,JR1,"Judicial Review Claim Form, England and Wales (Upper Tribunal - Tax & Chancery Chamber)",jr001(tcc)-eng.pdf,application/pdf,583623,11/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4409
+4410,JR2,"Judicial Review - Acknowledgment of Service Form  (Upper Tribunal - Tax & Chancery Chamber)",jr002(tcc)-eng.pdf,application/pdf,590551,11/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4410
+4411,Application for Anonymity,"Application for Anonymity (UTIAC)",anonymity-form-utiac-eng.pdf,application/pdf,32438,12/2010,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4411
+4412,Application for Anonymity,"Application for Anonymity (UTIAC)",anonymity-form-utiac-eng.doc,application/msword,35328,12/2010,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4412
+4413,IAUT3,"Application of Renewal (UTIAC)",iaut003-utiac-eng.doc,application/msword,348672,11/2013,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4413
+4414,IAUT3,"Application of Renewal (UTIAC)",iaut003-utiac-eng.pdf,application/pdf,31836,11/2013,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4414
+4415,Notice of intention to pursue an appeal,"Notice of Intention to Pursue an Appeal (UTIAC)",appeal-notice-utiac-eng.pdf,application/pdf,48229,11/2013,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4415
+4416,SSCS4,"Notice of appeal against a decision of the Department for Work and Pensions - Recovery of NHS Charges",sscs004-eng.pdf,application/pdf,106162,01/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4416
+4417,TALG975,"Application for Permission to Appeal a Decision to the Upper Tribunal (Lands Chamber). Applications for Stay, Suspension and Postponement Pending Appeal",talg975-eng.doc,application/msword,257024,02/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4417
+4418,T359,"Immigration guidance for unrepresented appellants",t359-eng.pdf,application/pdf,148331,11/2014,8,4,false,1,2017-03-17,GetForm.do?court_forms_id=,4418
+4423,EX370,"Your First Time at Court? What You Can Expect",ex370-eng.pdf,application/pdf,148877,03/2014,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4423
+4424,T412,"A Short Guide for Users",t412-eng.pdf,application/pdf,148706,07/2013,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4424
+4425,Claim Information Form,"Claim Information Form",claim-info-eng.xls,application/vnd.ms-excel,99840,04/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4425
+4426,EX108,"Tape transcription",ex108-eng.pdf,application/pdf,73667,07/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4426
+4427,N182,"Mediation settlement agreement",n182-eng.doc,application/msword,83456,04/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4427
+4430,N208PC,"Planning statutory review claim",n208pc-eng-20151222.pdf,application/pdf,129000,12/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4430
+4439,N215PC,"Certificate of Service (Planning Court)",n215pc-eng.pdf,application/pdf,295667,09/2011,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4439
+4440,EAC1,"Application for Certificate to Act as an Enforcement Agent",eac001-eng.pdf,application/pdf,152820,04/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4440
+4442,EAC2,"Complaint Against a Certificated Person",eac002-eng.pdf,application/pdf,75533,04/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4442
+4444,N331,"Notice of withdrawal from possession or payment over of moneys, on notice of receiving or winding-Up order",n331-eng.doc,application/msword,33792,04/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4444
+4445,EX381,"Court of Appeal frequently asked questions",ex381-eng.pdf,application/pdf,132158,12/2016,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4445
+4450,N461PC,"Judicial Review Claim Form",n461pc-eng.pdf,application/pdf,356767,04/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4450
+4451,N462PC,"Judicial Review Acknowledgment of service",n462pc-eng.pdf,application/pdf,192018,07/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4451
+4452,N463PC,"Judicial Review Application for Urgent Consideration",n463pc-eng.pdf,application/pdf,80235,04/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4452
+4453,N464PC,"Application for Directions as to Venue for Administration and Determination",n464pc-eng.pdf,application/pdf,331432,04/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4453
+4454,EX730,"Would You like to Settle Your Case without Going to a Court Hearing?",ex730-eng.pdf,application/pdf,398854,04/2014,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4454
+4455,PC001,"Request for an Adjournment (Birmingham)",pc001-birmingham-eng.pdf,application/pdf,19261,09/2008,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4455
+4456,PC001,"Request for an Adjournment (Cardiff)",pc001-cardiff-eng.pdf,application/pdf,18960,09/2008,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4456
+4457,County Court Business Centre Code of Practice,"County Court Business Centre Code of Practice",ccbc-cop-eng-20160216.pdf,application/pdf,605598,12/2015,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4457
+4458,PC001,"Request for an Adjournment (London)",pc001-london-eng.pdf,application/pdf,19622,09/2008,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4458
+4459,PC001,"Request for an Adjournment (Manchester)",pc001-manchester-eng.pdf,application/pdf,19073,09/2008,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4459
+4460,PCPF244,"Application Notice (Part 23) in the High Court of Justice, Queens Bench Division, the Planning Court",pcpf244-eng.pdf,application/pdf,70848,04/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4460
+4461,SSCS5,"Notice of appeal against a decision of HM Revenue and Customs",sscs005-eng.pdf,application/pdf,154548,07/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4461
+4462,GMappeal1,"Notice of Appeal Form",gm-appeal001-eng.pdf,application/pdf,38781,06/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4462
+4463,GMappeal2,"Application to Extend Time",gm-appeal002-eng.pdf,application/pdf,38748,06/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4463
+4464,POAC1,"Notice of Appeal to the Proscribed Organisations Appeals Commission (POAC)",poac001-eng.pdf,application/pdf,117350,07/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4464
+4471,SEND11,"Attendance form - parents",send011-eng.pdf,application/pdf,56086,07/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4471
+4472,SEND11YP,"Attendance form - young person",send11yp-eng.pdf,application/pdf,145940,09/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4472
+4473,SEND12,"Attendance form - local authority",send012-eng.pdf,application/pdf,55797,07/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4473
+4475,SEND1A,"Appeal form - statement of educational needs",send01a-eng-2016.03.01.pdf,application/pdf,174366,02/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4475
+4476,SEND20A,"Application for permission to appeal",send020a-eng.pdf,application/pdf,170939,08/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4476
+4477,SEND20B,"Application for review",send020b-eng.pdf,application/pdf,173691,08/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4477
+4478,SEND20C,"Application to set aside final decision",send020c-eng.pdf,application/pdf,199735,08/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4478
+4480,N142,"Guardianship Order",n142-eng.pdf,application/pdf,136581,07/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4480
+4485,N143,"[Interim] Hospital Order",n143-eng.pdf,application/pdf,153687,07/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4485
+4495,T609,"Appeals From Decisions Made by the First-Tier Tribunal (Property Chamber) in Residential Property and Agricultural Land and Drainage Cases",t609-eng.pdf,application/pdf,162744,09/2014,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4495
+4496,CIC Guide 1996,"Guide to the Criminal Injuries Compensation Scheme 1996",cic-guide-1996-eng.pdf,application/pdf,114461,04/1999,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4496
+4497,CIC Guide 2001,"Guide to the Criminal Injuries Compensation Scheme 2001",cic-guide-2001-eng.pdf,application/pdf,712752,12/2007,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4497
+4498,CIC Guide 2008,"Guide to the Criminal Injuries Compensation Scheme 2008",cic-guide-2008-eng.pdf,application/pdf,114461,07/2014,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4498
+4499,CIC Guide 2012,"Guide to the Criminal Injuries Compensation Scheme 2012",cic-guide-2012-eng.pdf,application/pdf,506438,07/2014,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4499
+4500,Criminal Injuries Compensation Scheme 1996,"The Criminal Injuries Compensation Scheme 1996",cic-scheme-1996-eng.pdf,application/pdf,57168,04/1999,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4500
+4501,Criminal Injuries Compensation Scheme 2001,"The Criminal Injuries Compensation Scheme 2001",cic-scheme-2001-eng.pdf,application/pdf,136973,04/2001,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4501
+4502,Criminal Injuries Compensation Scheme 2008,"The Criminal Injuries Compensation Scheme 2008",cic-scheme-2008-eng.pdf,application/pdf,1098260,07/2014,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4502
+4503,Criminal Injuries Compensation Scheme 2012,"The Criminal Injuries Compensation Scheme 2012",cic-scheme-2012-eng.pdf,application/pdf,721490,07/2014,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4503
+4504,CS01,"Memorandum of understanding between Ofsted and the First-Tier Tribunal of the Health, Education and Social Care Chamber",cs001-eng.pdf,application/pdf,73971,04/2014,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4504
+4505,CS02,"Memorandum of Understanding Between Department for Education (Independent Education and Boarding Team) and HM Courts & Tribunals Service (First-tier Tribunal Health, Education and Social Care Chamber)",cs002-eng.pdf,application/pdf,56234,08/2015,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4505
+4506,CS03,"Memorandum of Understanding between Care Quality Commission and HM Courts & Tribunals Service regrading expedited appeals to the First-tier Tribunal (Care Standards)",cs003-eng.pdf,application/pdf,50217,07/2014,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4506
+4507,CS04,"Memorandum of Understanding Between the Welsh Ministers and Tribunals Service in Respect of Expedited Appeals",cs004-eng.pdf,application/pdf,82624,07/2014,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4507
+4508,PHL Guide,"A guide to Making an Appeal to Primary Health Lists",phl-guide-eng.pdf,application/pdf,297645,10/2014,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4508
+4509,REMO 11,"Annex C - Application for Establishment of a Decision",remo-011-eng.doc,application/msword,65024,08/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4509
+4510,REMO 12,"Annex D - Application for Modification of a Decision",remo-012-eng.doc,application/msword,76288,08/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4510
+4511,REMO 13,"Annex E - Financial Circumstances Form",remo-013-eng.doc,application/msword,242176,08/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4511
+4512,SEND21,"Mediation Certificate",send021-eng.pdf,application/pdf,70595,09/2014,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4512
+4513,SEND22,"Answering a Claim - A Guide to Responsible Bodies",send022-eng.pdf,application/pdf,189501,08/2014,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4513
+4514,SEND3,"Information About Schools",send003-eng.pdf,application/pdf,67136,07/2014,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4514
+4515,SEND6,"Information for Children and Young People",send006-eng.pdf,application/pdf,463723,07/2014,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4515
+4516,T243,"At Your Hearing",t243-eng.pdf,application/pdf,541665,03/2015,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4516
+4517,T244,"Further Appeal Notes",t244-eng.pdf,application/pdf,531592,03/2015,8,3,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4517
+4518,Application for Anonymity,"Application for anonymity guidance notes (IAT)",anonymity-guide-iat-eng.pdf,application/pdf,54910,08/2012,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4518
+4519,IAFT-1 Guide,"A guide to completing IAFT-1 appeal form",iaft001-guide-eng.pdf,application/pdf,378615,09/2015,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4519
+4520,T490,"Gender Recognition Panel Application Process Flowchart",t490-eng.pdf,application/pdf,2193,07/2014,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4520
+4521,T491,"Table of Gender Recognition Schemes in Countries and Territories",t491-eng.pdf,application/pdf,159883,06/2011,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4521
+4522,T492,"Additonal Guidance Issued by the President on the GRA's Medical Requirements",t492-eng.pdf,application/pdf,29787,12/2005,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4522
+4523,T493,"List of specialists in the field of gender dysphoria",t493-eng.pdf,application/pdf,110828,01/2017,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4523
+4524,T494,"Expenses and Allowances Payable to Parties and Witnesses Attending an Employment Tribunal",t494-eng.pdf,application/pdf,31709,10/2006,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4524
+4525,T622,"Bail Variation Request Form (SIAC B2)",t622-eng.pdf,application/pdf,470083,07/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4525
+4526,T496,"Guide to loss of earnings and special expenses",t496-eng.pdf,application/pdf,36233,08/2010,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4526
+4527,T497,"Criminal Injuries Compensation (Your appeal)",t497-eng.pdf,application/pdf,147809,07/2014,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4527
+4529,IAFT-3 Guide,"A guide to completing IAFT-3 appeal form",iaft003-guide-eng.pdf,application/pdf,361337,09/2015,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4529
+4530,IAFT-4 Guide,"A guide to completing IAFT-4 application form",iaft004-guide-eng.pdf,application/pdf,165208,09/2015,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4530
+4531,T611,"Judicial Mediation - Scotland",t611-eng.pdf,application/pdf,15405,07/2014,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4531
+4532,T612,"Judicial Mediation - England and Wales",t612-eng.pdf,application/pdf,15040,07/2014,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4532
+4533,IAFT-5 Guide,"A guide to completing IAFT-5 appeal form - Information on fee payment. Notice of appeal to the First-tier Tribunal (Immigration and Asylum Chamber) in country",iaft5-guide-eng.pdf,application/pdf,198723,12/2016,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4533
+4534,T614,"Procedure flowchart for appeals from The First-tier Tribunal (Property Chamber) in England and the Leasehold Valuation and Residential Property Tribunals in Wales",t614-eng.pdf,application/pdf,397255,01/2016,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4534
+4535,T615,"Procedure flowchart for rating appeals",t615-eng.pdf,application/pdf,381077,01/2016,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4535
+4536,T616,"Procedure flowchart for claims for compensation for the compulsory purchase of land and other claims for land compensation",t616-eng.pdf,application/pdf,388115,01/2016,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4536
+4537,T617,"Procedure flowchart for applications to discharge or modify restrictive covenants affecting land",t617-eng.pdf,application/pdf,202926,01/2016,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4537
+4538,T618,"Upper Tribunal Lands Chamber Flowchart - Detailed Assessment of Costs",t618-eng.pdf,application/pdf,52655,11/2010,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4538
+4539,T619A,"Guidance Notes for Completion of SIAC Appeal Form",t619a-eng.pdf,application/pdf,574728,07/2015,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4539
+4540,T98A,"Rights of appeal",t098a-eng.pdf,application/pdf,27588,11/2014,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4540
+4542,FL701,"Forced Marriage Protection Orders - How can they protect me? (Arabic)",fl701-ara.pdf,application/pdf,554028,02/2015,2,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4542
+4543,FL701,"Forced Marriage Protection Orders - How can they protect me? (Bengali)",fl701-ben.pdf,application/pdf,401170,02/2015,3,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4543
+4544,FL701,"Forced Marriage Protection Orders - How can they protect me? (Farsi)",fl701-far.pdf,application/pdf,299571,02/2015,9,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4544
+4545,FL701,"Forced Marriage Protection Orders - How can they protect me? (Punjabi)",fl701-pun.pdf,application/pdf,655057,02/2015,17,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4545
+4546,FL701,"Forced Marriage Protection Orders - How can they protect me? (Urdu)",fl701-urd.pdf,application/pdf,233762,02/2015,24,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4546
+4547,SEND23,"Working document guidance",send23-eng-2016.03.01.pdf,application/pdf,141804,01/2015,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4547
+4549,IAFT-6 Guide,"A guide to completing IAFT-6 appeal form - Information on fee payment - Notice of appeal to the First-Tier Tribunal (Immigration and Asylum Chamber) overseas entry clearance",iaft6-guide-eng.pdf,application/pdf,192098,11/2016,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4549
+4550,T94,"Appealing to the First-tier Tribunal (Transport)",t094-eng.pdf,application/pdf,203924,08/2014,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4550
+4551,SEND25,"How to Appeal a Special Educational Needs and Disability (SEND) Decision",send025-eng.pdf,application/pdf,248991,09/2014,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4551
+4552,T499,"The War Pensions and Armed Forces Compensation Chamber Short Guide",t499-eng.pdf,application/pdf,106430,04/2011,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4552
+4553,T610,"The War Pensions and Armed Forces Compensation FAQ",t610-eng.pdf,application/pdf,44172,10/2008,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4553
+4554,IAFT-7 Guide,"A guide to completing IAFT-7 appeal form - Information on fee payment - Notice of appeal to the First-Tier Tribunal (Immigration and Asylum Chamber) overseas appeal against a decision made inside the UK",iaft7-guide-eng.pdf,application/pdf,240760,11/2016,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4554
+4555,SEND14,"Information About Schools",send014-eng.pdf,application/pdf,240015,08/2014,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4555
+4556,REMO 7 Notes,"Guidance Notes for Completing an Application for Recognition, Declaration of Enforceability or Enforcement of a Decision Relating to Maintenance Obligations",remo007-notes-eng.pdf,application/pdf,229511,09/2014,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4556
+4557,REMO 8 Notes,"Guidance Notes for Completing an Application to Obtain a Maintenance Decision or to Have a Decision Relating to Maintenance Modified",remo008-notes-eng.pdf,application/pdf,147884,08/2014,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4557
+4558,IAUT1 Guide,"A guide to completing IAUT-1 application form",iaut001-guide-eng.pdf,application/pdf,171511,07/2015,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4558
+4577,REMO 20,"A guide to Reciprocal Enforcement of Maintenance Orders",remo020-eng.pdf,application/pdf,540718,06/2015,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4577
+4592,COP42,"Making an application to the Court of Protection",cop42-eng.pdf,application/pdf,251489,12/2013,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4592
+4600,COP44,"Court of Protection fees",cop044-eng.pdf,application/pdf,74743,11/2015,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4600
+4601,PH1,"Application by occupier of a park home on a protected site (other than a transit pitch on a local authority gypsy and traveller site) for an order that the site owner give the occupier a written statement as to the terms of their agreement",ph1-eng.doc,application/msword,131072,01/2017,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4601
+4602,COP44B,"Guide - Applying for help with Court of Protection fees",cop44b-eng.pdf,application/pdf,454231,04/2016,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4602
+4603,PH3,"Application by occupier of a park home or a park home site owner for a determination of any question arising under the Mobile Homes Act 1983 or agreement to which it applies",ph3-eng.doc,application/msword,158720,01/2017,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4603
+4604,PH4,"Application by site owner for a determination that having regard to its condition a park home is having a detrimental effect on the amenity of the site",ph4-eng.doc,application/msword,141824,01/2017,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4604
+4605,PH5,"Application by owner of a park home site for a refusal order preventing the occupier from selling the park home and assigning the agreement to the proposed occupier",ph5-eng.doc,application/msword,160768,01/2017,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4605
+4606,PH6,"Application by owner of a park home site for a refusal order preventing the occupier from giving the park home and assigning the agreement to a member of the occupier's family",ph6-eng.doc,application/msword,159744,01/2017,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4606
+4607,PH7,"Application by site owner for a determination that the owner may require an occupier to re-site the occupier's home temporarily to another pitch on the protected site",ph7-eng.doc,application/msword,138752,01/2017,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4607
+4608,PH8,"Application by the occupier for an order that the site owner secure that a temporarily re-sited home is returned to the original pitch",ph8-eng.doc,application/msword,129536,01/2017,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4608
+4609,PH9,"Application by site owner or occupier for determination of new level of pitch fee",ph9-eng.doc,application/msword,163840,01/2017,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4609
+4610,PH10,"Application by a protected site owner for a determination that improvements should be taken into account when the pitch fee is reviewed",ph10-eng.doc,application/msword,134144,01/2017,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4610
+4611,PH11,"Application to the tribunal by a park homes site residents' association for an order recognising the applicant as a qualifying association",ph11-eng.doc,application/msword,137728,01/2017,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4611
+4612,PH12,"Application by site owner for a determination as to the applicant's entitlement to terminate the agreement",ph12-eng.doc,application/msword,145408,01/2017,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4612
+4613,PH13,"Application by a local authority site owner for determination of new level of pitch fee",ph13-eng.doc,application/msword,167936,01/2017,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4613
+4614,PH14,"Application under regulation 17 of the Mobile Homes (Site Rules) (England) Regulations 2014",ph14-eng.doc,application/msword,130560,01/2017,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4614
+4615,PH15,"Application under regulation 10 of the Mobile Homes (Site Rules) (England) Regulations 2014 ('the 2014 regulations') with regard to the proposed making, varying or deletion of a site rule or rules",ph15-eng.doc,application/msword,147968,01/2017,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4615
+4616,PH16,"Application under regulation 6 of the Mobile Homes (Site Licensing) (England) Regulations 2014 ('the 2014 regulations') with regard to the local authority's refusal to issue, or consent to the transfer of, a site licence",ph16-eng.doc,application/msword,132608,01/2017,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4616
+4617,PH17,"Application by a local authority under Section 5A(3) of the Caravan Sites and Control of Development Act 1960 (as amended) ('the Act') for an order as to payment of the annual site licence fee by the licence holder ('a payment order') OR an order for revocation of the site licence on the ground of non-compliance with a payment order",ph17-eng.doc,application/msword,133632,01/2017,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4617
+4618,PH18,"Appeal under Section 7 or 8 of the Caravan Sites and Control of Development Act 1960 (as amended) ('the Act') (1) with regard to conditions attached to a site licence or (2) to an alteration by the local authority of conditions attached to a licence",ph18-eng.doc,application/msword,142336,01/2017,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4618
+4619,PH19,"Appeal under the Caravan Sites and Control of Development Act 1960 (as amended) ('the Act') against: (1) a compliance notice served by a local authority under Section 9A of the Act with regard to an alleged breach of condition(s) attached to a site licence, or (2) the taking of emergency action by the local authority under Section 9E of the Act, or (3) the demand by a local authority for a charge under Section 9F of the Act in respect of action in default or emergency action",ph19-eng.doc,application/msword,144384,01/2017,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4619
+4630,Form 200,"Civil Appeals Office fees (from 18 April 2016)",form-200-eng.pdf,application/pdf,89134,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,989
+4635,LOC014,"Court fees for bankrupts",loc014-eng.pdf,application/pdf,144500,12/2008,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4635
+4640,Form 56C,"Court of Appeal Mediation Scheme - Fees Schedule",form-056c-eng.pdf,application/pdf,13988,10/2012,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4640
+4645,Gambling - Application for fee remission for companies,"Application for fee remission for companies",gambling-fee-exemption(company)-eng.pdf,application/pdf,20968,01/2010,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4645
+4650,EX504,"Graduated Fees Reference to a Judge",ex504-eng.pdf,application/pdf,383396,08/2009,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4650
+4660,UTLC Fees,"Upper Tribunal (Lands Chamber) fees table (from 18 April 2016)",utlc-fees-eng.pdf,application/pdf,73795,11/2016,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4660
+4724,SEND24,"EHC appeal form - child of or under statutory school age",send24-eng-2016.03.30.pdf,application/pdf,599191,02/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4724
+4725,SEND24A,"EHC appeal form - young person over statutory school age",send024a-eng.pdf,application/pdf,223063,06/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4725
+4726,SEND4B,"Disability Discrimination Claim by Young Person",send004b-eng.pdf,application/pdf,166358,09/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4726
+4727,SEND26A,"Disability discrimination claim after permanent exclusion - parent",send026a-eng.pdf,application/pdf,199651,09/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4727
+4728,SEND26B,"Disability discrimination claim after permanent exclusion - young person",send026b-eng.pdf,application/pdf,177797,09/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4728
+4729,SEND28,"Appeal form - child detained in youth accommodation",send28-eng-2016.03.01.pdf,application/pdf,130042,02/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4729
+4730,SEND28A,"Appeal form - young person under 18 detained in youth accommodation",send28a-eng-2016.03.01.pdf,application/pdf,221712,02/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4730
+4733,SEND 30,"Request for a Witness Summons",send030-eng.pdf,application/pdf,77852,07/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4733
+4734,EXN161,"Appellant's notice - Application for Permission to Appeal Under Sections 26, 28, 103, 105, 108 and 110 of the Extradition Act 2003",exn161-eng.doc,application/msword,62464,10/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4734
+4735,EXN162,"Respondent's notice - To an Application for Permission to Appeal Under Sections 26, 28, 103, 105, 108 and 110 of the Extradition Act 2003",exn162-eng.doc,application/msword,55808,10/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4735
+4736,EX244,"Application Notice - (Pursuant to the Extradition Act 2003)",ex244-eng.doc,application/msword,36864,10/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4736
+4737,SEND24B,"Appeal form - refusal to secure an EHC assessment - child of or under statutory school age",send24b-eng.pdf,application/pdf,235511,08/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4737
+4738,EX160A,"Sut i wneud cais am help i dalu ffioedd | How to apply for help with fees",ex160a-bil.pdf,application/pdf,193900,02/2017,26,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4738
+4750,REMO 7,"Application Form With a View to the Recognition, Declaration of Enforceability or Enforcement of a Decision in Matters Relating to Maintenance Obligations",remo007-eng.pdf,application/pdf,119793,10/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4750
+4751,REMO 8,"Application Form to Obtain or Have Modified a Decision in Matters Relating to Maintenance Obligations",remo008-eng.pdf,application/pdf,132901,10/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4751
+4752,UT3 Notes,"Notes for Appellants Form UT3 (Mental Health)",ut003-notes-eng.pdf,application/pdf,39430,11/2009,8,3,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4752
+4753,UT3 Leaflet,"Appealing Against a Decision of the Health, Education and Social Care Chamber of the First-tier Tribunal (Mental Health) (Appeals from Decisions of the First-tier Tribunal)",ut003-leaflet-eng.pdf,application/pdf,111679,04/2013,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4753
+4754,UT3 Leaflet,"Appealing Against a Decision of the Health, Education and Social Care Chamber of the First-tier Tribunal (Mental Health) (Appeals from Decisions of the First-tier Tribunal)",ut003-leaflet-eng.doc,application/msword,1787904,03/2013,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4754
+4755,UT4 Notes,"Notes for Appellants Form UT4 (Special Educational Needs and Disability Discrimination in Schools)",ut004-notes-eng.pdf,application/pdf,34204,10/2011,8,3,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4755
+4756,UT4 Leaflet,"Appealing Against a Decision of the Health, Education and Social Care Chamber of the First-tier Tribunal (Special Educational Needs) (Appeals from Decisions of the First-tier Tribunal)",ut004-leaflet-eng.pdf,application/pdf,67454,04/2014,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4756
+4757,UT5 Notes,"Notes for Applicants and Appellants Form UT5 (Health Education & Social Care Chamber Care Standards and NHS (Performers) List)",ut005-notes-eng.pdf,application/pdf,87807,05/2013,8,3,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4757
+4758,UT5 Leaflet,"Appealing to the Upper Tribunal Administrative Appeals Chamber from the First-tier Tribunal. Care Standards and NHS (Performers) List Decisions",ut005-leaflet-eng.pdf,application/pdf,117591,05/2013,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4758
+4759,UT6 Notes,"Notes for Appellants Form UT6 (War Pensions and Armed Forces Compensation)",ut006-notes-eng.pdf,application/pdf,30866,07/2012,8,3,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4759
+4760,UT6 Notes,"Notes for Appellants Form UT6 (War Pensions and Armed Forces Compensation)",ut006-notes-eng.doc,application/msword,54272,07/2012,8,3,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4760
+4761,UT6 Leaflet,"Appealing Against a Decision of the War Pensions and Armed Forces Compensation Chamber of the First-tier Tribunal (Appeals from Decisions of the First-tier Tribunal)",ut006-leaflet-eng.pdf,application/pdf,85785,07/2012,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4761
+4762,UT6 Leaflet,"Appealing Against a Decision of the War Pensions and Armed Forces Compensation Chamber of the First-tier Tribunal (Appeals from Decisions of the First-tier Tribunal)",ut006-leaflet-eng.doc,application/msword,1807360,04/2013,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4762
+4763,UT8 Notes,"Notes for Applicants and Appellants form UT8 (Mental Health Wales)",ut008-notes-eng.pdf,application/pdf,320445,04/2012,8,3,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4763
+4765,UT8 Leaflet,"Appealing Against a Decision of the Health, Education and Social Care Chamber of the First-tier Tribunal (Mental Health Wales) (Appeals from Decisions of the First-tier Tribunal)",ut008-leaflet-eng.pdf,application/pdf,64029,03/2014,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4765
+4766,UT9 Notes,"Notes for Applicants and Appellants Form UT9 (Appeals from Special Educational Needs Tribunal for Wales)",ut009-notes-eng.pdf,application/pdf,309844,04/2012,8,3,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4766
+4767,UT9 Leaflet,"Appealing Against a Decision of the Health, Education and Social Care Chamber of the First-tier Tribunal (Special Educational Needs Wales) (Appeals from Decisions of the First-tier Tribunal)",ut009-leaflet-eng.pdf,application/pdf,107267,05/2009,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4767
+4768,UT10 Leaflet,"Appeals against decisions of the Disclosure and Barring Service (Appeals direct to the Upper Tribunal)",ut10-leaflet-eng.pdf,application/pdf,185000,09/2016,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4768
+4770,UT11 Notes,"Notes for Applicants and Appellants Form UT11 (General Regulatory Chamber)",ut011-notes-eng.pdf,application/pdf,551704,11/2014,8,3,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4770
+4771,UT11 Leaflet,"All General Regulatory Chamber Cases Except Information Rights (Appeals from Decisions of the First-tier Tribunal)",ut011-leaflet-eng.pdf,application/pdf,419962,09/2015,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4771
+4772,UT12 Notes,"Notes for appellants form UT12 (Traffic Commissioner) appeals",ut12-notes-eng.pdf,application/pdf,404635,12/2016,8,3,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4772
+4773,UT12 Leaflet,"Appeals Against Decisions of the Traffic Commissioner (Appeals Direct to the Upper Tribunal)",ut012-leaflet-eng.pdf,application/pdf,167343,08/2009,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4773
+4774,UT13 Leaflet,"Appealing to the Administrative Appeals Chamber of the Upper Tribunal - Against Decisions of the First-Tier Tribunal in Information Rights Cases (General Regulatory Chamber)",ut013-leaflet-eng.pdf,application/pdf,245431,09/2014,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4774
+4780,Fee Account,"Fee Account - The Easy Way to Pay Fees",fee-account-eng.pdf,application/pdf,113727,06/2015,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4780
+4781,Secure Data Transfer,"Secure Data Transfer (SDT) - Using SDT to improve the service we offer",secure-data-transfer-eng.pdf,application/pdf,168835,04/2016,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4781
+4782,Fee Account FAQs,"Fee Account - Frequently Asked Questions",fee-account-faq-eng.pdf,application/pdf,548281,09/2016,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4782
+4783,Fee Account T&Cs,"Fee Account terms and conditions",fee-account-tc-eng-20160203.pdf,application/pdf,553525,01/2016,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4783
+4784,MCOL Guide,"Money Claim Online (MCOL) - User guide for claimants",mcol-guide-eng.pdf,application/pdf,378241,07/2016,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4784
+4800,CS A1,"Appeal application form - Child Care Providers and Children's Homes",csa001-eng.pdf,application/pdf,119605,07/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4800
+4801,CS R1,"Response to appeal application - for Justice of the Peace, Ofsted, Care quality commission (CGC), Care and Social Services Inspectorate Wales (CCSIW), Health Inspectorate Wales or a Child Minder Agency (CMA) cases",csr001-eng.pdf,application/pdf,84808,07/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4801
+4802,CS A2,"Appeal Application Form - Establishment Agencies",csa002-eng.pdf,application/pdf,125534,07/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4802
+4803,CS R2,"Response to appeal application - for all Welsh Ministers, Secretary of State - Department of Education cases",csr002-eng.pdf,application/pdf,79192,11/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4803
+4804,CS A3,"Appeal application form - Independent Schools/Non-maintained Special Schools",csa003-eng.pdf,application/pdf,117738,11/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4804
+4805,CS R3,"Response to appeal application - Secretary of State for All Inclusion on the Protection of Children (PoCA) or on the Protection of Vulnerable Adults (PoVA) List and Monitor",csr003-eng.pdf,application/pdf,80865,07/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4805
+4806,CS A4,"Appeal Application Form - Monitor",csa004-eng.pdf,application/pdf,109840,07/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4806
+4807,CS A90,"Appeal Application Form - Inclusion on the Protection of Children (PoCA) List",csa090-eng.pdf,application/pdf,122825,07/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4807
+4808,CS A91,"Appeal Application Form - Prohibition or Restriction From Participating in the Management of an Independent School Under Section 142 of the Education Act",csa091-eng.pdf,application/pdf,105243,07/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4808
+4809,CS R91,"Response to appeal application - Prohibition or Restriction from participating in the management of an independent school under Section 142 of the Education Act",csr091-eng.pdf,application/pdf,83582,07/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4809
+4810,CS P1,"Application for permission to appeal a decision of the First-tier Tribunal (Care Standards)",csp001-eng.pdf,application/pdf,89659,07/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4810
+4811,CS S1,"Application to set aside a decision of the First-tier Tribunal (Care Standards)",css001-eng.pdf,application/pdf,94644,07/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4811
+4812,CS WD,"Withdrawal Form (Except for PoCA and PoVA Cases)",cswd-eng.pdf,application/pdf,69738,07/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4812
+4827,SEND27,"Guidance for the Local Authority producing the hearing bundle",send27-eng.pdf,application/pdf,360004,04/2016,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4827
+4828,SEND28B,"Detained Children and Young People With SEN",send028b-eng.pdf,application/pdf,137251,05/2015,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4828
+4850,Crown Court Preliminary Hearing form,"Crown Court Preliminary Hearing Form (Section 28)",preliminary-hearing-eng.doc,application/msword,219136,09/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4850
+4851,Ground Rules Hearing Form,"Defence Ground Rules Hearing Form (Section 28)",ground-rules-hearing-eng.doc,application/msword,104448,10/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4851
+4852,T386,"Respondent's notice (Valuation Tribunal Appeal)",t386-eng.pdf,application/pdf,546967,01/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4852
+4853,SSCS6,"Notice of Appeal Against a Decision by the Scheme Administrator for the Diffuse Mesothelioma Payment Scheme",sscs006-eng.pdf,application/pdf,184551,10/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4853
+4900,T464,"Cais Amgen am Dystysgrif Cydnabod Rhyw",t464-cym.pdf,application/pdf,664728,06/2016,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,4900
+4901,T466,"Statutory Declaration for Applicants who are married",t466-eng.pdf,application/pdf,333129,10/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4901
+4902,T467,"Statutory Declaration for single Applicants",t467-eng.pdf,application/pdf,182470,10/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4902
+4903,T468,"Statutory Declaration for Applicants in a Civil Partnership",t468-eng.pdf,application/pdf,301555,10/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4903
+4904,T469,"Statutory Declaration for the Spouse of an Applicant for Gender Recognition",t469-eng.pdf,application/pdf,270091,10/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4904
+4910,N460,"Reasons for allowing or refusing permission to appeal (including referral to the Court of Appeal (Civil Division)), and information concerning routes of appeal",n460-eng.pdf,application/pdf,80648,10/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4910
+4915,N460HC,"Reasons for allowing or refusing permission to appeal and information concerning routes of appeal",n460hc-eng.pdf,application/pdf,73241,10/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4915
+4920,N325A,"Request for Warrant for Possession of Land following a Suspended Order for Possession",n325a-eng.pdf,application/pdf,69480,12/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4920
+5053,EU Article 53,"Certificate Concerning a Judgment in Civil and Commercial Matters",eu-article-053-eng.pdf,application/pdf,728949,01/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,5053
+5060,EU Article 60,"Certificate Concerning an Authentic Instrument Court Settlement in Civil and Commercial Matters",eu-article-060-eng.pdf,application/pdf,694967,01/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,5060
+5100,D89,"Cais am wasanaeth cyflwyno personol gan feili llys",d89-cym.pdf,application/pdf,76164,10/2016,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,5100
+5105,FP161A,"Nodiadau Canllaw ar Lenwi Ffurflen FP161 - Hysbysiad Apelydd",fp161a-cym.pdf,application/pdf,87715,10/2016,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,5105
+5110,FP161,"Hysbysiad apelydd",fp161-cym.pdf,application/pdf,139717,10/2016,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,5110
+5115,FP161B,"Nodiadau i Atebwyr",fp161b-cym.pdf,application/pdf,27827,10/2016,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,5115
+5120,FP162,"Hysbysiad atebydd",fp162-cym.pdf,application/pdf,121789,10/2016,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,5120
+5125,FP162A,"Nodiadau canllaw ar lenwi Ffurflen FP162 - Hysbysiad Atebydd",fp162a-cym.pdf,application/pdf,65887,10/2016,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,5125
+5130,FP244,"Rhybudd Cyflwyno Cais (I'w ddefnyddio mewn ceisiadau a wneir mewn apeliadau i Adran Deulu'r Uchel Lys)",fp244-cym.pdf,application/pdf,64759,10/2016,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,5130
+5135,FP200,"Ffioedd Achosion Teulu o 18 Ebrill 2016",fp200-cym.pdf,application/pdf,159502,10/2016,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,5135
+5145,FP201,"Llwybrau Apelio",fp201-cym.pdf,application/pdf,112907,10/2016,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,5145
+5155,FP202,"Sut i apelio i Adran Deulu'r Uchel Lys",fp202-cym.pdf,application/pdf,135779,10/2016,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,5155
+5165,FP244A,"Rhybudd Cyflwyno Cais (FP244) - Nodiadau Canllaw",fp244a-cym.pdf,application/pdf,47635,10/2016,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,5165
+5175,N161D,"Nodiadau canllaw ar lenwi ffurflen N161 - Hysbysiad Apelydd (pob apêl achos teulu yn y Llys Apêl (yr Adran Si l) a'r llys teulu)",n161d-cym.pdf,application/pdf,148313,10/2016,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,5175
+7000,COP1,"Ffurflen gais",cop001-cym.pdf,application/pdf,273240,08/2015,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,7000
+7060,COP7,"Cais i wrthwynebu cofrestru Atwrneiaeth Arhosol (LPA)",cop007-cym.pdf,application/pdf,111816,08/2015,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,7060
+7080,COP9,"Hysbysiad o gais",cop009-cym.pdf,application/pdf,72798,12/2013,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,7080
+7090,COP10,"Hysbysiad o gais ar gyfer ceisiadau i ymuno fel parti",cop010-cym.pdf,application/pdf,69982,12/2013,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,7090
+7130,COP14,"Achos yn eich cylch chi yn y Llys Gwarchod",cop014-cym.pdf,application/pdf,37352,12/2013,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,7130
+7196,COP20B,"Tystysgrif cyflwyno/dim cyflwyno hysbysu/dim hysbysu",cop020b-cym.pdf,application/pdf,121194,12/2013,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,7196
+7206,COP21B,"Y Llys Gwarchod: Nodiadau Canllaw ar gyfer llenwi ffurflen COP20B - Darllenwch y nodiadau canlynol cyn llenwi ffurflen COP20B",cop021b-cym.pdf,application/pdf,37180,01/2012,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,7206
+7220,COP23,"Tystysgrif methiant tyst neu wrthodiad gan dyst i fod yn bresennol gerbron archwiliwr",cop023-cym.pdf,application/pdf,62246,12/2013,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,7220
+7230,COP24,"Datganiad tyst",cop024-cym.pdf,application/pdf,47269,12/2013,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,7230
+7240,COP25,"Affidafid",cop025-cym.pdf,application/pdf,53760,12/2013,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,7240
+7270,COP28,"Hysbysiad o wrandawiad",cop028-cym.pdf,application/pdf,30153,01/2012,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,7270
+7280,COP29,"Hysbysiad o wrandawiad ar gyfer gorchymyn traddodi",cop029-cym.pdf,application/pdf,28314,01/2012,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,7280
+7290,COP30,"Hysbysiad newid cyfreithiwr",cop030-cym.pdf,application/pdf,63144,12/2013,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,7290
+7300,COP31,"Hysbysiad o fwriad i ffeilio tystiolaeth drwy ddeponiad",cop031-cym.pdf,application/pdf,45826,12/2013,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,7300
+7340,COP35,"Hysbysiad apelydd",cop035-cym.pdf,application/pdf,204200,12/2013,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,7340
+7350,COP36,"Hysbysiad atebydd",cop036-cym.pdf,application/pdf,138644,12/2013,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,7350
+7360,COP37,"Dadl fframwaith",cop037-cym.pdf,application/pdf,53387,12/2013,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,7360
+7430,COP44,"Y Llys Gwarchod - ffioedd",cop044-cym.pdf,application/pdf,155579,11/2015,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,7430
+7460,COP DLB,"Colli Rhyddid Datganiad brys eithriadol",cop-dlb-cym.pdf,application/pdf,98305,12/2013,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,7460
+7470,COP DLC,"Colli Rhyddid Ffurflen caniatad",cop-dlc-cym.pdf,application/pdf,51462,04/2009,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,7470
+7480,COP DLD,"Colli Rhyddid - Tystysgrif cyflwyno/dim cyflwyno; Tystysgrif hysbysu/dim hysbysu",cop-dld-cym.pdf,application/pdf,53265,04/2009,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,7480
+7490,COP DLE,"Colli Rhyddid - Cydnabyddiad cyflwyno/hysbysu",cop-dle-cym.pdf,application/pdf,63976,04/2009,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,7490
+7500,COP DOL10,"Cais i awdurdodi colli rhyddid (adran 4A(3) a 16(2)(a) o Ddeddf Galluedd Meddyliol 2005)",cop-dol010-cym.pdf,application/pdf,232300,10/2014,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,7500
+7510,COP GN1,"Ceisiadau am benodi dirprwy ar gyfer eiddo a materion ariannol",cop-gn001-cym.pdf,application/pdf,71565,12/2013,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,7510
+7520,COP GN2,"Arweiniad ar werthu eiddo y mae mwy nag un yn berchen arno",cop-gn002-cym.pdf,application/pdf,63448,08/2013,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,7520
+7530,COP GN3,"Nodyn Canllaw - Ceisiadau gan ddirprwyon cyfredol",cop-gn003-cym.pdf,application/pdf,56803,08/2013,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,7530
+7540,COP GN4,"Gwneud cais lles personol i'r Llys Gwarchod",cop-gn004-cym.pdf,application/pdf,74836,08/2013,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,7540
+7550,COP GN5,"Dod i Wrandawiad yn y Llys Gwarchod yn Llundain neu yn un o'n llysoedd rhanbarthol",cop-gn005-cym.pdf,application/pdf,37124,12/2013,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,7550
+7560,COP GN6,"Ceisiadau i'r Llys Gwarchod yng nghyswllt cytundebau tenantiaeth sengl a lluosog",cop-gn006-cym.pdf,application/pdf,45798,08/2013,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,7560
+7570,COP GN7,"Polisi rhestru - gwybodaeth i ddefnyddwyr y llys",cop-gn007-cym.pdf,application/pdf,56826,08/2013,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,7570
+7580,COP GN8,"Ceisiadau am Ewyllysiau Statudol, Rhoddion, Setliadau a thrafodion eraill yn ymwneud ag eiddo P",cop-gn008-cym.pdf,application/pdf,57522,08/2013,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,7580
+10000,COP1,"COP1 - Court of Protection Application Form",cop001-eng.pdf,application/pdf,134441,07/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,10000
+10001,COP1,"Ffurflen gais | Application form",cop01-bil.pdf,application/pdf,419661,03/2010,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,10001
+10010,COP1A,"COP1A - Annex A Supporting information for property and affairs applications",cop001a-eng.pdf,application/pdf,183652,07/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,10010
+10011,COP1A,"Atodiad A: Gwybodaeth ategol ar gyfer ceisiadau ynghylch eiddo a materion ariannol | Annex A: Supporting information for property and affairs applications",cop01a-bil.pdf,application/pdf,455301,03/2010,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,10011
+10020,COP1B,"COP1B - Annex B - Supporting information for personal welfare applications",cop001b-eng.pdf,application/pdf,117054,07/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,10020
+10021,COP1B,"Atodiad B: Gwybodaeth ategol ar gyfer ceisiadau lles personol | Annex B: Supporting information for personal welfare applications",cop01b-bil.pdf,application/pdf,233196,03/2010,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,10021
+10030,COP1C,"Annex C - Supporting information for statutory will, codicil, gift(s), deed of variation or settlement of property",cop001c-eng.pdf,application/pdf,111969,07/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,10030
+10040,COP1D,"Annex D - Supporting information for applications to appoint or discharge a trustee",cop001d-eng.pdf,application/pdf,104580,07/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,10040
+10050,COP1E,"Annex E - Supporting information for an application by existing deputy or attorney",cop001e-eng.pdf,application/pdf,100206,07/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,10050
+10060,COP1F,"Annex F - Supporting information relating to validity or operation of enduring power of attorney (EPA) or lasting power of attorney (LPA)",cop001f-eng.pdf,application/pdf,113175,07/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,10060
+10070,COP2,"Ffurflen ganiatad",cop002-cym.pdf,application/pdf,93857,10/2013,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,10070
+10071,COP2,"Ffurflen ganiatâd | Permission form",cop02-bil.pdf,application/pdf,116358,03/2010,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,10071
+10080,COP3,"Assessment of capacity",cop003-eng.pdf,application/pdf,307714,12/2013,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,10080
+10081,COP3,"Asesu gallu | Assessment of capacity",cop03-bil.pdf,application/pdf,230413,03/2010,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,10081
+10090,COP4,"COP4 - Deputy's declaration",cop004-eng.pdf,application/pdf,152658,09/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,10090
+10091,COP4,"Datganiad dirprwy | Deputy's declaration",cop04-bil.pdf,application/pdf,258800,03/2010,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,10091
+10100,COP5,"Acknowledgment of Service/Notification",cop005-eng.pdf,application/pdf,107612,07/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,10100
+10101,COP5,"Cydnabod cyflwyniad/hysbysiad | Acknowledgment of service/notification",cop05-bil.pdf,application/pdf,182207,03/2010,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,10101
+10120,COP7,"COP7 - Application to object to the registration of a Lasting Power of Attorney",cop007-eng.pdf,application/pdf,326588,07/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,10120
+10121,COP7,"Cais i wrthwynebu cofrestru Atwrneiaeth Arhosol (AA) | Application to object to the registration of a lasting power of attorney (LPA)",cop07-bil.pdf,application/pdf,219592,03/2010,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,10121
+10130,COP8,"Application relating to the registration of an enduring power of attorney (EPA)",cop008-eng.pdf,application/pdf,333743,07/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,10130
+10140,COP9,"COP9 - Application notice",cop009-eng.pdf,application/pdf,284977,07/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,10140
+10141,COP9,"Hysbysiad o gais | Application notice",cop09-bil.pdf,application/pdf,147748,03/2010,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,10141
+10150,COP10,"COP10 - Application notice for applications to be joined as a party",cop010-eng.pdf,application/pdf,281804,07/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,10150
+10151,COP10,"Hysbysiad o gais ar gyfer ceisiadau i ymuno fel parti | Application notice for applications to be joined as a party",cop10-bil.pdf,application/pdf,153905,03/2010,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,10151
+10170,COP12,"Special undertaking by trustees",cop12-eng-2016.03.08.pdf,application/pdf,239004,01/2012,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,10170
+10190,COP14,"Proceedings about you in the Court of Protection",cop14-eng-2016.03.08.pdf,application/pdf,241693,12/2013,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,10190
+10191,COP14,"Achos yn eich cylch yn y Llys Gwarchod | Proceedings about you in the Court of Protection",cop14-bil.pdf,application/pdf,97604,03/2010,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,10191
+10200,COP15,"Notice that an application form has been issued",cop15-eng-2016.03.08.pdf,application/pdf,243299,12/2013,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,10200
+10201,COP15,"Hysbysiad bod y ffurflen gais wedi'i chyhoeddi | Notice that an application form has been issued",cop15-bil.pdf,application/pdf,107490,03/2010,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,10201
+10250,COP20,"Tystysgrif cyflwyno/diffyg cyflwyno Tystysgrif hysbysu/diffyg hysbysu | Certificate of service/non-service Certificate of notification/non-notification",cop20-bil.pdf,application/pdf,281208,03/2010,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,10250
+10260,COP20A,"Certificate of notification/non-notification of the person to whom the proceedings relate",cop020a-eng.pdf,application/pdf,125358,07/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,10260
+10270,COP20B,"Certificate of service/non-service notification/non-notification",cop020b-eng.pdf,application/pdf,140797,07/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,10270
+10290,COP22,"COP22 - Certificate of suitability of litigation friend",cop022-eng.pdf,application/pdf,273929,07/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,10290
+10291,COP22,"Tystysgrif addasrwydd cyfaill cyfreitha | Certificate of suitability of litigation friend",cop22-bil.pdf,application/pdf,122504,03/2010,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,10291
+10300,COP23,"Certificate of failure or refusal of witness to attend before an examiner",cop23-eng-2016.03.08.pdf,application/pdf,310501,12/2013,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,10300
+10301,COP23,"Tystysgrif methiant neu wrthodiad gan dyst i fod yn bresennol gerbron arholwr | Certificate of failure or refusal of witness to attend before an examiner",cop23-bil.pdf,application/pdf,130790,03/2010,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,10301
+10310,COP24,"COP24 - Witness statement",cop024-eng.pdf,application/pdf,239486,09/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,10310
+10311,COP24,"Y Llys Gwarchod Datganiad Tyst | Court of Protection Witness statement",cop24-bil.pdf,application/pdf,109900,03/2010,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,10311
+10320,COP25,"COP25 - Affidavit",cop025-eng.pdf,application/pdf,270700,07/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,10320
+10321,COP25,"Affidafid | Affidavit",cop25-bil.pdf,application/pdf,117567,03/2010,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,10321
+10350,COP28,"Notice of hearing",cop28-eng-2016.03.08.pdf,application/pdf,259056,01/2012,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,10350
+10351,COP28,"Hysbysiad o wrandawiad | Notice of hearing",cop28-bil.pdf,application/pdf,93125,03/2010,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,10351
+10360,COP29,"Notice of hearing for committal order",cop29-eng-2016.03.08.pdf,application/pdf,47951,01/2012,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,10360
+10361,COP29,"Hysbysiad o wrandawiad ar gyfer gorchymyn traddodi | Notice of hearing for committal order",cop29-bil.pdf,application/pdf,84724,03/2010,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,10361
+10370,COP30,"COP30 - Notice of change of solicitor",cop030-eng.pdf,application/pdf,260198,07/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,10370
+10371,COP30,"Hysbysiad ynghylch newid twrnai | Notice of change of solicitor",cop30-bil.pdf,application/pdf,136203,03/2010,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,10371
+10380,COP31,"COP31 - Notice of intention to file evidence by deposition",cop031-eng.pdf,application/pdf,325926,07/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,10380
+10381,COP31,"Hysbysiad o fwriad i ffeilio tystiolaeth drwy ddeponiad | Notice of intention to file evidence by deposition",cop31-bil.pdf,application/pdf,109561,03/2010,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,10381
+10420,COP35,"Appellant's notice",cop035-eng.pdf,application/pdf,132673,07/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,10420
+10421,COP35,"Hysbysiad apelydd | Appellant's notice",cop35-bil.pdf,application/pdf,223363,03/2010,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,10421
+10430,COP36,"Respondent's notice",cop36-eng-2016.03.08.pdf,application/pdf,301436,12/2013,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,10430
+10431,COP36,"Hysbysiad apelydd | Respondent's notice",cop36-bil.pdf,application/pdf,205201,03/2010,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,10431
+10440,COP37,"Skeleton argument",cop037-eng.pdf,application/pdf,296375,07/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,10440
+10450,COP DLA,"Deprivation of Liberty Application Form - For urgent consideration",cop-dla-eng.pdf,application/pdf,420366,07/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,10450
+10460,COP DLB,"Deprivation of Liberty - Declaration of exceptional urgency",cop-dlb-eng.pdf,application/pdf,357023,07/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,10460
+10480,COP DLD,"Deprivation of liberty Certificate of service non service Certificate of notification non notification",cop-dld-eng.pdf,application/pdf,351365,07/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,10480
+10490,COP DLE,"Acknowledgment of service/notification",cop-dle-eng.pdf,application/pdf,356572,07/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,10490
+10500,COP DOL10,"Application to authorise a deprivation of liberty",cop-dol10-eng.pdf,application/pdf,292098,12/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,10500
+10510,LPA 008,"Notice to the Office of the Public Guardian of an application to object to registration of a lasting power of attorney made to the Court of Protection",lpa008-eng.pdf,application/pdf,351845,09/2011,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,10510
+12000,FGM001,"Application for a Female Genital Mutilation (FGM) Protection Order",fgm001-eng.pdf,application/pdf,121840,07/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,12000
+12010,FGM002,"Rhybudd o achos",fgm002-cym.pdf,application/pdf,28693,07/2015,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,12010
+12020,FGM003,"Application to vary, extend or discharge a Female Genital Mutilation (FGM) Protection Order",fgm003-eng.pdf,application/pdf,92166,07/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,12020
+12030,FGM004,"Gorchymyn Amddiffyn rhag Anffurfio Organau Cenhedlu Benywod (FGM)",fgm004-cym.pdf,application/pdf,41887,07/2015,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,12030
+12040,FGM005,"Application for a Warrant of Arrest - Female Genital Mutilation (FGM) Protection Order",fgm005-eng.pdf,application/pdf,63072,07/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,12040
+12050,FGM006,"Application for leave to apply for a Female Genital Mutilation (FGM) Protection Order",fgm006-eng.pdf,application/pdf,82874,07/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,12050
+12060,FGM007,"Application to be joined as, or cease to be, a party to a Female Genital Mutilation (FGM) Protection Order",fgm007-eng.pdf,application/pdf,106716,07/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,12060
+12065,FGM701,"Gorchmynion Amddiffyn rhag Anffurfio Organau Cenhedlu Benywod (FGM) - Canllawiau interim ar gyfer awdurdodau lleol fel trydydd parti perthnasol a gwybodaeth sy'n berthnasol i waith partneriaeth amlasiataethol",fgm701-cym.pdf,application/pdf,246232,08/2015,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,12065
+13000,FGM700,"Female Genital Mutilation (FGM) Protection Orders - How can they protect me? (Amharic)",fgm700-amh.pdf,application/pdf,335067,07/2015,1,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,13000
+13005,FGM700,"Female Genital Mutilation (FGM) Protection Orders - How can they protect me? (Arabic)",fgm700-ara.pdf,application/pdf,347839,07/2015,2,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,13005
+13015,FGM700,"Female Genital Mutilation (FGM) Protection Orders - How can they protect me? (Farsi)",fgm700-far.pdf,application/pdf,488583,07/2015,9,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,13015
+13020,FGM700,"Female Genital Mutilation (FGM) Protection Orders - How can they protect me? (French)",fgm700-fre.pdf,application/pdf,399729,07/2015,10,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,13020
+13025,FGM700,"Female Genital Mutilation (FGM) Protection Orders - How can they protect me? (Somali)",fgm700-som.pdf,application/pdf,231986,07/2015,19,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,13025
+13030,FGM700,"Female Genital Mutilation (FGM) Protection Orders - How can they protect me? (Swahili)",fgm700-swa.pdf,application/pdf,281224,07/2015,21,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,13030
+13035,FGM700,"Female Genital Mutilation (FGM) Protection Orders - How can they protect me? (Tigrigina)",fgm700-tir.pdf,application/pdf,409558,07/2015,22,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,13035
+13040,FGM700,"Female Genital Mutilation (FGM) Protection Orders - How can they protect me? (Turkish)",fgm700-tur.pdf,application/pdf,158428,07/2015,23,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,13040
+13045,FGM700,"Female Genital Mutilation (FGM) Protection Orders - How can they protect me? (Urdu)",fgm700-urd.pdf,application/pdf,297881,07/2015,24,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,13045
+14000,N1(CCFL),"Claim form Part 7 - Commercial Court Financial List",n001(ccfl)-eng.pdf,application/pdf,55693,10/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,14000
+14005,N1(CHFL),"Claim form Part 7- Chancery Division Financial List",n001(chfl)-eng.pdf,application/pdf,55757,10/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,14005
+14010,Guidance for misc out of court payments,"Guidance for miscellaneous payments out of court",out-of-court-payments(misc)-eng-20160202.pdf,application/pdf,518144,01/2016,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,14010
+14115,FP161A,"Guidance notes on completing form FP161 - Appellant's notice",fp161a-eng.pdf,application/pdf,92657,10/2016,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,14115
+14116,FP161B,"Notes for respondent",fp161b-eng.pdf,application/pdf,137000,10/2016,8,3,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,14116
+14117,FP162A,"Guidance notes on completing form FP162 - Respondent's notice",fp162a-eng.pdf,application/pdf,137000,10/2016,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,14117
+14118,FP200,"Family Proceedings fees from 18 April 2016",fp200-eng.pdf,application/pdf,137000,10/2016,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,14118
+14119,FP201,"Routes of appeal",fp201-eng.pdf,application/pdf,137000,10/2016,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,14119
+14120,FP202,"How  to appeal to the Family Division of the High Court",fp202-eng.pdf,application/pdf,137000,10/2016,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,14120
+14121,FP244A,"Guidance notes on completing form FP244 - Application notice",fp244a-eng.pdf,application/pdf,137000,10/2016,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,14121
+14122,N161D,"Guidance notes on completing form N161 ? Appellant?s notice (all family proceedings appeals in the court of appeal (Civil Division) and the family court)",n161d-eng.pdf,application/pdf,137000,10/2016,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,14122
+14123,T495,"Immigration and Appeals Tribunal fees guidance",t495-eng.pdf,application/pdf,187342,11/2016,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,14123
+14124,IAFT-5(DIA) Guide,"A guide to completing IAFT5(DIA) appeal form",iaft5(dia)-guide-eng.pdf,application/pdf,175735,12/2016,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,14124
+14800,N9(CCFL),"Acknowledgment of Service - Commercial Court Financial List",n009(ccfl)-eng.pdf,application/pdf,339809,10/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,14800
+14805,N9(CCCH),"Acknowledgment of Service - Chancery Division Financial List",n009(chfl)-eng.pdf,application/pdf,340062,10/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,14805
+15700,N208(CCFL),"Claim form - Commercial Court Financial List",n208(ccfl)-eng.pdf,application/pdf,53201,10/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,15700
+15705,N208(CHFL),"Claim form - Chancery Division Financial List",n208(chfl)-eng.pdf,application/pdf,53303,10/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,15705
+15720,N210(CCFL),"Acknowledgment of Service - Commercial Court Financial List",n210(ccfl)-eng.pdf,application/pdf,229466,10/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,15720
+15725,N210(CHFL),"Acknowledgment of Service - Chancery Division Financial List",n210(chfl)-eng.pdf,application/pdf,229648,10/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,15725
+15730,N211(CCFL),"Claim form Part 20 - Commercial Court Financial List",n211(ccfl)-eng.pdf,application/pdf,72479,10/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,15730
+15735,N211(CHFL),"Claim form Part 20 - Chancery Division Financial List",n211(chfl)-eng.pdf,application/pdf,54776,10/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,15735
+15750,N213(CCFL),"Acknowledgment of Service - Commercial Court Financial List",n213(ccfl)-eng.pdf,application/pdf,244418,10/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,15750
+15755,N213(CHFL),"Acknowledgment of Service - Chancery Division Financial List",n213(chfl)-eng.pdf,application/pdf,244543,10/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,15755
+16060,N244(CCFL),"Application notice - Commercial Court Financial List",n244(ccfl)-eng.pdf,application/pdf,76388,10/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,16060
+16065,N244(CHFL),"Application notice - Chancery Division Financial List",n244(chfl)-eng.pdf,application/pdf,76714,10/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,16065
+16270,N265(CCFL),"List of documents: standard disclosure - Commercial Court Financial List",n265(ccfl)-eng.pdf,application/pdf,220132,10/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,16270
+16275,N265(CHFL),"List of documents: standard disclosure - Chancery Division Financial List",n265(chfl)-eng.pdf,application/pdf,220782,10/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,16275
+16300,Precedent R,"Claimant budget discussion report",precedent(r)-eng.xlsx,application/vnd.ms-excel,11458,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,16300
+16303,COA bundle index A2,"Appeal from an Employment Appeal Tribunal",coa-a2-eng.doc,application/msword,30000,09/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,16303
+16306,COA bundle index B6,"First appeal in divorce financial remedies matters",coa-b6-eng.doc,application/msword,30000,09/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,16306
+16307,COA bundle index C3,"Appeal from the Competition Appeal Tribunal",coa-c3-eng.doc,application/msword,30000,09/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,16307
+16308,COA bundle index T2,"Appeal from the Special Immigration Appeal Commission",coa-t2-eng.doc,application/msword,31000,09/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,16308
+16309,COA bundle index A3/C3,"Appeal from the Upper Tribunal Administrative Appeals Chamber or Tax and Chancery Chamber",coa-a3c3-eng.doc,application/msword,30000,09/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,16309
+16310,COA bundle index C3,"Appeal from the Upper Tribunal Lands Chamber",coa-utc3-eng.doc,application/msword,30000,09/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,16310
+16311,COA bundle index B2/B5,"First appeal from the County Court",coa-b2b5-eng.doc,application/msword,29000,09/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,16311
+16312,COA bundle index A1/A2/A3,"First appeal from the High Court",coa-a1a2a3-eng.doc,application/msword,30000,09/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,16312
+16313,COA bundle index A2,"First appeal in a bankruptcy or insolvency matter",coa-ba2-eng.doc,application/msword,30000,09/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,16313
+16314,COA bundle index B3,"First appeal in a personal injury or clinical negligence matter",coa-b3-eng.doc,application/msword,30000,09/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,16314
+16315,COA bundle index B5,"Homelessness appeal",coa-b5-eng.doc,application/msword,29000,09/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,16315
+16316,COA bundle index A3a,"Intellectual property first appeal",coa-a3a-eng.doc,application/msword,30000,09/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,16316
+16317,COA bundle index A3b,"Intellectual property second appeal",coa-a3b-eng.doc,application/msword,30000,09/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,16317
+16318,COA bundle index C4/C1,"Judicial review appeal from the Administrative Court or Judicial Review of decision of Upper Tribunal",coa-c4c1-eng.doc,application/msword,36000,09/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,16318
+16319,COA bundle index C1/C4/T3,"Judicial review appeal from the Administrative Court",coa-c1c4t3-eng.doc,application/msword,41000,09/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,16319
+16320,COA bundle index B4,"First appeal in a child case",coa-b4-eng.doc,application/msword,30000,09/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,16320
+16321,COA bundle index C2/C3/A3,"Judicial review from the Upper Tribunal",coa-c2c3a3-eng.doc,application/msword,36000,09/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,16321
+16322,COA bundle index C6,"Judicial review of administrative review decision or appeal from UTIAC",coa-c6-eng.doc,application/msword,31000,09/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,16322
+16323,COA bundle index B2/B5,"Second appeal from County Court, except homelessness",coa-ccb2b5-eng.doc,application/msword,30000,09/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,16323
+16324,COA bundle index A1/A2/A3a,"Second appeal from the High Court",coa-a1a2a3a-eng.doc,application/msword,31000,09/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,16324
+16325,COA bundle index A2,"Second appeal in bankruptcy or insolvency matters",coa-sba2-eng.doc,application/msword,30000,09/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,16325
+16326,COA bundle index B4,"Second appeal in a child case",coa-sab4-eng.doc,application/msword,31000,09/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,16326
+16327,COA bundle index B6,"Second appeal in divorce financial remedies matters",coa-sab6-eng.doc,application/msword,33000,09/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,16327
+16328,COA bundle index B3,"Second appeal in personal injury or clinical negligence matters",coa-sab3-eng.doc,application/msword,30000,09/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,16328
+16332,FP161,"Appellant's notice (For use in appeals to the Family Division of the High Court)",fp161-eng.pdf,application/pdf,153000,10/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,16332
+16333,FP162,"Respondent's notice (For use in appeals in the Family Division of the High Court)",fp162-eng.pdf,application/pdf,137000,10/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,16333
+16334,FP244,"Application notice (For use in applications made within appeals to the Family Division of the High Court)",fp244-eng.pdf,application/pdf,137000,10/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,16334
+16335,IAFT-5(DIA),"Appeal to the First-tier Tribunal - Information sheet",iaft5(dia)-eng.doc,application/msword,309760,12/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,16335
+17000,A20,"Mabwysiadu: Canllaw i ddefnyddwyr y llys teulu",a020-cym.pdf,application/pdf,161927,04/2014,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,18
+17001,C20,"Atodiad i gais am orchymyn i gadw plentyn mewn Llety Diogel",c20-cym.pdf,application/pdf,25070,08/2016,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,77
+17002,CB2,"Gwrandawiadau brys a gwrandawiadau heb rybudd mewn perthynas a threfniadau plant",cb002-cym.pdf,application/pdf,129930,07/2014,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,94
+17003,D63,"Judgment summons",d063-eng.pdf,application/pdf,119339,04/2011,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,134
+17004,EX20,"Talu fy nyfarniad - Beth ddylwn i wneud? | Paying my judgment, what do I do?",ex020-bil.pdf,application/pdf,251340,04/2006,26,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,177
+17005,EX301,"Yn gwneud hawliad? Ambell gwestiwn i chi ofyn i chi'ch hun | Making a claim? Some questions to ask yourself",ex301-bil.pdf,application/pdf,279782,04/2006,26,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,181
+17006,EX303,"Mae hawliad wedi'i wneud yn fy erbyn - beth ddylwn i ei wneud? | A claim has been made against me, what should I do?",ex303-bil.pdf,application/pdf,267464,04/2006,26,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,189
+17007,EX304,"Dim ateb i fy ffurflen hawliad - Beth ddylwn i wneud? | No reply to my claim form, what should I do?",ex304-bil.pdf,application/pdf,240093,04/2006,26,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,193
+17008,EX350,"Canllawiau i fusnesau bach ar gyfer adennill dyled drwy'r llys sirol | A guide to debt recovery through a county court for small businesses",ex350-bil.pdf,application/pdf,179855,04/2006,26,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,263
+17009,EX550,"Affidafid (gorchymyn i ddod i'r llys ar gyfer holi a gorchymyn traddodi gohiriedig) | Affidavit (order to attend for questioning and suspended committal order)",ex550-bil.pdf,application/pdf,188434,03/2002,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,270
+17010,N117,"Ffurflen Gyffredinol Ymgymeriad | General form of undertaking",n117-bil.pdf,application/pdf,54628,10/2012,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,346
+17011,N316,"Cais am orchymyn i ddyledwr ddod i'r llys ar gyfer holi",n316-cym.pdf,application/pdf,137656,06/2016,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,547
+17012,PA2,"How to obtain probate, a guide for people acting without a solicitor",pa2-eng.pdf,application/pdf,436147,10/2016,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,740
+17013,PA4,"Directory of Probate Registries and interview venues",pa4-eng.pdf,application/pdf,261040,03/2017,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,744
+17014,Pre-trial Checklist,"Pre-trial Checklist",pretrial-eng.doc,application/msword,19968,04/2005,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,897
+17015,EX50A,"Rhestr lawn o ffioedd sy'n gymwys yn y Llysoedd Sifil a Theulu (o 25 mis Gorffennaf 2016)",ex50a-cym.doc,application/msword,928768,07/2016,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,921
+17016,EX302,"Sut mae gwneud hawliad yn y llys? I bobl sydd am fynd ag anghydfod i'r llys",ex302-cym.pdf,application/pdf,149047,04/2014,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,993
+17017,EX320,"Dyfarniad cofrestredig - Beth mae hynny'n ei olygu?",ex320-cym.pdf,application/pdf,139924,04/2013,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,996
+17018,A21,"Mabwysiadu Rhyng-wladol a Chytundeb yr Hag 1993",a021-cym.pdf,application/pdf,177276,04/2014,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,1002
+17019,A51 Nodiadau | A51 Notes,"Cais i amrywio gorchymyn lleoli (Ffurflen 51) Nodiadau ar lenwi'r ffurflen | Application for variation of a placement order (Form A51) Notes on completing the form",a051-notes-bil.pdf,application/pdf,101066,12/2005,26,3,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,1004
+17020,A57 Nodiadau | A57 Notes,"Cais am orchymyn dychwelyd plentyn (Ffurflen A57) Nodiadau ar lenwi'r ffurflen | Application for a recovery order (Form A57) Notes on completing the form",a057-notes-bil.pdf,application/pdf,113887,12/2005,26,3,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,1007
+17021,AJ20,"Siarter Llysoedd - Y Llysoedd Sifil",aj20-cym.pdf,application/pdf,203710,11/2006,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,1011
+17022,AJ24,"Siarter Llysoedd - Y Gwasanaeth Profiant",aj24-cym.pdf,application/pdf,162548,11/2007,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,1013
+17023,AJ25,"Siarter Llysoedd - Llysoedd Teulu",aj25-cym.pdf,application/pdf,209612,12/2006,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,1014
+17024,AJ26,"Siarter Llysoedd - Y Llys Ynadon",aj26-cym.pdf,application/pdf,184190,11/2006,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,1015
+17025,5222,"Eich canllaw i Wasanaeth Rheithgor",5222-cym.pdf,application/pdf,216535,02/2015,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,1016
+17026,AJ22,"Courts Charter - The Royal Courts of Justice",aj22-eng.pdf,application/pdf,195164,10/2008,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,1018
+17027,AJ24,"Courts Charter - The Probate Service",aj24-eng.pdf,application/pdf,204235,11/2007,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,1020
+17028,PA1A,"Nodiadau canllaw ar gyfer y Ffurflen Gais am Brofiant PA1 | Guidance Notes for Probate Application Form PA1",pa001a-bil.pdf,application/pdf,193885,12/2008,26,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,1024
+17029,N162A,"Nodiadau cyfarwyddiadol ar gyfer llenwi rhybudd yr atebydd | Guidance notes for completing the respondent's notice",n162a-bil.pdf,application/pdf,344677,04/2007,26,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,1025
+17030,N461 Nodiadau | N461 Notes,"Nodiadau canllaw ar lenwi'r ffurflen hawlio Adolygiad Barnwrol | Guidance notes on completing the Judicial Review claim form",n461-notes-bil.pdf,application/pdf,196019,05/2009,26,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,1026
+17031,MC100,"Make Sure You Can Pay Your Fine (Polish)",mc100-pol.pdf,application/pdf,519635,12/2013,15,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,1028
+17032,ADM21,"Declaration as to inability of a defendant to file and serve statement of case under a decree of limitation",adm021-eng.pdf,application/pdf,75284,03/2002,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,1029
+17033,5222A,"Yn gefn ichi Drwy'ch Gwasanaeth Rheithgor",5222a-cym.pdf,application/pdf,143219,01/2015,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,1029
+17034,N211C(CC) Nodiadau,"Nodiadau i ddiffynnydd Rhan 20 ar ymateb i ffurflen hawlio Rhan 20 (Y Llys Masnachol)/Notes for Part 20 defendant on replying to the Part 20 claim form (Commercial Court)",n211c(cc)-cym.pdf,application/pdf,180833,10/2008,25,3,false,1,2017-03-17,W_GetForm.do?court_forms_id=,1030
+17035,LOC002,"I Want to challenge the outcome of an election and how do I apply for relief",loc002-eng.pdf,application/pdf,162915,08/2014,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,1031
+17036,PA5,"Do I need a Grant of Representation (Probate or Letters of Administration)? A guide for people dealing with the estate when someone has recently died",pa005-eng.pdf,application/pdf,345315,04/2011,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,1032
+17037,PA5,"A oes angen grant cynrychiolaeth arnaf (profiant neu lythyrau gweinyddu)? Arweiniad i bobl sy'n delio a'r ystad pan fo rhywun wedi marw'n ddiweddar",pa005-cym.pdf,application/pdf,195946,04/2011,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,1032
+17038,PA7,"How to deposit a will with the Probate Service, a guide for people who want to deposit a will for safekeeping",pa007-eng.pdf,application/pdf,266446,04/2011,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,1033
+17039,PA7,"Sut i adneuo ewyllys gyda'r Gwasanaeth Profiant. Arweiniad i bobl sydd am adneuo ewyllys i fod dan ofal sicr",pa007-cym.pdf,application/pdf,154300,04/2011,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,1033
+17040,PA8,"How to enter a caveat, a guide for people who want to challenge an application for grant on an estate",pa008-eng.pdf,application/pdf,236943,04/2011,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,1034
+17041,PA8,"Sut i gofnodi cafeat. Arweiniad i bobl sydd am herio cais am grant ar ystad",pa008-cym.pdf,application/pdf,173011,04/2011,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,1034
+17042,PA9,"Sut i gychwyn chwiliad cyffredinol",pa009-cym.pdf,application/pdf,162230,04/2011,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,1035
+17043,FL701,"Gorchmynion Amddiffyn rhag Priodas dan Orfod - Sut y gallant fy amddiffyn?",fl701-cym.pdf,application/pdf,162454,06/2014,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,1037
+17044,ADM1C,"Nodiadau I'r diffynnydd ar ymateb i ffurflen hawlio'r Morlys/Notes for defendant on replying to an admiralty claim form",adm001(c)-cym.pdf,application/pdf,201506,10/2008,25,3,false,1,2017-03-17,W_GetForm.do?court_forms_id=,1042
+17045,CB6,"Canllaw i egluro rhai geiriau ac ymadroddion a ddefnyddir mewn achosion preifat sy'n ymwneud a phlant",cb6-cym.pdf,application/pdf,279872,07/2015,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,1046
+17046,A61 Nodiadau | A61 Notes,"Cais am orchymyn cyfrifoldeb rhiant cyn mabwysiadu dramor (Ffur en A61). Nodiadau ar lenwi'r ffur en | Application for an order for parental responsibilty prior to adoption abroad (Form A61). Notes on completing the form",a61-notes-bil.pdf,application/pdf,192589,11/2016,26,3,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,1070
+17047,A58 Nodiadau | A58 Notes,"Cais am orchymyn mabwysiadu (Ffur en A58), nodiadau ar lenwi'r ffur en | Application for an adoption order (Form A58). Notes on completing the form",a58-notes-bil.pdf,application/pdf,212673,11/2016,26,3,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,1071
+17048,EX107 Gwybodaeth | EX107 Info,"Canllawiau, Rhestr y Panel Trawsgrifio a Phrisiau | Guidance, transcription panel list and prices",ex107-info-bil-20160128.pdf,application/pdf,153776,01/2016,26,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,1074
+17049,D191,"Ynglyn a dirymiad",d191-cym.pdf,application/pdf,187331,04/2014,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,1500
+17050,UT8 Nodiadau,"Nodiadau i Geiswyr ac Apelyddion Ffurflen UT8",ut008-notes-cym.pdf,application/pdf,236668,04/2012,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,1520
+17051,5138,"Cais am ymestyn gorchymyn cynrychiolaeth i fwy nag un eiriolwr neu i CF yn unig (Rheoliad 18 o'r Rheoliadau Cymorth Cyfreithiol Troseddol (Penderfyniadau gan Lys a Dewis Cynrychiolydd) 2013 fel y'u diwygiwyd)",5138-cym.doc,application/msword,274944,04/2014,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,2270
+17052,C19,"Cais am warant cymorth",c019-cym.pdf,application/pdf,950,09/2009,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,2386
+17053,D8D Nodiadau | D8D Notes,"Nodiadau canllaw ar lenwi deiseb am orchymyn/ddyfarniad rhagdybiaeth o farwolaeth a diddymu'r briodas/bartneriaeth sifil | Supporting notes for guidance on completing a petition for a presumption of death decree/order and dissolution of the marriage/civil partnership",d008d-notes-bil.pdf,application/pdf,182162,01/2014,26,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2400
+17054,D8N Nodiadau | D8N Notes,"Nodiadau canllaw ar gyfer llenwi deiseb dirymu | Supporting notes for guidance on completing a nullity petition",d008n-notes-bil.pdf,application/pdf,172286,04/2014,26,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2401
+17055,Ffurflen E Nodiadau | Form E Notes,"Datganiad ariannol am orchymyn ariannol neu am gymorth ariannol ar ol ysgariad neu ddiddymiad dramor ayb | Financial statement for a financial order or for financial relief after an overseas divorce or dissolution etc",form-e-notes-bil.pdf,application/pdf,172558,01/2014,26,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2402
+17056,Gwys Rheithgor,"Gwys Rheithgor",jury-summons-cym.pdf,application/pdf,247191,05/2011,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,2403
+17057,FP1A,"Nodiadau ar gyfer ceisydd ar lenwi'r cais (Ffurflen FP1) | Notes for applicant on completing the application (Form FP1)",fp001a-bil.pdf,application/pdf,143703,04/2011,26,3,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2403
+17058,C110,"Cais am orchymyn gofal neu oruchwylio dan Ddeddf Plant 1989 | Application under the Children Act 1989 for a care or supervision order",c110-bil.pdf,application/pdf,420515,04/2010,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2404
+17059,D191,"About Annulment",d191-eng.pdf,application/pdf,215383,04/2014,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2500
+17060,MC100,"Gwnewch yn siwr y gallwch dalu eich dirwy",mc100-cym.pdf,application/pdf,214447,12/2013,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,2501
+17061,C5,"Cais yn ymwneud a chofrestriad gwarchodwr plant neu ddarparwr gofal dydd | Application concerning the registration of a child-minder or provider of day-care",c005-bil.pdf,application/pdf,227581,04/2011,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2502
+17062,D258B,"Cais am asesiad manwl (Costau'n daladwy o gronfa ar wahan i Gronfa'r Gwasanaeth Cyfreithiol Cymunedol) | Request for detailed assessment (Costs payable out of a fund other than the Community Legal Service Fund)",d258b-bil.pdf,application/pdf,75436,04/2011,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2510
+17063,D258C,"Cais am wrandawiad asesu manwl yn unol a gorchymyn o dan Rhan III Deddf Cyfreithwyr 1974 | Request for detailed assessment hearing pursuant to an order under Part III of the Solicitors Act 1974",d258c-bil.pdf,application/pdf,77696,04/2011,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2511
+17064,D50,"Hysbysiad o gais ar sail methu â darparu cynhaliaeth resymol neu ar gyfer newid cytundeb cynhaliaeth yn ystod oes y partion | Notice of application on ground of failure to provide reasonable maintenance or for alteration of maintenance agreement during parties' lifetime",d050-bil.pdf,application/pdf,168485,04/2012,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2513
+17065,D50A,"Rhybudd o achos a chydnabyddiad cyflwyno dan adran 17 Deddf Eiddo Gwragedd Priod 1882/adran 66 Deddf Partneriaeth Sifil 2004 | Notice of proceedings and acknowledgement of service under section 17 of the Married Women's Property Act 1882/section 66 of the Civil Partnership Act 2004",d050a-bil.pdf,application/pdf,221235,04/2012,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2514
+17066,D50B,"Cais dan adran 17 Deddf Eiddo Gwragedd Priod 1882/adran 66 Deddf Partneriaeth Sifil 2004/Cais i drosglwyddo tenantiaeth dan Ddeddf Cyfraith Teulu 1996 | Application under section 17 of The Married Women's Property Act 1882/section 66 of the Civil Partnership Act 2004/Application to transfer a tenancy under The Family Law Act 1996",d050b-bil.pdf,application/pdf,214763,04/2012,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2515
+17067,EX327,"Mae gen i orchymyn cynhaliaeth ond nid ywn cael ei dalu | I've got a maintenance order but its not being paid",ex327-bil.pdf,application/pdf,294306,07/2011,26,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2518
+17068,D50H,"Cais am newid cytundeb cynhaliaeth yn ystod oes y partion | Application for alteration of maintenance agreement during parties lifetime",d050h-bil.pdf,application/pdf,142089,01/2014,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2520
+17069,D50J,"Cais am orchymyn yn atal osgoi dan adran 32L Deddf Cynnal Plant 1991 | Application for an order preventing avoidance under section 32L of the Child Support Act 1991",d050j-bil.pdf,application/pdf,218388,04/2011,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2521
+17070,D62,"Cais am godi gwys dyfarniad | Request for issue of judgment summons",d062-bil.pdf,application/pdf,185729,04/2011,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2523
+17071,D70,"Cais am ddatganiad am statws priodasol/partneriaeth sifil | Application for declaration of marital/civil partnership status",d070-bil.pdf,application/pdf,183433,01/2014,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2524
+17072,Ffurflen I | Form I,"Hysbysiad o gais am orchymyn taliadau cyfnodol ar yr un gyfradd a gorchymyn am gynhaliaeth tra disgwylir canlyniad achos | Notice of request for periodical payments order at same rate as order for maintenance pending outcome of proceedings",form-i-bil.pdf,application/pdf,133859,04/2011,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2530
+17073,FP1,"Cais dan Ran 19 Rheolau Trefniadaeth Teulu 2010 | Application under Part 19 of the Family Procedure Rules 2010",fp001-bil.pdf,application/pdf,161445,04/2011,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2531
+17074,FP5,"Cydnabyddiad cyflwyno Cais dan Ran 19 Rheolau Trefniadaeth Teulu 2010 | Acknowledgment of service Application under Part 19 of the Family Procedure Rules 2010",fp005-bil.pdf,application/pdf,223879,04/2011,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2532
+17075,T118,"Information for Victims",t118-eng.pdf,application/pdf,320825,04/2012,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2540
+17076,T122,"Information for non-restricted patients detained under the Mental Health Act 1983",t122-eng.pdf,application/pdf,173390,08/2016,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2544
+17077,T116 Notes,"Role of the Independent Mental Health Advocate (IMHA) in First-tier Tribunal (Mental Health) Hearings",t116-notes-eng.pdf,application/pdf,225858,07/2012,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2600
+17078,T420,"Making a claim to an Employment Tribunal",t420-eng.pdf,application/pdf,429907,03/2017,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2622
+17079,T421,"Your claim - what next",t421-eng.pdf,application/pdf,214483,03/2017,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2623
+17080,T422,"Responding to a claim to an Employment Tribunal",t422-eng.pdf,application/pdf,277315,03/2017,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2624
+17081,T423,"Responding to a claim to an Employment Tribunal (Details of a hearing to be sent)",t423-eng.pdf,application/pdf,274475,03/2017,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2625
+17082,T424,"The hearing - guidance for claimants",t424-eng.pdf,application/pdf,253397,03/2017,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2626
+17083,C100,"Cais o dan adran 8 Deddf Plant 1989 am orchymyn trefniadau plant, gorchymyn camau gwaharddedig, gorchymyn mater penodol neu i amrywio neu ddiddymu neu ofyn am ganiata&amp;#770;d i roi gorchymyn adran 8 | Application under section 8 of the Children Act 1989 for a child arrangements, prohibited steps, specific issue order or to vary or discharge or ask permission to make a section 8 order",c100-bil.pdf,application/pdf,246617,06/2016,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2627
+17084,T426,"The judgment",t426-eng.pdf,application/pdf,279199,03/2017,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2628
+17085,SEND4,"How to Claim Against Disability Discrimination in Schools - a Guide for Young People",send004-eng.pdf,application/pdf,356310,11/2014,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2641
+17086,T129,"Your Rights to Legal Representation and to See the Tribunal Doctor",t129-eng.pdf,application/pdf,186100,04/2014,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2642
+17087,SEND5,"Coming to the Tribunal",send005-eng.pdf,application/pdf,204032,09/2012,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2643
+17088,SEND15,"Guidance for Parents Claiming Expenses",send015-eng.pdf,application/pdf,150234,09/2014,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2644
+17089,SEND16,"Guidance for Witnesses Claiming Expenses",send016-eng.pdf,application/pdf,219734,09/2014,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2645
+17090,Going to a Magistrates' Court,"Going to a Magistrates' Court - Information for People with Learning Disabilities",going-to-magistrates-court-eng.pdf,application/pdf,3043314,05/2012,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2646
+17091,N322A Guidance Notes,"Guidance notes for completing form N322A",n322a-notes-eng.pdf,application/pdf,193364,06/2009,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2647
+17092,N322B Guidance Notes,"Guidance notes for completing form N322B",n322b-notes-eng.pdf,application/pdf,128921,06/2009,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2648
+17093,N322A Nodiadau Canllaw | N322A Guidance Notes,"Nodiadau canllaw ar gyfer llenwi'r ffurflen gais i orfodi penderfyniad neu setliad amodol ACAS (Ffurflen COT3) mae angen caniatâd y llys arno i fynd rhagddo | Notes for guidance on completing the application form to enforce a decision or ACAS conditional settlement (Form COT3) that requires permission of the court to proceed",n322a-notes-bil.pdf,application/pdf,168974,06/2009,26,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2649
+17094,N322B Nodiadau Canllaw | N322B Guidance Notes,"Nodiadau canllaw ar gyfer llenwi'r ffurflen gais i orfodi penderfyniad neu setliad amodol ACAS (Ffurflen COT3) nad oes angen caniatâd y llys arno i fynd rhagddo | Notes for guidance on completing the application form to enforce a decision or ACAS settlement (Form COT3) that does not require permission of the court to proceed",n322b-notes-bil.pdf,application/pdf,168418,06/2009,26,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2650
+17095,A60 Nodiadau | A60 Notes,"Cais am orchymyn mabwysiadu (ac eithrio gorchymyn mabwysiadu dan y Cytundeb) (Ffur en A60). Nodiadau ar lenwi'r ffur en | Application for an adoption order (excluding a Convention adoption order) (Form A60). Notes on completing the form",a60-notes-bil.pdf,application/pdf,186630,11/2016,26,3,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2651
+17096,ADM15B,"Nodiadau i'r diffynnydd (hawliad cyfyngu'r Morlys) | Notes for defendant (admiralty limitation claim)",adm15(b)-bil.pdf,application/pdf,167893,10/2008,26,3,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2652
+17097,SEND15YP,"Guidance for a young person claiming expenses",send15yp-eng.pdf,application/pdf,147722,09/2016,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2653
+17098,T130,"When can I apply to or be referred to the Tribunal for a hearing?",t130-eng.pdf,application/pdf,553174,06/2015,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2654
+17099,N67,"Judgment summons (Debtors Act 1869)",n067-eng.pdf,application/pdf,206133,04/2006,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2667
+17100,D50K,"Hysbysiad o Gais am Orfodaeth drwy ddull gorfodi a ystyrir yn briodol gan y llys Rheolau Trefniadaeth Teulu 2010 Rheol 33.3(2)(b) | Notice of Application for Enforcement by such method of enforcement as the court may consider appropriate Family Procedure Rules 2010 Rule 33.3(2)(b)",d50k-bil.pdf,application/pdf,137219,06/2016,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2670
+17101,T451,"Canllawiau ynghylch llenwi'r ffurflen gais am Dystysgrif Cydnabod Rhyw",t451-cym.pdf,application/pdf,631152,06/2016,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,2683
+17102,Ffurflen E Canllawiau,"Ffurflen E Nodiadau",form-e-notes-cym.pdf,application/pdf,224807,04/2013,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,2703
+17103,T242,"Making an Appeal Explanatory Booklet",t242-eng.pdf,application/pdf,555602,03/2015,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2705
+17104,T248,"Guidance Notes on Completing the First-tier Tribunal Application for Permission to Appeal to the Upper Tribunal",t248-eng.pdf,application/pdf,529235,03/2015,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2706
+17105,Precedent H Guidance Notes,"Precedent H guidance notes",precedent(h)-notes-eng.doc,application/msword,53248,04/2016,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2723
+17106,EX375,"Gorchymyn Gorfodi Ewropeaidd (EEO)",ex375-cym.pdf,application/pdf,75188,04/2014,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,2724
+17107,Eich apêl - Y Camau Nesaf,"Eich apêl - Y Camau Nesaf",information-leaflet-cym.pdf,application/pdf,71449,10/2013,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,2726
+17108,SSCS1A,"Sut i apelio yn erbyn penderfyniad a wnaed gan yr Adran Gwaith a Phensiynau",sscs001a-cym.pdf,application/pdf,284632,07/2015,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,2727
+17109,T481 Nodiadau,"Nodiadau cyfarwyddyd ar gyfer llenwi ffurflen hawlio'r Adolygiad Barnwrol",t481-notes-cym.pdf,application/pdf,237890,08/2013,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,2728
+17110,T108A,"Guide to Telephone Case Management Hearing, Statements, Bundles and Witness Templates",t108a-eng.pdf,application/pdf,184813,10/2014,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2731
+17111,Ffurflen Ymholiadau,"Ffurflen Ymholiadau",appellent-enquiry-form-cym.pdf,application/pdf,42585,10/2013,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,2731
+17112,T110,"Application to First-tier Tribunal (Mental Health) Mental Health Act 1983 (as amended)",t110-eng.doc,application/msword,68096,05/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2732
+17113,D440,"Cais am chwiliad am Ddyfarniad Absoliwt Ysgariad",d440-cym.pdf,application/pdf,357855,08/2014,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,2732
+17114,Ffurflen Ymholiadau,"Ffurflen Cyswllt (Pleidiau eraill)",other-party-enquiry-form-cym.pdf,application/pdf,41190,10/2013,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,2732
+17115,T110 Guardianship,"Guardianship - Application to First-Tier Tribunal (Mental Health) Mental Health Act 1983 (As Amended)",t110-guardianship-eng.doc,application/msword,65024,03/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2733
+17116,CB5,"Ceisiadau sy'n ymwneud a gorfodi gorchymyn trefniadau plant",cb005-cym.pdf,application/pdf,208998,08/2014,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,2733
+17117,SSCS1,"Hysbysiad o apêl yn erbyn penderfyniad yr Adran Gwaith a Phensiynau (Nawdd Cymdeithasol a Chynnal Plant)",sscs1-cym.pdf,application/pdf,109586,09/2013,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,2733
+17118,T111,"Referral to First-tier Tribunal (Mental Health) Mental Health Act 1983 (as amended)",t111-eng.doc,application/msword,72192,11/2011,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2734
+17119,SSCS1,"Hysbysiad o apêl yn erbyn penderfyniad yr Adran Gwaith a Phensiynau (Print Bras)",sscs001-large-cym.pdf,application/pdf,173250,04/2013,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,2734
+17120,SSCS2,"Hysbysiad o apêl yn erbyn penderfyniad yr Adran Gwaith a Phensiynau - y Grwp Cynhaliaeth Plant (Print Bras)",sscs002-large-cym.pdf,application/pdf,187577,08/2013,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,2735
+17121,CB1,"Gwneud cais (Plant a'r llysoedd teulu)",cb001-cym.pdf,application/pdf,300949,04/2014,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,2736
+17122,SSCS2,"Hysbysiad o apêl yn erbyn penderfyniad yr Adran Gwaith a Phensiynau - y Grwp Cynhaliaeth Plant",sscs002-cym.pdf,application/pdf,108803,08/2013,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,2736
+17123,T480,"Adolygiad Barnwrol - Ffurflen Hawlio",t480-cym.pdf,application/pdf,99894,06/2016,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,2737
+17124,T540,"Guidance on rent cases, general information about the process",t540-eng.pdf,application/pdf,486387,01/2017,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2738
+17125,T436,"Ffioedd Tribiwnlys Cyflogaeth ar gyfer grwpiau a mwy nag un hawliad (O'r 29 Gorffennaf 2013 ymlaen)",t436-cym.pdf,application/pdf,229700,03/2015,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,2738
+17126,T482,"Adolygiad Barnwrol - Cydnabyddiad Cyflwyno",t482-cym.pdf,application/pdf,80929,08/2016,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,2738
+17127,T437,"Ffioedd y Tribiwnlys Apeliadau Cyflogaeth",t437-cym.pdf,application/pdf,152509,04/2014,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,2739
+17128,T483,"Adolygiad Barnwrol - Cais am ystyriaeth frys",t483-cym.pdf,application/pdf,138986,08/2013,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,2739
+17129,T542,"Guidance on enfranchisement. General information about the process",t542-eng.pdf,application/pdf,454339,01/2017,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2740
+17130,EX731,"Paratoi ar gyfer cyfryngu dros y ffon",ex731-cym.pdf,application/pdf,146533,04/2014,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,2740
+17131,T484,"Hysbysiad cyflwyno cais (Uwch Dribiwnlys Y Siambr Mewnfudo a Lloches)",t484-cym.pdf,application/pdf,77709,06/2016,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,2740
+17132,T543,"Guidance on Housing Act 2004 Cases. General information about the process",t543-eng.pdf,application/pdf,532244,01/2017,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2741
+17133,T485,"Datganiad o dan Reol 28A (2)(b) yr Uwch Dribiwnlys",t485-cym.pdf,application/pdf,57645,08/2016,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,2741
+17134,T544,"Guidance on park homes and sites cases. General information about the process",t544-eng.pdf,application/pdf,466095,01/2017,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2742
+17135,T486,"Rhybudd newid cyfreithiwr",t486-cym.pdf,application/pdf,116578,08/2013,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,2742
+17136,T545,"Guidance on recognition of Tenants' Association. General information about the process",t545-eng.pdf,application/pdf,429412,01/2017,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2743
+17137,CB3,"Cyflwyno'r ffurflenni - Deddf Plant 1989",cb003-cym.pdf,application/pdf,136190,04/2014,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,2743
+17138,T546,"Guidance on right to buy cases. General information about the process",t546-eng.pdf,application/pdf,428482,01/2017,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2744
+17139,CB4,"Gwarcheidiaeth Arbennig - Canllaw ar gyfer defnyddwyr y llys teulu",cb004-cym.pdf,application/pdf,156470,04/2014,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,2744
+17140,PA1S,"Cais am chwiliad profiant (copiau o grantiau ac ewyllysiau) | Application for a probate search (copies of grants and wills)",pa001s-bil.pdf,application/pdf,111668,04/2014,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2748
+17141,PPF1,"Cronfa Diogelu Pensiynau (CDP) - Rhannu - Atodiad i Orchymyn Rhannu Iawndal Pensiwn [Adran 24E Deddf Achosion Priodasol 1973] [paragraff 19A Atodlen 5 Deddf Partneriaethau Sifil 2004] | Pension Protection Fund (PPF) Sharing Annex to a Pension Compensation Sharing Order [section 24E of the Matrimonial Causes Act 1973] [paragraph 19A of Schedule 5 to the Civil Partnership Act 2004]",ppf1-bil.pdf,application/pdf,232416,04/2011,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2750
+17142,D80B,"Datganiad i gefnogi ysgariad/diddymiad/ymwahaniad (cyfreithiol) - ymddygiad afresymol | Statement in support of divorce/dissolution/(judicial) separation - unreasonable behaviour",d080b-bil.pdf,application/pdf,117807,04/2014,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2754
+17143,D80D,"Datganiad i gefnogi ysgariad/diddymiad/ymwahaniad (cyfreithiol) - cydsyniad 2 flynedd | Statement in support of divorce/dissolution/(judicial) separation - 2 years' consent",d080d-bil.pdf,application/pdf,121525,04/2014,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2755
+17144,T003,"Notice of appeal/Application for review",t003-eng.pdf,application/pdf,99546,04/2012,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2756
+17145,SSCS6,"Hysbysiad o apêl yn erbyn penderfyniad gan Weinyddwr y Cynllun Taliadau Mesothelioma Ymledol",sscs006-cym.pdf,application/pdf,148731,10/2014,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,2756
+17146,TGRCRef,"References - Some Questions and Answers",tgrcref-eng.pdf,application/pdf,74922,07/2013,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,2757
+17147,UT1,"Application for permission to appeal to an Upper Tribunal judge and notice of appeal for social security, child support, tax credits, housing benefit and council tax benefit cases",ut001-eng.doc,application/msword,604160,07/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2759
+17148,UT2,"Application/appeal form for the Secretary of State, HM Revenue and Customs and local authorities for social security, child support, tax credits and housing benefit and council tax benefit cases",ut002-eng.pdf,application/pdf,62844,07/2012,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2760
+17149,UT2,"Application/appeal form for the Secretary of State, HM Revenue and Customs and local authorities for social security, child support, tax credits and housing benefit and council tax benefit cases",ut002-eng.doc,application/msword,215552,07/2012,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2761
+17150,UT5,"Application for permission to appeal to an Upper Tribunal judge and notice of appeal form for care standards and primary health lists cases",ut005-eng.pdf,application/pdf,117065,10/2011,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2766
+17151,UT7,"Application/appeal form for the Secretary of State for war pensions and armed forces compensation cases",ut007-eng.pdf,application/pdf,76465,10/2011,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2770
+17152,UT13,"Application for permission to appeal and notice of appeal from an information rights decision of the First-tier Tribunal (General Regulatory Chamber)",ut013-eng.pdf,application/pdf,134022,09/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2783
+17153,JRC1,"Judicial review claim form - criminal injuries compensation cases, England and Wales",jrc1-eng.doc,application/msword,234496,03/2013,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2790
+17154,JRC1,"Judicial review claim form - criminal injuries compensation cases, England and Wales",jrc1-eng.pdf,application/pdf,59623,01/2012,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2791
+17155,REMO20,"Canllaw i Gydorfodi Gorchmynion Cynhaliaeth",remo020-cym.pdf,application/pdf,170367,06/2015,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,2800
+17156,A101A,"Cytundeb i wneud gorchymyn rhieni yng nghyswllt fy mhlentyn | Agreement to the making of a parental order in respect of my child",a101a-bil.doc,application/msword,73216,04/2010,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2808
+17157,C52,"Cydnabyddiaeth Adran 54 o Ddeddf Ffrwythloni Dynol ac Embryoleg 2008 | Acknowledgment Section 54 Human Fertilisation and Embryology Act 2008",c052-bil.pdf,application/pdf,116807,10/2012,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2821
+17158,C63,"Cais am ddatganiad ynghylch pwy yw rhiant person dan adran 55A Deddf Cyfraith Teulu 1986 | Application for declaration of parentage under section 55A of the Family Law Act 1986",c63-bil.pdf,application/pdf,139163,06/2016,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2822
+17159,C7,"Cydnabyddiad | Acknowledgement",c007-bil.pdf,application/pdf,385827,12/2008,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2823
+17160,C79,"Cais yn ymwneud a gorfodi gorchymyn trefniadau plant | Application related to enforcement of a child arrangement order",c79-bil.pdf,application/pdf,188623,06/2016,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2825
+17161,T454,"Canllawiau ynghylch llenwi'r ffurflen gais Dramor am Dystysgrif Cydnabod Rhyw",t454-cym.pdf,application/pdf,615083,06/2016,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,2827
+17162,Ffurflen 6.28 | Form 6.28,"Datganiad Amgylchiadau Ariannol (Deiseb Dyledwr)Deddf Ansolfedd 1986 | Statement of Affairs (Debtor's Petition)Insolvency Act 1986",form-628-bil.pdf,application/pdf,167697,10/2012,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2850
+17163,FL407A,"Cais am Warant Arestio. Gorchymyn Amddiffyn Priodi Dan Orfod Rhan 4A Deddf Cyfraith Teulu 1996 | Application for a Warrant of Arrest. Forced Marriage Protection Order Part 4A Family Law Act 1996",fl407a-bil.pdf,application/pdf,77478,11/2008,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2854
+17164,T450,"Cais am Dystysgrif Cydnabod Rhyw",t450-cym.pdf,application/pdf,581548,06/2016,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,2896
+17165,N110A,"Pwer i arestio wedi'i atodi i'r waharddeb",n110a-cym.pdf,application/pdf,37321,06/2015,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,3010
+17166,C110A,"Cais am orchymyn gofal neu orchymyn goruchwylio a gorchmynion eraill dan Ran 4 Deddf Plant 1989, neu Orchymyn Amddiffyn Brys dan adran 44 Deddf Plant 1989",c110a-cym.pdf,application/pdf,269102,11/2014,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,3115
+17167,T453,"Cais am Dystysgrif Cydnabod Rhyw (Cais am Gydnabyddiaeth Gyfreithiol Dramor)",t453-cym.pdf,application/pdf,622974,06/2016,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,4389
+17168,FL404B,"Gorchymyn Amddiffyn rhag Priodas dan Orfod",fl404b-cym.pdf,application/pdf,153268,06/2014,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,4404
+17169,Undertaking to Issue Form,"Request for an Urgent Application (High Court Family Division)",undertaking-to-issue-eng.doc,application/msword,37376,04/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4423
+17170,T415,"Information on Challenging Decisions in Land Registration Cases",t415-eng.pdf,application/pdf,70384,03/2014,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4425
+17171,EX380,"Information about appeals for victims of crime",ex380-eng.pdf,application/pdf,305154,04/2016,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4440
+17172,N358,"Notice of Claim to Goods Taken Under Control",n358-eng.doc,application/msword,39424,04/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4445
+17173,N465PC,"Response to application as to venue for administration and determination",n465pc-eng.pdf,application/pdf,315565,04/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4454
+17174,SSCS5A,"How to appeal against a decision made by HM Customs and Revenue",sscs005a-eng.pdf,application/pdf,244418,07/2014,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4455
+17175,T04,"General Regulatory Chamber - Guidance Note for Respondents",t004-eng.pdf,application/pdf,83520,02/2014,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4456
+17176,PC001,"Request for an Adjournment (Leeds)",pc001-leeds-eng.pdf,application/pdf,19015,09/2008,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4457
+17177,T470,"Gangmasters Licensing Appeals - a guide to making an appeal",t470-eng.pdf,application/pdf,170668,10/2014,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4458
+17178,T170,"Appeal/Applicatiion Form (A)",t170-eng.pdf,application/pdf,562377,10/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4496
+17179,T171,"Application to Set Aside a Decision of Primary Health Lists (SA)",t171-eng.pdf,application/pdf,548097,10/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4498
+17180,T172,"Application for Permission to Appeal Decision of Primary Health Lists (AA)",t172-eng.pdf,application/pdf,539591,10/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4500
+17181,T200,"Notice of Appeal (Form EO9)",t200-eng.pdf,application/pdf,114104,04/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4501
+17182,T210,"Appeal form",t210-eng.doc,application/msword,183558,07/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4502
+17183,T211,"Rhybudd Apel yn erbyn penderfyniad gan yr Awdurdod Iawndal am Anafiadau Troseddol | Notice of appeal against a decision of the Criminal Injuries Compensation Authority",t211-bil.pdf,application/pdf,93042,09/2014,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4503
+17184,T173,"Response to appeal application Form",t173-eng.pdf,application/pdf,536883,10/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4504
+17185,T247,"Application for Permission to Appeal Decision of the Tax Tribunal",t247-eng.pdf,application/pdf,506237,03/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4505
+17186,T619,"Notice of Appeal to the Special Immigration Appeal Commission",t619-eng.doc,application/msword,213504,03/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4506
+17187,REMO 9,"Annex A - Application for Recognition or Recognition and Enforcement",remo-009-eng.doc,application/msword,71680,08/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4507
+17188,REMO 10,"Annex B - Application for Enforcement of a Decision Made or Recognised in the Requested State",remo-010-eng.doc,application/msword,56320,08/2014,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4508
+17189,SEND1,"How to Appeal Against a SEN decision",send001-eng.pdf,application/pdf,256566,01/2015,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4509
+17190,SEND2,"Preparing the Local Authority's Case",send002-eng.pdf,application/pdf,62468,07/2014,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4510
+17191,SEND20,"Guidance Notes - Applying to the First-tier Tribunal (Special Educational Needs and Disability)",send020-eng.pdf,application/pdf,178483,09/2014,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4511
+17192,T621,"Application to be released on SIAC bail (SIAC B1)",t621-eng.pdf,application/pdf,570235,07/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4520
+17193,COP42,"Gwneud cais i'r Llys Gwarchod",cop42-cym.pdf,application/pdf,183592,12/2013,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,4592
+17194,COP44A,"Apply for help with Court of Protection fees",cop44a-eng.pdf,application/pdf,127118,02/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4600
+17195,PH2,"Application by an occupier of a park home on a protected site, or a park home site owner, for: (1) an order (under section 2(2) implying a term or terms concerning the matters mentioned in Part 2 of Schedule 1 to the 1983 Act (see below) into an agreement for occupation or (2) an order (under Section 2(3)(a)) varying or deleting any express term (other than a site rule) of an agreement for occupation or (3) an order (under Section 2(3)(b)) that an unenforceable express term have full effect, or to have such effect subject to any variation specified in the order",ph2-eng.doc,application/msword,156160,01/2017,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4602
+17196,T435,"Employment Tribunal fees for individuals (from 29 July 2013)",t435-eng.pdf,application/pdf,210188,02/2017,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4605
+17197,T436,"Employment Tribunal fees for groups and multiples (from 29 July 2013)",t436-eng.pdf,application/pdf,226140,02/2017,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4610
+17198,T437,"Employment Appeal Tribunal fees (from 29 July 2013)",t437-eng-20151230.pdf,application/pdf,177790,12/2015,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4615
+17199,PA3,"Probate fees (from April 2014)",pa003-eng.pdf,application/pdf,172000,02/2017,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4630
+17200,T613,"UTIAC fees (from 22 April 2014)",t613-eng.pdf,application/pdf,39604,04/2014,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4635
+17201,Gambling - Guidance on fee remission for companies,"Guidance on fee remission for companies",gambling-fee-exemption-notes(company)-eng.pdf,application/pdf,30556,05/2011,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4640
+17202,T547,"A guide to what costs fees and expenses may be recoverable in the First-Tier Tribunal (Property Chamber) (Residential Property)",t547-eng.pdf,application/pdf,530167,03/2015,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4645
+17203,SSCS6A,"How to Appeal Against a Decision Made By the Scheme Administrator for the Diffuse Mesothelioma Payment Scheme",sscs006a-eng.pdf,application/pdf,412451,10/2014,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4736
+17204,EX370,"Eich tro cyntaf yn y llys? Beth y gallwch ei ddisgwyl | Your First Time At Court? What You Can Expect",ex370-bil.pdf,application/pdf,184060,03/2014,26,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4737
+17205,UT1 Leaflet,"UT1 Social Entitlement Leaflet - Appealing to the Administrative Appeals Chamber of the Upper Tribunal England and Wales",ut001-leaflet-eng.pdf,application/pdf,139584,07/2015,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4750
+17206,T465,"Guidance on Completing the Alternative Application Form for a Gender Recognition Certificate",t465-eng.pdf,application/pdf,593286,06/2016,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,4900
+17207,T465,"Canllawiau ynghylch Llenwi'r Ffurflen Gais Amgen am Dystysgrif Cydnabod Rhyw",t465-cym.pdf,application/pdf,624591,06/2016,25,2,false,1,2017-03-17,W_GetLeaflet.do?court_leaflets_id=,4900
+17208,COP3,"Asesu galluedd",cop003-cym.pdf,application/pdf,183339,12/2013,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,10080
+17209,COP4,"Datganiad y dirprwy",cop004-cym.pdf,application/pdf,255385,10/2013,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,10090
+17210,COP8,"Cais yn ymwneud a chofrestru atwrneiaeth barhaus (EPA)",cop008-cym.pdf,application/pdf,149980,12/2013,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,10130
+17211,COP12,"Ymgymeriad arbennig gan ymddiriedolwyr",cop012-cym.pdf,application/pdf,55203,01/2012,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,10170
+17212,COP15,"Hysbysiad bod ffurflen gais wedi'i chyhoeddi",cop015-cym.pdf,application/pdf,38182,12/2013,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,10200
+17213,COP44A,"Gwneud cais am gymorth gyda ffioedd y Llys Gwarchod",cop044a-cym.pdf,application/pdf,94220,11/2015,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,10300
+17214,COP DLA,"Ffurflen gais Colli Rhyddid I'w hystyried ar frys",cop-dla-cym.pdf,application/pdf,159055,01/2012,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,10450
+17215,FGM001,"Cais am Orchymyn Amddiffyn rhag Anffurfio Organau Cenhedlu Benywod (FGM)",fgm001-cym.pdf,application/pdf,84890,07/2015,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,12000
+17216,FGM003,"Cais i amrywio, ymestyn neu ryddhau Gorchymyn Amddiffyn rhag Anffurfio Organau Cenhedlu Benywod (FGM)",fgm003-cym.pdf,application/pdf,47235,07/2015,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,12020
+17217,FGM005,"Cais am Warant Arestio",fgm005-cym.pdf,application/pdf,26088,07/2015,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,12040
+17218,FGM006,"Cais am ganiatâd i wneud cais am Orchymyn Amddiffyn rhag Anffurfio Organau Cenhedlu Benywod (FGM)",fgm006-cym.pdf,application/pdf,33513,07/2015,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,12050
+17219,FGM700,"Female Genital Mutilation (FGM) Protection Orders - How can they protect me?",fgm700-eng.pdf,application/pdf,213251,07/2015,8,2,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,12060
+17220,FGM701,"Female Genital Mutilation (FGM) Protection Orders - Interim guidance for local authorities as a relevant third party and information relevant to multi-agency partnership working",fgm701-eng.pdf,application/pdf,129121,08/2015,8,4,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,12065
+17221,FGM700,"Gorchmynion Amddiffyn rhag Anffurfio Organau Cenhedlu Benywod (FGM)",fgm700-cym.pdf,application/pdf,199659,07/2015,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,13000
+17222,N1C(CCCHFL),"Notes for defendant on replying to the Part 7 claim form - Chancery Division/Commercial Court Financial List",n001c(ccchfl)-eng.pdf,application/pdf,140180,05/2015,8,3,false,1,2017-03-17,GetLeaflet.do?court_leaflets_id=,14000
+17223,A60,"Cais am orchymyn mabwysiadu (ac eithrio gorchymyn mabwysiadu dan y Cytundeb) | Application for an adoption order (excluding a Convention adoption order)",a60-bil.pdf,application/pdf,444197,11/2016,26,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2501
+17224,MPs Expenses - Notice of Appeal,"Notice of Appeal",mp-expenses-noa-eng.pdf,application/pdf,520561,03/2015,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,2731
+17225,T464,"Alternative application for a Gender Recognition Certificate",t464-eng.pdf,application/pdf,312633,11/2016,8,1,false,1,2017-03-17,GetForm.do?court_forms_id=,4900
+17226,FGM007,"Cais i ymuno fel parti neu roi'r gorau i fod yn barti i Orchymyn Amddiffyn rhag Anffurfio Organau Cenhedlu Benywod (FGM)",fgm007-cym.pdf,application/pdf,55245,07/2015,25,1,false,1,2017-03-17,W_GetForm.do?court_forms_id=,12060


### PR DESCRIPTION
Added 'original_url' field to the 'documents' table and updated the documents.csv seed to include the legacy formfinder URLs and IDs.